### PR TITLE
Adjust groups pagination

### DIFF
--- a/src/SmartComponents/Group/Groups.js
+++ b/src/SmartComponents/Group/Groups.js
@@ -1,185 +1,124 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Route, Link } from 'react-router-dom';
-import isEqual from 'lodash/isEqual';
+import { Route } from 'react-router-dom';
 import debouncePromise from 'awesome-debounce-promise';
-import { Toolbar, ToolbarGroup, ToolbarItem, Button, Level, LevelItem } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, expandable } from '@patternfly/react-table';
-import { Pagination } from '@red-hat-insights/insights-frontend-components/components/Pagination';
-import { TableToolbar } from '@red-hat-insights/insights-frontend-components/components/TableToolbar';
 
 import AddGroup from './add-group-modal';
+import GroupsToolbar from './groups-toolbar';
 import RemoveGroup from './remove-group-modal';
 import { fetchUsers } from '../../redux/Actions/UserActions';
 import { createInitialRows } from './group-table-helpers';
 import { fetchGroups } from '../../redux/Actions/GroupActions';
 import { fetchUsersByGroupId } from '../../redux/Actions/GroupActions';
-import { scrollToTop, getCurrentPage, getNewPage } from '../../Helpers/Shared/helpers';
-import GroupsFilterToolbar from '../../PresentationalComponents/Group/GroupsFilterToolbar';
+import { scrollToTop, getNewPage } from '../../Helpers/Shared/helpers';
 
 import './group.scss';
 
-const columns = [{
-  title: 'Name',
-  cellFormatters: [ expandable ]
-},
-'Description',
-'Members'
-];
+const columns = [{ title: 'Name', cellFormatters: [ expandable ]}, 'Description', 'Members' ];
 
-class Groups extends Component {
-    state = {
-      filteredItems: [],
-      isOpen: false,
-      filterValue: '',
-      rows: []
+const Groups = ({ fetchGroups, fetchUsers, pagination, history: { push }}) => {
+  const [ filterValue, setFilterValue ] = useState('');
+  const [ rows, setRows ] = useState([]);
+
+  useEffect(() => {
+    fetchGroups().then(({ value: { data }}) => setRows(createInitialRows(data)));
+    fetchUsers();
+    scrollToTop();
+  }, []);
+
+  const handleOnPerPageSelect = limit => fetchGroups({
+    offset: pagination.offset,
+    limit
+  }).then(({ value: { data }}) => setRows(createInitialRows(data)));
+
+  const  handleSetPage = (number, debounce) => {
+    const options = {
+      offset: getNewPage(number, pagination.limit),
+      limit: pagination.limit
     };
-
-    fetchData = () => {
-      this.props.fetchGroups().then(() => this.setState({ rows: createInitialRows(this.props.groups) }));
-      this.props.fetchUsers();
-    };
-
-    componentDidMount() {
-      this.fetchData();
-      scrollToTop();
+    const request = () => fetchGroups(options);
+    if (debounce) {
+      return debouncePromise(request, 250)();
     }
 
-    componentDidUpdate(prevProps) {
-      if (!isEqual(this.props.groups, prevProps.groups)) {
-        this.setState({ rows: createInitialRows(this.props.groups) });
-      }
-    }
+    return request().then(({ value: { data }}) => setRows(createInitialRows(data)));
+  };
 
-    handleOnPerPageSelect = limit => this.props.fetchGroups({
-      offset: this.props.pagination.offset,
-      limit
-    }).then(() => this.setState({ rows: createInitialRows(this.props.groups) }));
-
-    handleSetPage = (number, debounce) => {
-      const options = {
-        offset: getNewPage(number, this.props.pagination.limit),
-        limit: this.props.pagination.limit
+  const handleOpen = (data, uuid) => data.map(row => {
+    if (row.uuid === uuid) {
+      return {
+        ...row,
+        isOpen: !row.isOpen
       };
-      const request = () => this.props.fetchGroups(options);
-      if (debounce) {
-        return debouncePromise(request, 250)();
-      }
-
-      return request().then(() => this.setState({ rows: createInitialRows(this.props.groups) }));
     }
 
-    setOpen = (data, uuid) => data.map(row => {
-      if (row.uuid === uuid) {
-        return {
-          ...row,
-          isOpen: !row.isOpen
-        };
-      }
+    return { ...row };
+  });
 
-      return { ...row };
-    });
-
-    setSelected = (data, uuid) => data.map(row => {
-      if (row.uuid === uuid) {
-        return {
-          ...row,
-          selected: !row.selected
-        };
-      }
-
-      return { ...row };
-    })
-
-    onFilterChange = filterValue => this.setState({ filterValue })
-
-    onCollapse = (_event, _index, _isOpen, { uuid }) => this.setState(({ rows }) => ({ rows: this.setOpen(rows, uuid) }));
-
-    selectRow = (_event, selected, index, { uuid } = {}) => index === -1
-      ? this.setState(({ rows }) => ({ rows: rows.map(row => ({ ...row, selected })) }))
-      : this.setState(({ rows }) => ({ rows: this.setSelected(rows, uuid) }));
-
-    renderToolbar() {
-      return (
-        <TableToolbar>
-          <Level style={ { flex: 1 } }>
-            <LevelItem>
-              <Toolbar>
-                <ToolbarGroup>
-                  <ToolbarItem>
-                    <GroupsFilterToolbar onFilterChange={ this.onFilterChange } filterValue={ this.state.filterValue }/>
-                  </ToolbarItem>
-                </ToolbarGroup>
-                <ToolbarGroup>
-                  <ToolbarItem>
-                  </ToolbarItem>
-                  <ToolbarItem>
-                    <Link to="/groups/add-group">
-                      <Button variant="primary" aria-label="Create Group">
-                      Create Group
-                      </Button>
-                    </Link>
-                  </ToolbarItem>
-                </ToolbarGroup>
-              </Toolbar>
-            </LevelItem>
-            <LevelItem>
-              <Pagination
-                itemsPerPage={ this.props.pagination.limit || 50 }
-                numberOfItems={ this.props.pagination.count || 50 }
-                onPerPageSelect={ this.handleOnPerPageSelect }
-                page={ getCurrentPage(this.props.pagination.limit, this.props.pagination.offset) }
-                onSetPage={ this.handleSetPage }
-                direction="down"
-              />
-            </LevelItem>
-          </Level>
-        </TableToolbar>
-      );
+  const handleSelected = (data, uuid) => data.map(row => {
+    if (row.uuid === uuid) {
+      return {
+        ...row,
+        selected: !row.selected
+      };
     }
 
-    actionResolver = (groupData, { rowIndex }) => {
-      if (rowIndex === 1) {
-        return null;
-      }
+    return { ...row };
+  });
 
-      return [
-        {
-          title: 'Edit',
-          onClick: (event, rowId, group) =>
-            this.props.history.push(`/groups/edit/${group.uuid}`)
-        },
-        {
-          title: 'Delete',
-          onClick: (event, rowId, group) =>
-            this.props.history.push(`/groups/remove/${group.uuid}`)
-        }
-      ];
-    };
+  const onCollapse = (_event, _index, _isOpen, { uuid }) => setRows(rows => handleOpen(rows, uuid));
 
-    render() {
-      return (
-        <Fragment>
-          <Route exact path="/groups/add-group" component={ AddGroup } />
-          <Route exact path="/groups/edit/:id" component={ AddGroup } />
-          <Route exact path="/groups/remove/:id" component={ RemoveGroup } />
-          { this.renderToolbar() }
-          <Table
-            aria-label="Groups table"
-            onCollapse={ this.onCollapse }
-            rows={ this.state.rows }
-            cells={ columns }
-            onSelect={ this.selectRow }
-            actionResolver={ this.actionResolver }
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </Fragment>
-      );
+  const selectRow = (_event, selected, index, { uuid } = {}) => index === -1
+    ? setRows(rows.map(row => ({ ...row, selected })))
+    : setRows(rows => handleSelected(rows, uuid));
+
+  const actionResolver = (_groupData, { rowIndex }) => {
+    if (rowIndex === 1) {
+      return null;
     }
-}
+
+    return [
+      {
+        title: 'Edit',
+        onClick: (_event, _rowId, group) =>
+          push(`/groups/edit/${group.uuid}`)
+      },
+      {
+        title: 'Delete',
+        onClick: (_event, _rowId, group) =>
+          push(`/groups/remove/${group.uuid}`)
+      }
+    ];
+  };
+
+  return (
+    <Fragment>
+      <Route exact path="/groups/add-group" component={ AddGroup } />
+      <Route exact path="/groups/edit/:id" component={ AddGroup } />
+      <Route exact path="/groups/remove/:id" component={ RemoveGroup } />
+      <GroupsToolbar
+        filterValue={ filterValue }
+        setFilterValue={ setFilterValue }
+        pagination={ pagination }
+        handleOnPerPageSelect={ handleOnPerPageSelect }
+        handleSetPage={ handleSetPage }
+      />
+      <Table
+        aria-label="Groups table"
+        onCollapse={ onCollapse }
+        rows={ rows }
+        cells={ columns }
+        onSelect={ selectRow }
+        actionResolver={ actionResolver }
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+    </Fragment>
+  );
+};
 
 const mapStateToProps = ({ groupReducer: { groups, isLoading }, userReducer: { users, filterValue }}) => ({
   groups: groups.data,
@@ -202,7 +141,6 @@ Groups.propTypes = {
     goBack: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired
   }).isRequired,
-  filteredItems: PropTypes.array,
   groups: PropTypes.array,
   platforms: PropTypes.array,
   isLoading: PropTypes.bool,

--- a/src/SmartComponents/Group/groups-toolbar.js
+++ b/src/SmartComponents/Group/groups-toolbar.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Pagination } from '@red-hat-insights/insights-frontend-components/components/Pagination';
+import { TableToolbar } from '@red-hat-insights/insights-frontend-components/components/TableToolbar';
+import { Button, Level, LevelItem, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+
+import { getCurrentPage } from '../../Helpers/Shared/helpers';
+import GroupsFilterToolbar from '../../PresentationalComponents/Group/GroupsFilterToolbar';
+
+const GroupsToolbar = ({
+  setFilterValue,
+  filterValue,
+  pagination,
+  handleOnPerPageSelect,
+  handleSetPage
+}) => (
+  <TableToolbar>
+    <Level style={ { flex: 1 } }>
+      <LevelItem>
+        <Toolbar>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <GroupsFilterToolbar onFilterChange={ value => setFilterValue(value) } filterValue={ filterValue }/>
+            </ToolbarItem>
+          </ToolbarGroup>
+          <ToolbarGroup>
+            <ToolbarItem>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Link to="/groups/add-group">
+                <Button variant="primary" aria-label="Create Group">
+                  Create Group
+                </Button>
+              </Link>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
+      </LevelItem>
+      <LevelItem>
+        <Pagination
+          itemsPerPage={ pagination.limit }
+          numberOfItems={ pagination.count }
+          onPerPageSelect={ handleOnPerPageSelect }
+          page={ getCurrentPage(pagination.limit, pagination.offset) }
+          onSetPage={ handleSetPage }
+          direction="down"
+        />
+      </LevelItem>
+    </Level>
+  </TableToolbar>
+);
+
+GroupsToolbar.propTypes = {
+  setFilterValue: PropTypes.func.isRequired,
+  filterValue: PropTypes.string.isRequired,
+  pagination: PropTypes.shape({
+    limit: PropTypes.number.isRequired,
+    count: PropTypes.number.isRequired
+  }).isRequired,
+  handleOnPerPageSelect: PropTypes.func.isRequired,
+  handleSetPage: PropTypes.func.isRequired
+};
+
+export default GroupsToolbar;


### PR DESCRIPTION
merge after #13 

### Changes
- use react hooks
- split the groups table toolbar to separate component
- make safe pagination transitions (it was using wrong parameters and could get out of sync)