### PR TITLE
Hide add role if user is not entitled for cost management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,6 +2861,15 @@
         }
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz",
+      "integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
     "@babel/preset-react": "^7.0.0",
+    "axios-mock-adapter": "^1.17.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.7.1",

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -11,7 +11,10 @@ export function fetchRoles({ limit, offset }) {
 }
 
 export async function fetchRolesWithPolicies({ limit, offset, name, orderBy }) {
-  return roleApi.listRoles(limit, offset, name, orderBy);
+  return {
+    ...await roleApi.listRoles(limit, offset, name, orderBy),
+    ...await insights.chrome.auth.getUser()
+  };
 }
 
 export async function fetchRole(uuid) {

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -1,5 +1,4 @@
-import { getRoleApi, getAxiosInstance } from '../shared/user-login';
-import { RBAC_API_BASE } from '../../utilities/constants';
+import { getRoleApi } from '../shared/user-login';
 
 const roleApi = getRoleApi();
 
@@ -7,26 +6,12 @@ export async function createRole(data) {
   return await roleApi.createRoles(data);
 }
 
-export const fetchFilterRoles = (filterValue) =>
-  getAxiosInstance().get(`${RBAC_API_BASE}/roles/${filterValue.length > 0
-    ? `?name=${filterValue}`
-    : ''}`)
-  .then(({ data }) => data.map(({ uuid, name }) => ({ label: name, value: uuid })));
-
 export function fetchRoles({ limit, offset }) {
   return roleApi.listRoles(limit, offset);
 }
 
 export async function fetchRolesWithPolicies({ limit, offset, name, orderBy }) {
-  let rolesData = await roleApi.listRoles(limit, offset, name, orderBy);
-  let roles = rolesData.data;
-  return Promise.all(roles.map(async role => {
-    let roleWithPolicies = await roleApi.getRole(role.uuid);
-    return { ...role, policies: roleWithPolicies.policyCount };
-  })).then(data => ({
-    ...rolesData,
-    data
-  }));
+  return roleApi.listRoles(limit, offset, name, orderBy);
 }
 
 export async function fetchRole(uuid) {

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -1,21 +1,6 @@
-import axios from 'axios';
+import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 import { GroupApi, PrincipalApi, RoleApi, PolicyApi } from '@redhat-cloud-services/rbac-client';
 import { RBAC_API_BASE } from '../../utilities/constants';
-
-const axiosInstance = axios.create();
-
-const resolveInterceptor = response => response.data || response;
-const errorInterceptor = (error = {}) => {
-  throw { ...error.response };
-};
-
-// check identity before each request. If the token is expired it will log out user
-axiosInstance.interceptors.request.use(async config => {
-  await window.insights.chrome.auth.getUser();
-  return config;
-});
-axiosInstance.interceptors.response.use(resolveInterceptor);
-axiosInstance.interceptors.response.use(null, errorInterceptor);
 
 const principalApi = new PrincipalApi(undefined, RBAC_API_BASE, axiosInstance);
 const groupApi = new GroupApi(undefined, RBAC_API_BASE, axiosInstance);

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -9,6 +9,7 @@ import { defaultSettings  } from '../../helpers/shared/pagination';
 import FilterToolbar from '../../presentational-components/shared/filter-toolbar-item';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/TableToolbar';
 import { ListLoader } from './loader-placeholders';
+import './table-toolbar-view.scss';
 
 export const TableToolbarView = ({
   request,
@@ -92,7 +93,7 @@ export const TableToolbarView = ({
     : setRows((rows) => setSelected(rows, uuid));
 
   const renderToolbar = () => {
-    return (<TableToolbar>
+    return (<TableToolbar className="rbac-table__toolbar">
       <Level style={ { flex: 1 } }>
         <LevelItem>
           <Toolbar>

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -182,5 +182,6 @@ TableToolbarView.defaultProps = {
   isSelectable: false,
   isCompact: false,
   borders: true,
-  routes: () => null
+  routes: () => null,
+  fetchData: () => undefined
 };

--- a/src/presentational-components/shared/table-toolbar-view.scss
+++ b/src/presentational-components/shared/table-toolbar-view.scss
@@ -1,0 +1,5 @@
+.pf-l-toolbar.rbac-table__toolbar {
+  .pf-l-toolbar__item {
+    min-width: 5rem;
+  }
+}

--- a/src/smart-components/common/suspend-component.js
+++ b/src/smart-components/common/suspend-component.js
@@ -1,0 +1,23 @@
+import React, { Suspense, Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+const asyncComponent = (asyncFunction, callback, props) => React.lazy(() => asyncFunction().then(data => ({
+  default: () => callback(data, props)
+})));
+
+const SuspendComponent = ({ asyncFunction, callback, fallback, ...props }) => {
+  const Async = asyncComponent(asyncFunction, callback, props);
+  return (
+    <Suspense fallback={ fallback || <Fragment /> }>
+      <Async />
+    </Suspense>
+  );
+};
+
+SuspendComponent.propTypes = {
+  asyncFunction: PropTypes.func,
+  callback: PropTypes.func,
+  fallback: PropTypes.node
+};
+
+export default SuspendComponent;

--- a/src/smart-components/role/role-table-helpers.js
+++ b/src/smart-components/role/role-table-helpers.js
@@ -2,9 +2,11 @@ import { timeAgo } from '../../helpers/shared/helpers';
 
 export const createRows = (data, filterValue = undefined) => (
   data.filter(item => { const filter = filterValue ? item.name.includes(filterValue) : true;
-    return filter; }).reduce((acc,  { uuid, name, description, policyCount, modified }) => ([
+    return filter;
+  }).reduce((acc, { uuid, name, description, system, policyCount, modified }) => ([
     ...acc, {
       uuid,
+      system,
       cells: [ name, description, policyCount, `${timeAgo(modified)}` ]
     }
   ]), [])

--- a/src/test/__mocks__/apiMock.js
+++ b/src/test/__mocks__/apiMock.js
@@ -1,0 +1,4 @@
+import { getAxiosInstance } from '../../helpers/shared/user-login';
+import MockAdapter from 'axios-mock-adapter';
+
+export const mock = new MockAdapter(getAxiosInstance());

--- a/src/test/helpers/group/group-helper.test.js
+++ b/src/test/helpers/group/group-helper.test.js
@@ -13,7 +13,7 @@ describe('group helper', () => {
   });
 
   it.only('should call addGroup', async () => {
-    const newGroup = { uuid: '123', name: 'group name', user_list: [{ username: 'user1', uuid: '12' }] };
+    const newGroup = { uuid: '123', name: 'group name', user_list: [{ username: 'user1', uuid: '12' }]};
     mock.onPost(`${RBAC_API_BASE}/groups/`).reply(200, newGroup)
     .onPost(`${RBAC_API_BASE}/groups/123/principals/`).reply(200, newGroup);
     const data = await addGroup(newGroup);

--- a/src/test/helpers/group/group-helper.test.js
+++ b/src/test/helpers/group/group-helper.test.js
@@ -1,34 +1,28 @@
 import { RBAC_API_BASE } from '../../../utilities/constants';
+import { mock } from '../../__mocks__/apiMock';
 import { fetchGroups, addGroup, removeGroup } from '../../../helpers/group/group-helper';
 
 describe('group helper', () => {
-  it('should call list groups helper', done => {
-    expect.assertions(1);
-    apiClientMock.get(`${RBAC_API_BASE}/groups/?limit=10&offset=0`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      done();
-      return res.status(200);
-    }));
-    fetchGroups({ limit: 10, offset: 0 });
+  it('should call list groups helper', async () => {
+    const mockedData = {
+      data: []
+    };
+    mock.onGet(`${RBAC_API_BASE}/groups/?limit=10&offset=0`).reply(200, mockedData);
+    const data = await fetchGroups({ limit: 10, offset: 0 });
+    expect(data).toEqual(mockedData);
   });
 
-  it('should call addGroup', done => {
-    expect.assertions(1);
-    apiClientMock.post(`${RBAC_API_BASE}/groups/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      done();
-      return res.status(200);
-    }));
-    addGroup({ uuid: '123', name: 'group name', user_list: [{ username: 'user1', uuid: '12' }]});
+  it.only('should call addGroup', async () => {
+    const newGroup = { uuid: '123', name: 'group name', user_list: [{ username: 'user1', uuid: '12' }] };
+    mock.onPost(`${RBAC_API_BASE}/groups/`).reply(200, newGroup)
+    .onPost(`${RBAC_API_BASE}/groups/123/principals/`).reply(200, newGroup);
+    const data = await addGroup(newGroup);
+    expect(data).toEqual(newGroup);
   });
 
-  it('should call remove group', done => {
-    expect.assertions(1);
-    apiClientMock.delete(`${RBAC_API_BASE}/groups/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      done();
-      return res.status(200);
-    }));
-    removeGroup('123');
+  it('should call remove group', async () => {
+    mock.onDelete(`${RBAC_API_BASE}/groups/123/`).reply(200);
+    const data = await removeGroup('123');
+    expect(data.status).toBe(200);
   });
 });

--- a/src/test/redux/actions/group-actions.test.js
+++ b/src/test/redux/actions/group-actions.test.js
@@ -4,6 +4,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { RBAC_API_BASE } from '../../../utilities/constants';
 import { fetchGroups } from '../../../redux/actions/group-actions';
 import { FETCH_GROUPS } from '../../../redux/action-types';
+import { mock } from '../../__mocks__/apiMock';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
 
 describe('group actions', () => {
@@ -29,23 +30,20 @@ describe('group actions', () => {
       type: `${FETCH_GROUPS}_FULFILLED`
     }];
 
-    apiClientMock.get(`${RBAC_API_BASE}/groups/`, mockOnce({
-      body: {
-        data: [{
-          name: 'groupName',
-          uuid: '1234'
-        }]
-      }
-    }));
+    mock.onGet(`${RBAC_API_BASE}/groups/`).reply(200, {
+      data: [{
+        name: 'groupName',
+        uuid: '1234'
+      }]
+    });
 
-    apiClientMock.get(`${RBAC_API_BASE}/groups/1234/`, mockOnce({
-      body: {
-        data: {
-          name: 'groupName',
-          uuid: '1234'
-        }
+    mock.onGet(`${RBAC_API_BASE}/groups/1234/`).reply(200, {
+      data: {
+        name: 'groupName',
+        uuid: '1234'
       }
-    }));
+    });
+
     return store.dispatch(fetchGroups()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });

--- a/src/test/redux/actions/policy-actions.test.js
+++ b/src/test/redux/actions/policy-actions.test.js
@@ -1,6 +1,7 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store' ;
 import promiseMiddleware from 'redux-promise-middleware';
+import { mock } from '../../__mocks__/apiMock';
 import { RBAC_API_BASE } from '../../../utilities/constants';
 import { fetchGroupPolicies } from '../../../redux/actions/policy-actions';
 import { FETCH_GROUP_POLICIES } from '../../../redux/action-types';
@@ -28,23 +29,20 @@ describe('policy actions', () => {
       type: `${FETCH_GROUP_POLICIES}_FULFILLED`
     }];
 
-    apiClientMock.get(`${RBAC_API_BASE}/policies/`, mockOnce({
-      body: {
-        data: [{
-          name: 'policyName',
-          uuid: '1234'
-        }]
-      }
-    }));
+    mock.onGet(`${RBAC_API_BASE}/policies/`).reply(200, {
+      data: [{
+        name: 'policyName',
+        uuid: '1234'
+      }]
+    });
 
-    apiClientMock.get(`${RBAC_API_BASE}/policies/1234/`, mockOnce({
-      body: {
-        data: {
-          name: 'policyName',
-          uuid: '1234'
-        }
-      }
-    }));
+    mock.onGet(`${RBAC_API_BASE}/policies/1234/`).reply(200, {
+      data: [{
+        name: 'policyName',
+        uuid: '1234'
+      }]
+    });
+
     return store.dispatch(fetchGroupPolicies('1234')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });

--- a/src/test/redux/actions/role-actions.test.js
+++ b/src/test/redux/actions/role-actions.test.js
@@ -1,6 +1,7 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store' ;
 import promiseMiddleware from 'redux-promise-middleware';
+import { mock } from '../../__mocks__/apiMock';
 import { RBAC_API_BASE } from '../../../utilities/constants';
 import { fetchRoles } from '../../../redux/actions/role-actions';
 import { FETCH_ROLES } from '../../../redux/action-types';
@@ -31,23 +32,20 @@ describe('role actions', () => {
       type: `${FETCH_ROLES}_FULFILLED`
     }];
 
-    apiClientMock.get(`${RBAC_API_BASE}/roles/`, mockOnce({
-      body: {
-        data: [{
-          name: 'roleName',
-          uuid: '1234'
-        }]
-      }
-    }));
+    mock.onGet(`${RBAC_API_BASE}/roles/`).reply(200, {
+      data: [{
+        name: 'roleName',
+        uuid: '1234'
+      }]
+    });
 
-    apiClientMock.get(`${RBAC_API_BASE}/roles/1234/`, mockOnce({
-      body: {
-        data: {
-          name: 'roleName',
-          uuid: '1234'
-        }
-      }
-    }));
+    mock.onGet(`${RBAC_API_BASE}/roles/1234/`).reply(200, {
+      data: [{
+        name: 'roleName',
+        uuid: '1234'
+      }]
+    });
+
     return store.dispatch(fetchRoles()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });

--- a/src/test/role/remove-role-modal.test.js
+++ b/src/test/role/remove-role-modal.test.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import configureStore from 'redux-mock-store' ;
 import { MemoryRouter, Route } from 'react-router-dom';
 import promiseMiddleware from 'redux-promise-middleware';
+import { mock } from '../__mocks__/apiMock';
 import { notificationsMiddleware, ADD_NOTIFICATION } from '@redhat-cloud-services/frontend-components-notifications/';
 import { RBAC_API_BASE } from '../../utilities/constants';
 import RemoveRoleModal from '../../smart-components/role/remove-role-modal';
@@ -44,11 +45,7 @@ describe('<RemoveRoleModal />', () => {
 
   it('should call cancel action', () => {
     const store = mockStore(initialState);
-
-    apiClientMock.get(`${RBAC_API_BASE}/roles/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
+    mock.onGet(`${RBAC_API_BASE}/roles/123/`).reply(200, { data: []});
 
     const wrapper = mount(
       <RoleWrapper store={ store }>
@@ -62,20 +59,11 @@ describe('<RemoveRoleModal />', () => {
   it('should call the remove action', (done) => {
     const store = mockStore(initialState);
 
-    apiClientMock.get(`${RBAC_API_BASE}/roles/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
+    mock.onGet(`${RBAC_API_BASE}/roles/123/`).reply(200, { data: []});
 
-    apiClientMock.delete(`${RBAC_API_BASE}/roles/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200);
-    }));
+    mock.onDelete(`${RBAC_API_BASE}/roles/123/`).reply(200);
 
-    apiClientMock.get(`${RBAC_API_BASE}/roles/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
+    mock.onGet(`${RBAC_API_BASE}/roles/`).reply(200, { data: []});
 
     const wrapper = mount(
       <RoleWrapper store={ store }>

--- a/src/test/smart-components/group/remove-group-modal.test.js
+++ b/src/test/smart-components/group/remove-group-modal.test.js
@@ -6,6 +6,7 @@ import configureStore from 'redux-mock-store' ;
 import { MemoryRouter, Route } from 'react-router-dom';
 import promiseMiddleware from 'redux-promise-middleware';
 import { notificationsMiddleware, ADD_NOTIFICATION } from '@redhat-cloud-services/frontend-components-notifications/';
+import { mock } from '../../__mocks__/apiMock';
 import { RBAC_API_BASE } from '../../../utilities/constants';
 import RemoveGroupModal from '../../../smart-components/group/remove-group-modal';
 import { groupsInitialState } from '../../../redux/reducers/group-reducer';
@@ -45,11 +46,7 @@ describe('<RemoveGroupModal />', () => {
 
   it('should call cancel action', () => {
     const store = mockStore(initialState);
-
-    apiClientMock.get(`${RBAC_API_BASE}/groups/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
+    mock.onGet(`${RBAC_API_BASE}/groups/123/`).reply(200, { data: []});
 
     const wrapper = mount(
       <GroupWrapper store={ store }>
@@ -63,20 +60,9 @@ describe('<RemoveGroupModal />', () => {
   it('should call the remove action', (done) => {
     const store = mockStore(initialState);
 
-    apiClientMock.get(`${RBAC_API_BASE}/groups/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
-
-    apiClientMock.delete(`${RBAC_API_BASE}/groups/123/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200);
-    }));
-
-    apiClientMock.get(`${RBAC_API_BASE}/groups/`, mockOnce((req, res) => {
-      expect(req).toBeTruthy();
-      return res.status(200).body({ data: []});
-    }));
+    mock.onGet(`${RBAC_API_BASE}/groups/123/`).reply(200, { data: []});
+    mock.onDelete(`${RBAC_API_BASE}/groups/123/`).reply(200);
+    mock.onGet(`${RBAC_API_BASE}/groups/`).reply(200, { data: []});
 
     const wrapper = mount(
       <GroupWrapper store={ store }>


### PR DESCRIPTION
### Changes

There's been a lot of redundant code and a lot of reundant calls to API. I've removed the code and streamlined role fetching. When user is not entitled to cost management no button will be shown. Also filter was not properly working, so I updated the fetch function to actually filter. Next step should be ordering and refactoring of groups table.

### UI

Screenshots taken on account without `cost_management` entitlements.

**Before**
![Screenshot from 2019-11-06 16-42-20](https://user-images.githubusercontent.com/3439771/68313215-82fdb600-00b4-11ea-9a18-a92c71422019.png)

**After - user not org admin or not on beta**
![Screenshot from 2019-11-08 10-45-32](https://user-images.githubusercontent.com/3439771/68466763-56ad7b00-0215-11ea-9b8a-83fbd4362d93.png)

**After - user is org admin and on beta**
![Screenshot from 2019-11-08 10-45-09](https://user-images.githubusercontent.com/3439771/68466781-5f05b600-0215-11ea-94eb-71f7951052ec.png)

