### PR TITLE
Fetch data when pagination changes

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -32,12 +32,15 @@ export const TableToolbarView = ({
 
   useEffect(() => {
     fetchData(setRows, filterValue, pagination);
-    scrollToTop();
-  }, []);
+  }, [ filterValue, pagination.limit, pagination.offset ]);
 
   useEffect(() => {
     setRows(createRows(data, filterValue));
-  }, [ data, filterValue, pagination.limit, pagination.offset ]);
+  }, [ data ]);
+
+  useEffect(() => {
+    scrollToTop();
+  }, []);
 
   const handleOnPerPageSelect = limit => request({
     offset: pagination.offset,

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -26,7 +26,7 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }}) => {
   const [ groups, setGroups ] = useState([]);
 
   const fetchData = () => {
-    fetchGroups().then(({ value: { data }}) => setGroups(data));
+    fetchGroups(pagination).then(({ value: { data }}) => setGroups(data));
   };
 
   const routes = () => <Fragment>

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -25,7 +25,7 @@ const tabItems = [
 const Roles = ({ fetchRoles, isLoading, pagination, roles }) => {
   const [ filterValue, setFilterValue ] = useState('');
   const fetchData = (setRows) => {
-    fetchRoles().then(({ value: { data }}) => setRows(createRows(data, filterValue)));
+    fetchRoles(pagination).then(({ value: { data }}) => setRows(createRows(data, filterValue)));
   };
 
   const renderRolesList = () =>


### PR DESCRIPTION
The `TableToolbarView` component is not updating the table rows during pagination. This happens for both groups and roles tabs.

The `useEffect` code appears to be overriding the table rows with stale data. This code never calls the `Roles` / `Group` component's `fetchData` function; thus, the new data is never updated.

Fixes https://github.com/RedHatInsights/insights-rbac-ui/issues/48