### PR TITLE
When on groups page hide add group for non org admins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10162,18 +10162,6 @@
         "lodash": "^4.17.4"
       }
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -10196,12 +10184,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -11276,9 +11258,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -11288,12 +11270,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "koa-connect": "^2.0.1",
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.2",
-    "node-sass": "^4.9.3",
+    "node-sass": "^4.13.0",
     "npm-run-all": "^4.1.3",
     "prop-types": "^15.6.2",
     "redux-mock-store": "^1.5.3",

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -3,7 +3,10 @@ import { getGroupApi } from '../shared/user-login';
 const groupApi = getGroupApi();
 
 export async function fetchGroups({ limit, offset, name, orderBy }) {
-  return await groupApi.listGroups(limit, offset, name, orderBy);
+  return {
+    ...await groupApi.listGroups(limit, offset, name, orderBy),
+    ...await insights.chrome.auth.getUser()
+  };
 }
 
 export async function fetchGroup(uuid) {

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -3,9 +3,13 @@ import { getGroupApi } from '../shared/user-login';
 const groupApi = getGroupApi();
 
 export async function fetchGroups({ limit, offset, name, orderBy }) {
+  const [ groups, auth ] = await Promise.all([
+    groupApi.listGroups(limit, offset, name, orderBy),
+    insights.chrome.auth.getUser()
+  ]);
   return {
-    ...await groupApi.listGroups(limit, offset, name, orderBy),
-    ...await insights.chrome.auth.getUser()
+    ...groups,
+    ...auth
   };
 }
 

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -23,7 +23,7 @@ const tabItems = [
   { eventKey: 1, title: 'Roles', name: '/roles' }
 ];
 
-const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups }) => {
+const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups, userIdentity }) => {
   const [ filterValue, setFilterValue ] = useState('');
   const [ selectedRows, setSelectedRows ] = useState([]);
 
@@ -127,6 +127,7 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups 
 const mapStateToProps = ({ groupReducer: { groups, filterValue, isLoading }}) => ({
   groups: groups.data,
   pagination: groups.meta,
+  userIdentity: groups.identity,
   isLoading,
   searchFilter: filterValue
 });
@@ -136,6 +137,11 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 }, dispatch);
 
 Groups.propTypes = {
+  userIdentity: PropTypes.shape({
+    user: PropTypes.shape({
+      is_org_admin: PropTypes.bool
+    })
+  }),
   history: PropTypes.shape({
     goBack: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired
@@ -154,6 +160,7 @@ Groups.propTypes = {
 
 Groups.defaultProps = {
   groups: [],
+  userIdentity: {},
   pagination: defaultSettings
 };
 

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -46,7 +46,7 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups,
   </Fragment>;
 
   const actionResolver = (_groupData, { rowIndex }) =>
-    rowIndex % 2 === 1 ? null :
+    (rowIndex % 2 === 1) || !(userIdentity && userIdentity.user && userIdentity.user.is_org_admin) ? null :
       [
         {
           title: 'Edit group',
@@ -61,27 +61,30 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups,
       ];
 
   const toolbarButtons = () => [
-    <Link to="/groups/add-group" key="add-group">
-      <Button
-        variant="primary"
-        aria-label="Create group"
-      >
+    ...userIdentity && userIdentity.user && userIdentity.user.is_org_admin ?
+      [
+        <Link to="/groups/add-group" key="add-group">
+          <Button
+            variant="primary"
+            aria-label="Create group"
+          >
         Create a group
-      </Button>
-    </Link>,
-    {
-      label: 'Edit group',
-      props: {
-        isDisabled: !(selectedRows.length === 1)
-      },
-      onClick: () => push(`/groups/edit/${selectedRows[0].uuid}`)
-    },
-    {
-      label: 'Delete Group(s)',
-      props: {
-        isDisabled: !selectedRows.length > 0
-      }
-    }
+          </Button>
+        </Link>,
+        {
+          label: 'Edit group',
+          props: {
+            isDisabled: !(selectedRows.length === 1)
+          },
+          onClick: () => push(`/groups/edit/${selectedRows[0].uuid}`)
+        },
+        {
+          label: 'Delete Group(s)',
+          props: {
+            isDisabled: !selectedRows.length > 0
+          }
+        }
+      ] : []
   ];
 
   const renderGroupsList = () =>
@@ -98,7 +101,7 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups,
             data={ groups }
             createRows={ createRows }
             columns={ columns }
-            isSelectable
+            isSelectable={ userIdentity && userIdentity.user && userIdentity.user.is_org_admin }
             checkedRows={ selectedRows }
             setCheckedItems={ setCheckedItems }
             request={ fetchGroups }

--- a/src/test/smart-components/group/__snapshots__/groups.test.js.snap
+++ b/src/test/smart-components/group/__snapshots__/groups.test.js.snap
@@ -43,6 +43,7 @@ exports[`<Groups /> should render correctly 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;
 
@@ -89,5 +90,6 @@ exports[`<Groups /> should render correctly in loading state 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;

--- a/src/test/smart-components/group/principal/__snapshots__/principals.test.js.snap
+++ b/src/test/smart-components/group/principal/__snapshots__/principals.test.js.snap
@@ -43,6 +43,7 @@ exports[`<GroupPrincipals /> should render correctly 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;
 
@@ -89,5 +90,6 @@ exports[`<GroupPrincipals /> should render correctly in loading state 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;

--- a/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
+++ b/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
@@ -48,6 +48,7 @@ exports[`<GroupPrincipals /> should render correctly 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;
 
@@ -99,5 +100,6 @@ exports[`<GroupPrincipals /> should render correctly in loading state 1`] = `
       "unsubscribe": [Function],
     }
   }
+  userIdentity={Object {}}
 />
 `;

--- a/src/test/smart-components/group/role/group-roles.test.js
+++ b/src/test/smart-components/group/role/group-roles.test.js
@@ -7,6 +7,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import GroupRoles from '../../../../smart-components/group/role/group-roles';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import { rolesInitialState } from '../../../../redux/reducers/role-reducer';
+import { groupsInitialState } from '../../../../redux/reducers/group-reducer';
 
 describe('<GroupPrincipals />', () => {
 
@@ -18,7 +19,10 @@ describe('<GroupPrincipals />', () => {
   beforeEach(() => {
     initialProps = {};
     mockStore = configureStore(middlewares);
-    initialState = { roleReducer: { ...rolesInitialState, isLoading: false }};
+    initialState = {
+      roleReducer: { ...rolesInitialState, isLoading: false },
+      groupReducer: { ...groupsInitialState, isLoading: false }
+    };
   });
 
   it('should render correctly', () => {


### PR DESCRIPTION
## UI changes
* Users without org admin rights should not be able to add new group

### Before
![Screenshot from 2019-11-26 10-54-34](https://user-images.githubusercontent.com/3439771/69619004-29493580-103b-11ea-83a0-ad4a691ddf8a.png)

### After
![Screenshot from 2019-11-26 10-54-17](https://user-images.githubusercontent.com/3439771/69619003-29493580-103b-11ea-8885-b44346a3f944.png)

#### JIRA
RHCLOUD-3532