### PR TITLE
Removing yarn dependency for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
   "scripts": {
     "build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
     "test": "jest --passWithNoTests",
-    "lint": "yarn eslint ./src",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint ./src",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "prod": "NODE_ENV=production WEBPACK_SERVE=production webpack-serve --config config/dev.webpack.config.js",
     "server:ctr": "node src/server/generateServerKey.js",


### PR DESCRIPTION
We can still check our linting without yarn. One less package manager to deal with. :slightly_smiling_face: 