### PR TITLE
remove expandable rows from groups table

### DIFF
--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -1,11 +1,10 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
-import ExpandableDescription from './expandable-description';
 import { DateFormat } from '@redhat-cloud-services/frontend-components';
 
 export const createRows = (data, opened, selectedRows = []) => (
-  data.reduce((acc, { uuid, name, description, principalCount, modified }, key) => ([
+  data.reduce((acc, { uuid, name, description, principalCount, modified }) => ([
     ...acc,
     {
       uuid,

--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -9,7 +9,6 @@ export const createRows = (data, opened, selectedRows = []) => (
     ...acc,
     {
       uuid,
-      isOpen: Boolean(opened[uuid]),
       cells: [
         <Fragment key={ uuid }>
           <Link to={ `/groups/detail/${uuid}` }>
@@ -23,14 +22,6 @@ export const createRows = (data, opened, selectedRows = []) => (
         </Fragment>
       ],
       selected: Boolean(selectedRows && selectedRows.find(row => row.uuid === uuid))
-    }, {
-      parent: key * 2,
-      fullWidth: true,
-      cells: [{
-        title: opened[uuid] ?
-          <ExpandableDescription uuid={ uuid } /> :
-          <Fragment />
-      }]
     }
   ]), [])
 );


### PR DESCRIPTION
Jira coming soon

The expandable rows are being taken out in favor of the second page.

Screenshot:

<img width="1375" alt="Screen Shot 2020-01-30 at 3 15 22 PM" src="https://user-images.githubusercontent.com/12520842/73486543-5daadc00-4373-11ea-87ce-7bc5d580d24e.png">
