### PR TITLE
remove a from create a group

### DIFF
--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -69,7 +69,7 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups,
             variant="primary"
             aria-label="Create group"
           >
-        Create a group
+        Create group
           </Button>
         </Link>,
         {


### PR DESCRIPTION
**Jira**
https://projects.engineering.redhat.com/browse/RHCLOUD-4318

**What**
This removes the "a" from the "create a group" button to follow mocks: https://marvelapp.com/5dcjg6g/screen/63628276

**Screenshot**
![Screen Shot 2020-01-31 at 8 44 27 AM](https://user-images.githubusercontent.com/12520842/73543912-fe49dc00-4405-11ea-85db-49fdc9d38478.png)
