### PR TITLE
[WIP] Refresh table when Groups are changed

### DIFF
--- a/src/SmartComponents/Group/Groups.js
+++ b/src/SmartComponents/Group/Groups.js
@@ -14,19 +14,23 @@ import { scrollToTop, getNewPage } from '../../Helpers/Shared/helpers';
 
 const columns = [{ title: 'Name', cellFormatters: [ expandable ]}, 'Description', 'Members' ];
 
-const Groups = ({ fetchGroups, pagination, history: { push }}) => {
+const Groups = ({ fetchGroups, pagination, history: { push }, groups }) => {
   const [ filterValue, setFilterValue ] = useState('');
   const [ rows, setRows ] = useState([]);
 
   useEffect(() => {
-    fetchGroups().then(({ value: { data }}) => setRows(createInitialRows(data)));
+    fetchGroups();
     scrollToTop();
   }, []);
+
+  useEffect(() => {
+    setRows(createInitialRows(groups));
+  }, [ groups ]);
 
   const handleOnPerPageSelect = limit => fetchGroups({
     offset: pagination.offset,
     limit
-  }).then(({ value: { data }}) => setRows(createInitialRows(data)));
+  });
 
   const  handleSetPage = (number, debounce) => {
     const options = {
@@ -38,7 +42,7 @@ const Groups = ({ fetchGroups, pagination, history: { push }}) => {
       return debouncePromise(request, 250)();
     }
 
-    return request().then(({ value: { data }}) => setRows(createInitialRows(data)));
+    return request();
   };
 
   const handleOpen = (data, uuid) => data.map(row => {

--- a/src/SmartComponents/Group/add-group-modal.js
+++ b/src/SmartComponents/Group/add-group-modal.js
@@ -18,7 +18,8 @@ const AddGroupModal = ({
   initialValues,
   users,
   groupId,
-  updateGroup
+  updateGroup,
+  pagination,
 }) => {
   useEffect(() => {
     if (groupId) {
@@ -29,8 +30,8 @@ const AddGroupModal = ({
   const onSubmit = data => {
     const user_data = { ...data, user_list: selectedUsers.map(user => ({ username: user })) };
     initialValues
-      ? updateGroup(user_data).then(() => fetchGroups()).then(push('/groups'))
-      : addGroup(user_data).then(() => fetchGroups()).then(push('/groups'));
+      ? updateGroup(user_data).then(() => fetchGroups(pagination)).then(push('/groups'))
+      : addGroup(user_data).then(() => fetchGroups(pagination)).then(push('/groups'));
   };
 
   const onCancel = () => {
@@ -110,14 +111,20 @@ AddGroupModal.propTypes = {
   initialValues: PropTypes.object,
   groupId: PropTypes.string,
   users: PropTypes.array,
-  updateGroup: PropTypes.func.isRequired
+  updateGroup: PropTypes.func.isRequired,
+  pagination: PropTypes.shape({
+    limit: PropTypes.number.isRequired,
+    offset: PropTypes.number.isRequired,
+    count: PropTypes.number.isRequired
+  })
 };
 
 const mapStateToProps = (state, { match: { params: { id }}}) => {
   let selectedGroup = state.groupReducer.selectedGroup;
   return {
     initialValues: id && selectedGroup,
-    groupId: id
+    groupId: id,
+    pagination: state.groupReducer.groups.meta
   };
 };
 

--- a/src/SmartComponents/Group/remove-group-modal.js
+++ b/src/SmartComponents/Group/remove-group-modal.js
@@ -13,7 +13,8 @@ const RemoveGroupModal = ({
   fetchGroup,
   fetchGroups,
   groupId,
-  group
+  group,
+  pagination
 }) => {
   useEffect(() => {
     if (groupId) {
@@ -27,7 +28,7 @@ const RemoveGroupModal = ({
 
   const onSubmit = () => removeGroup(groupId)
   .then(() => {
-    fetchGroups();
+    fetchGroups(pagination);
     push('/groups');
   });
 
@@ -69,14 +70,20 @@ RemoveGroupModal.propTypes = {
   fetchGroups: PropTypes.func.isRequired,
   fetchGroup: PropTypes.func.isRequired,
   groupId: PropTypes.string,
-  group: PropTypes.object
+  group: PropTypes.object,
+  pagination: PropTypes.shape({
+    limit: PropTypes.number.isRequired,
+    offset: PropTypes.number.isRequired,
+    count: PropTypes.number.isRequired
+  })
 };
 
-const mapStateToProps = ({ groupReducer: { selectedGroup, isLoading }},
+const mapStateToProps = ({ groupReducer: { groups, selectedGroup, isLoading }},
   { match: { params: { id }}}) => ({
   groupId: id,
   group: selectedGroup,
-  isLoading
+  isLoading,
+  pagination: groups.meta
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-282

**Description**

- Table is rerendered when Groups are changed
- `Add/Edit`, `Remove` action call the fetch request with pagination (so, user is not redirected to the first page)

**TODO**

Waiting for API

- [ ] after adding a group send request for the last page where the group is created (offset=-1 ?)
- [ ] when removing the only item on the last page get data for previous/first page

@Hyperkid123 