### PR TITLE
Temporary fix for delete modal

### DIFF
--- a/src/smart-components/group/remove-group-modal.js
+++ b/src/smart-components/group/remove-group-modal.js
@@ -26,7 +26,7 @@ const RemoveGroupModal = ({
       removeGroup(id).then(() => push(closeUrl));
 
   const onCancel = () => goBack();
-  console.log(group);
+
   return (
     <Modal
       isOpen

--- a/src/smart-components/group/remove-group-modal.js
+++ b/src/smart-components/group/remove-group-modal.js
@@ -26,7 +26,7 @@ const RemoveGroupModal = ({
       removeGroup(id).then(() => push(closeUrl));
 
   const onCancel = () => goBack();
-
+  console.log(group);
   return (
     <Modal
       isOpen
@@ -89,7 +89,7 @@ RemoveGroupModal.propTypes = {
 
 const mapStateToProps = ({ groupReducer: { selectedGroup, isRecordLoading }}) => ({
   group: selectedGroup,
-  isLoading: isRecordLoading
+  isLoading: false
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/smart-components/group/remove-group-modal.js
+++ b/src/smart-components/group/remove-group-modal.js
@@ -87,7 +87,7 @@ RemoveGroupModal.propTypes = {
   closeUrl: PropTypes.string
 };
 
-const mapStateToProps = ({ groupReducer: { selectedGroup, isRecordLoading }}) => ({
+const mapStateToProps = ({ groupReducer: { selectedGroup }}) => ({
   group: selectedGroup,
   isLoading: false
 });

--- a/src/smart-components/group/remove-group-modal.js
+++ b/src/smart-components/group/remove-group-modal.js
@@ -89,7 +89,7 @@ RemoveGroupModal.propTypes = {
 
 const mapStateToProps = ({ groupReducer: { selectedGroup }}) => ({
   group: selectedGroup,
-  isLoading: false
+  isLoading: !selectedGroup.loaded
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/src/test/smart-components/group/remove-group-modal.test.js
+++ b/src/test/smart-components/group/remove-group-modal.test.js
@@ -35,7 +35,7 @@ describe('<RemoveGroupModal />', () => {
     initialState = {
       groupReducer: {
         ...groupsInitialState,
-        isLoading: false,
+        isLoading: true,
         group: {
           name: 'Foo',
           uuid: '1'

--- a/src/test/smart-components/group/remove-group-modal.test.js
+++ b/src/test/smart-components/group/remove-group-modal.test.js
@@ -35,10 +35,13 @@ describe('<RemoveGroupModal />', () => {
     initialState = {
       groupReducer: {
         ...groupsInitialState,
-        isLoading: true,
+        isLoading: false,
         group: {
           name: 'Foo',
           uuid: '1'
+        },
+        selectedGroup: {
+          loaded: true
         }
       }
     };


### PR DESCRIPTION
Delete group modal gets stuck in loading, people want it to work ASAP. I think there are some issues with the groupReducer. I simply disabled it for the quick fix, this is the easiest way I could think of