### PR TITLE
Update the title for the policy information page, depending on context

### DIFF
--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -54,7 +54,7 @@ const AddGroupModal = ({
     {
       name: 'Create policy',
       steps: [
-        { name: 'Name and description', component: new PolicyInformation(formData, handleChange) },
+        { name: 'Name and description', component: new PolicyInformation('Create policy (optional)', formData, handleChange) },
         { name: 'Add roles', component: new PolicySetRoles(formData, selectedRoles, setSelectedRoles, roles) }
       ]
     },

--- a/src/smart-components/group/add-group/policy-information.js
+++ b/src/smart-components/group/add-group/policy-information.js
@@ -13,13 +13,13 @@ import {
   Title
 } from '@patternfly/react-core';
 
-const PolicyInformation = (formValue, onHandleChange) => {
+const PolicyInformation = (title, formValue, onHandleChange) => {
   return (
     <Fragment>
       <Form>
         <Stack gutter="md">
           <StackItem>
-            <Title size="xl">Create policy (optional)</Title>
+            <Title size="xl">{ title }</Title>
           </StackItem>
           <StackItem>
             <TextContent>
@@ -65,7 +65,12 @@ const PolicyInformation = (formValue, onHandleChange) => {
 };
 
 PolicyInformation.propTypes = {
-  formData: PropTypes.object
+  formData: PropTypes.object,
+  title: PropTypes.string
+};
+
+PolicyInformation.defaultProps = {
+  title: 'Create policy'
 };
 
 export default PolicyInformation;

--- a/src/smart-components/group/policy/add-policy/add-policy-wizard.js
+++ b/src/smart-components/group/policy/add-policy/add-policy-wizard.js
@@ -28,7 +28,7 @@ const AddGroupPolicyWizard = ({
   };
 
   const steps = [
-    { name: 'Name and description', component: new PolicyInformation(formData, handleChange) },
+    { name: 'Name and description', component: new PolicyInformation('Create policy', formData, handleChange) },
     { name: 'Add roles', component: new PolicySetRoles(formData, selectedRoles, setSelectedRoles, roles) },
     { name: 'Review', component: new SummaryContent({ values: formData, selectedRoles }),
       nextButtonText: 'Confirm' }


### PR DESCRIPTION
Parametrize the title for the policy page, and have the 'optional' word only in the Add group wizard.

Add Group Wizard:

![Screenshot from 2019-09-16 12-00-10](https://user-images.githubusercontent.com/12769982/64975483-1f59c800-d87d-11e9-8735-29e76daf7e26.png)


Add Policy Wizard:
![Screenshot from 2019-09-16 11-59-25](https://user-images.githubusercontent.com/12769982/64975498-284a9980-d87d-11e9-95a6-88ff79e24c47.png)

