### PR TITLE
Added roles tab

### DIFF
--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -8,6 +8,18 @@ export async function fetchRoles({ limit, offset }) {
   return roles;
 }
 
+export async function fetchRolesWithPolicies({ limit, offset, name, orderBy }) {
+  let rolesData = await roleApi.listRoles(limit, offset, name, orderBy);
+  let roles = rolesData.data;
+  return Promise.all(roles.map(async role => {
+    let roleWithPolicies = await roleApi.getRole(role.uuid);
+    return { ...role, policies: roleWithPolicies.policyCount };
+  })).then(data => ({
+    ...rolesData,
+    data
+  }));
+}
+
 export async function fetchRole(id) {
   return await roleApi.getGroup(id);
 }

--- a/src/presentational-components/role/roles-filter-toolbar.js
+++ b/src/presentational-components/role/roles-filter-toolbar.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FilterToolbarItem from '../shared/filter-toolbar-item';
+
+const RolesFilterToolbar = ({ onFilterChange, filterValue, ...props }) => (
+  <FilterToolbarItem { ...props } searchValue={ filterValue } onFilterChange={ onFilterChange } placeholder={ 'Find a Role' }/>
+);
+
+RolesFilterToolbar.propTypes = {
+  onFilterChange: PropTypes.func.isRequired,
+  filterValue: PropTypes.string
+};
+
+export default RolesFilterToolbar;

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -6,6 +6,11 @@ export const fetchRoles = (options = {}) => ({
   payload: RoleHelper.fetchRoles(options)
 });
 
+export const fetchRolesWithPolicies = (options = {}) => ({
+  type: ActionTypes.FETCH_ROLES,
+  payload: RoleHelper.fetchRolesWithPolicies(options)
+});
+
 export const fetchRole = apiProps => ({
   type: ActionTypes.FETCH_ROLE,
   payload: RoleHelper.fetchRole(apiProps)

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import React, { lazy, Suspense } from 'react';
 import { AppPlaceholder } from './presentational-components/shared/loader-placeholders';
 
 const Groups = lazy(() => import('./smart-components/group/groups'));
+const Roles = lazy(() => import('./smart-components/role/roles'));
 
 const paths = {
   rbac: '/',
@@ -27,6 +28,7 @@ export const Routes = () => {
     <Suspense fallback={ <AppPlaceholder /> }>
       <Switch>
         <InsightsRoute path={ paths.groups } component={ Groups } rootClass="groups" />
+        <InsightsRoute path={ paths.roles } component={ Roles } rootClass="roles" />
         <Route render={ () => <Redirect to={ paths.groups } /> } />
       </Switch>
     </Suspense>

--- a/src/smart-components/app-tabs/app-tabs.js
+++ b/src/smart-components/app-tabs/app-tabs.js
@@ -3,12 +3,17 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { Tabs, Tab } from '@patternfly/react-core';
 
-const AppTabs = ({ history: { push }, location: { pathname }, tabItems }) => {
+const tabItems = [
+  { eventKey: 0, title: 'Groups', name: '/groups' },
+  { eventKey: 1, title: 'Roles', name: '/roles' }
+];
+
+const AppTabs = ({ history: { push }, location: { pathname }}) => {
   const activeTab = tabItems.find(({ name }) => pathname.includes(name));
   const handleTabClick = (_event, tabIndex) => push(tabItems[tabIndex].name);
 
   return (
-    <Tabs className="pf-u-mt-md" activeKey={ activeTab ? activeTab.eventKey : 0 } onSelect={ handleTabClick }>
+    <Tabs className="pf-u-mt-md" activeKey={ activeTab ? activeTab.eventKey : 1 } onSelect={ handleTabClick }>
       { tabItems.map((item) => <Tab title={ item.title } key={ item.eventKey } eventKey={ item.eventKey } name={ item.name }/>) }
     </Tabs>
   );
@@ -20,8 +25,7 @@ AppTabs.propTypes = {
   }),
   history: PropTypes.shape({
     push: PropTypes.func.isRequired
-  }),
-  tabItems: PropTypes.array.isRequired
+  })
 };
 
 export default withRouter(AppTabs);

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -16,7 +16,10 @@ import AppTabs from '../app-tabs/app-tabs';
 import { defaultSettings } from '../../helpers/shared/pagination';
 
 const columns = [{ title: 'Name', cellFormatters: [ expandable ]}, 'Description', 'Members', 'Last modified' ];
-const tabItems = [{ eventKey: 0, title: 'Groups', name: '/groups' }];
+const tabItems = [
+  { eventKey: 0, title: 'Groups', name: '/groups' },
+  { eventKey: 1, title: 'Roles', name: '/roles' }
+];
 
 const Groups = ({ fetchGroups, groups, pagination, history: { push }}) => {
   const [ filterValue, setFilterValue ] = useState('');

--- a/src/smart-components/role/role-table-helpers.js
+++ b/src/smart-components/role/role-table-helpers.js
@@ -1,0 +1,11 @@
+import { timeAgo } from '../../helpers/shared/helpers';
+
+export const createRows = (data, filterValue = undefined) => (
+  data.filter(item => { const filter = filterValue ? item.name.includes(filterValue) : true;
+    return filter; }).reduce((acc,  { uuid, name, description, policyCount, modified }) => ([
+    ...acc, {
+      uuid,
+      cells: [ name, description, policyCount, `${timeAgo(modified)}` ]
+    }
+  ]), [])
+);

--- a/src/smart-components/role/roles-toolbar.js
+++ b/src/smart-components/role/roles-toolbar.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Pagination } from '@redhat-cloud-services/frontend-components/components/Pagination';
+import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/TableToolbar';
+import { Level, LevelItem, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+
+import { getCurrentPage } from '../../helpers/shared/helpers';
+import RolesFilterToolbar from '../../presentational-components/role/roles-filter-toolbar';
+
+const RolesToolbar = ({
+  onFilterChange,
+  filterValue,
+  pagination,
+  handleOnPerPageSelect,
+  handleSetPage
+}) => (
+  <TableToolbar>
+    <Level style={ { flex: 1 } }>
+      <LevelItem>
+        <Toolbar>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <RolesFilterToolbar onFilterChange={ value => onFilterChange(value) } filterValue={ filterValue }/>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
+      </LevelItem>
+      <LevelItem>
+        <Pagination
+          itemsPerPage={ pagination.limit }
+          numberOfItems={ pagination.count }
+          onPerPageSelect={ handleOnPerPageSelect }
+          page={ getCurrentPage(pagination.limit, pagination.offset) }
+          onSetPage={ handleSetPage }
+          direction="down"
+        />
+      </LevelItem>
+    </Level>
+  </TableToolbar>
+);
+
+RolesToolbar.propTypes = {
+  onFilterChange: PropTypes.func.isRequired,
+  filterValue: PropTypes.string.isRequired,
+  pagination: PropTypes.shape({
+    limit: PropTypes.number.isRequired,
+    count: PropTypes.number.isRequired
+  }).isRequired,
+  handleOnPerPageSelect: PropTypes.func.isRequired,
+  handleSetPage: PropTypes.func.isRequired
+};
+
+export default RolesToolbar;

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -1,0 +1,89 @@
+import React, { Fragment, useState } from 'react';
+import { connect } from 'react-redux';
+import { Route, Switch } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import AppTabs from '../app-tabs/app-tabs';
+import { createRows } from './role-table-helpers';
+import { defaultSettings } from '../../helpers/shared/pagination';
+import { fetchRolesWithPolicies } from '../../redux/actions/role-actions';
+import { TopToolbar, TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
+import { TableToolbarView } from '../../presentational-components/shared/table-toolbar-view';
+
+const columns = [
+  { title: 'Role', orderBy: 'name' },
+  { title: 'Description' },
+  { title: 'Policies' },
+  { title: 'Last Modified', orderBy: 'modified' }
+];
+
+const tabItems = [
+  { eventKey: 0, title: 'Groups', name: '/groups' },
+  { eventKey: 1, title: 'Roles', name: '/roles' }
+];
+
+const Roles = ({ fetchRoles, pagination, roles }) => {
+  const [ filterValue, setFilterValue ] = useState('');
+  const fetchData = (setRows) => {
+    fetchRoles().then(({ value: { data }}) => setRows(createRows(data, filterValue)));
+  };
+
+  const renderRolesList = () =>
+    <Fragment>
+      <TopToolbar>
+        <TopToolbarTitle title="User access management" />
+        <AppTabs tabItems={ tabItems }/>
+      </TopToolbar>
+      <TableToolbarView
+        data={ roles }
+        createRows={ createRows }
+        columns={ columns }
+        fetchData={ fetchData }
+        request={ fetchRoles }
+        titlePlural="roles"
+        titleSingular="role"
+        pagination={ pagination }
+        filterValue={ filterValue }
+        setFilterValue={ setFilterValue }
+      />
+    </Fragment>;
+
+  return (
+    <Switch>
+      <Route path={ '/roles' } render={ () => renderRolesList() } />
+    </Switch>
+  );
+};
+
+const mapStateToProps = ({ roleReducer: { roles, filterValue, isLoading }}) => ({
+  roles: roles.data,
+  pagination: roles.meta,
+  isLoading,
+  searchFilter: filterValue
+});
+
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchRoles: apiProps => dispatch(fetchRolesWithPolicies(apiProps))
+  };
+};
+
+Roles.propTypes = {
+  roles: PropTypes.array,
+  platforms: PropTypes.array,
+  isLoading: PropTypes.bool,
+  searchFilter: PropTypes.string,
+  fetchRoles: PropTypes.func.isRequired,
+  pagination: PropTypes.shape({
+    limit: PropTypes.number.isRequired,
+    offset: PropTypes.number.isRequired,
+    count: PropTypes.number.isRequired
+  })
+};
+
+Roles.defaultProps = {
+  roles: [],
+  pagination: defaultSettings
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Roles);

--- a/src/test/role/__snapshots__/roles.test.js.snap
+++ b/src/test/role/__snapshots__/roles.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Roles /> should render correctly 1`] = `
+<Roles
+  fetchRoles={[Function]}
+  isLoading={false}
+  pagination={
+    Object {
+      "count": 0,
+      "limit": 10,
+      "offset": 0,
+    }
+  }
+  roles={Array []}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+/>
+`;
+
+exports[`<Roles /> should render correctly in loading state 1`] = `
+<Roles
+  fetchRoles={[Function]}
+  isLoading={false}
+  pagination={
+    Object {
+      "count": 0,
+      "limit": 10,
+      "offset": 0,
+    }
+  }
+  roles={Array []}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+/>
+`;

--- a/src/test/role/roles.test.js
+++ b/src/test/role/roles.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import thunk from 'redux-thunk';
+import { shallow } from 'enzyme';
+import configureStore from 'redux-mock-store' ;
+import { shallowToJson } from 'enzyme-to-json';
+import promiseMiddleware from 'redux-promise-middleware';
+import Roles from '../../smart-components/role/roles';
+import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
+import { rolesInitialState } from '../../redux/reducers/role-reducer';
+
+describe('<Roles />', () => {
+
+  let initialProps;
+  const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
+  let mockStore;
+  let initialState;
+
+  beforeEach(() => {
+    initialProps = {};
+    mockStore = configureStore(middlewares);
+    initialState = { roleReducer: { ...rolesInitialState, isLoading: false }, userReducer: { ...rolesInitialState }};
+  });
+
+  it('should render correctly', () => {
+    const store = mockStore(initialState);
+    const wrapper = shallow(<Roles store={ store } { ...initialProps } />);
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render correctly in loading state', () => {
+    const store = mockStore(initialState);
+    const wrapper = shallow(<Roles store={ store } { ...initialProps } isLoading />);
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Added a tab to display RBAC roles, per the lo-fi mock below.

Mock: https://marvelapp.com/c34g5a7/screen/58499708

Note that we will not implement edit and delete functionality. We will also use the Insights toolbar for now. PatternFly is in the process of refactoring the toolbar component.

Fixes https://github.com/RedHatInsights/insights-rbac-ui/issues/32

![Screen Shot 2019-09-03 at 10 42 39 AM](https://user-images.githubusercontent.com/17481322/64184056-dd6e6200-ce38-11e9-82ee-633e58762d09.png)

