### PR TITLE
Add the missing roles path

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,8 @@ const Roles = lazy(() => import('./smart-components/role/roles'));
 
 const paths = {
   rbac: '/',
-  groups: '/groups'
+  groups: '/groups',
+  roles: '/roles'
 };
 
 const InsightsRoute = ({ rootClass, ...rest }) => {


### PR DESCRIPTION
Add the missing roles path - fixes navigation in chrome to the User Management Settings