### PR TITLE
Fix info text when deleting single role form group

### DIFF
--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -131,7 +131,7 @@ const GroupRoles = ({
             const multipleRolesSelected = selectedRoles.length > 1;
             setConfirmDelete(() => () => removeRoles(uuid, selectedRoles.map(role => role.uuid), () => fetchRolesForGroup(pagination)(uuid)));
             setDeleteInfo({
-              title: 'Remove roles?',
+              title: multipleRolesSelected ? 'Remove roles?' : 'Remove role?',
               confirmButtonLabel: selectedRoles.length > 1 ? 'Remove roles' : 'Remove role',
               text: removeModalText(
                 name,

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -133,7 +133,10 @@ const GroupRoles = ({
             setDeleteInfo({
               title: 'Remove roles?',
               confirmButtonLabel: selectedRoles.length > 1 ? 'Remove roles' : 'Remove role',
-              text: removeModalText(name, multipleRolesSelected ? selectedRoles.length : selectedRoles[0].label, multipleRolesSelected)
+              text: removeModalText(
+                name,
+                multipleRolesSelected ? selectedRoles.length : roles.find(role => role.uuid === selectedRoles[0].uuid).name,
+                multipleRolesSelected)
             });
             setShowRemoveModal(true);
           }


### PR DESCRIPTION
Modal was showing link instead of plain text. Also it was using plural form in title for one selected user.

#### Before
![Screenshot from 2020-02-10 15-24-32](https://user-images.githubusercontent.com/9535558/74158880-22ce6100-4c1b-11ea-96f6-5550a0b0e005.png)
#### After
![Screenshot from 2020-02-10 15-39-09](https://user-images.githubusercontent.com/9535558/74159122-835d9e00-4c1b-11ea-8b0c-d8796ccaf319.png)

