### PR TITLE
Clear filter and unselect group after a single delete

### DIFF
--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -43,7 +43,11 @@ const Groups = ({ fetchGroups, isLoading, pagination, history: { push }, groups,
   const routes = () => <Fragment>
     <Route exact path="/groups/add-group" render={ props => <AddGroupWizard { ...props } postMethod={ fetchData } /> } />
     <Route exact path="/groups/edit/:id" render={ props => <EditGroup { ...props } postMethod={ fetchData } /> } />
-    <Route exact path="/groups/remove/:id" render={ props => <RemoveGroup { ...props } postMethod={ fetchData } /> } />
+    <Route exact path="/groups/remove/:id" render={ props => <RemoveGroup { ...props } postMethod={ (ids) => {
+      fetchData();
+      setSelectedRows(selectedRows.filter(row => (!ids.includes(row.uuid))));
+      setFilterValue('');
+    } } /> } />
   </Fragment>;
 
   const actionResolver = () =>

--- a/src/smart-components/group/remove-group-modal.js
+++ b/src/smart-components/group/remove-group-modal.js
@@ -22,7 +22,7 @@ const RemoveGroupModal = ({
   }, []);
 
   const onSubmit = () =>
-    postMethod ? removeGroup(id).then(() => postMethod()).then(push(closeUrl)) :
+    postMethod ? removeGroup(id).then(() => postMethod([ id ])).then(push(closeUrl)) :
       removeGroup(id).then(() => push(closeUrl));
 
   const onCancel = () => goBack();


### PR DESCRIPTION
New state:

When 1...* groups selected and one of them deleted...
- a search filter is now cleared
- the deleted group doesn't remain selected anymore
 
![001](https://user-images.githubusercontent.com/50696716/73844581-1f089c00-4821-11ea-984b-3dd441b05866.png)
