### PR TITLE
Create Group summary visual fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7178,8 +7178,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7200,14 +7199,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7222,20 +7219,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7352,8 +7346,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7365,7 +7358,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7380,7 +7372,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7388,14 +7379,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7414,7 +7403,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7495,8 +7483,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7508,7 +7495,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7594,8 +7580,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7631,7 +7616,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7651,7 +7635,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7695,14 +7678,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/App.scss
+++ b/src/App.scss
@@ -94,3 +94,11 @@
 .pf-c-table tbody tr.ins-c-rbac__group-default {
   .pf-c-table__check:first-of-type input { display: none; }
 }
+
+.ins-c-rbac__summary {
+  .pf-l-grid {
+    .pf-l-grid__item {
+      margin-bottom: var(--pf-global--gutter--md);
+    }
+  }
+}

--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -72,6 +72,7 @@ const AddGroupWizard = ({
   return (
     <Wizard
       isLarge
+      isCompactNav
       title="Create and configure a group"
       description="To give users access permissions, create a group and assign roles to it."
       isOpen

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -21,7 +21,7 @@ const SummaryContent = (formData) => {
   return (
     <Fragment>
       <Stack gutter="md">
-        <StackItem>
+        <StackItem className="pf-u-mb-md">
           <Title size="xl"> Review </Title>
         </StackItem>
         <StackItem>

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -55,9 +55,9 @@ const SummaryContent = (formData) => {
                 </GridItem>
                 <GridItem span= { 10 }>
                   <Text
-                    className="groups-table-detail content"
+                    className="groups-table-detail content pf-u-mb-md"
                     component={ TextVariants.h5 }>
-                    { `${selectedUsers.map((user, index) => `${index !== 0 ? ' ' : ''}${user.label}`)}` }
+                    { selectedUsers.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{ role.label }</Text>) }
                   </Text>
                 </GridItem>
               </Grid>
@@ -69,7 +69,7 @@ const SummaryContent = (formData) => {
                   <Text
                     className="groups-table-detail content"
                     component={ TextVariants.h5 }>
-                    { `${selectedRoles.map((role, index) => `${index !== 0 ? ' ' : ''}${role.label}`)}` }
+                    { selectedRoles.map((role, index) => <Text className= "pf-u-mb-0" key={ index }>{ role.label }</Text>)  }
                   </Text>
                 </GridItem>
               </Grid>

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -35,23 +35,23 @@ const SummaryContent = (formData) => {
             <StackItem>
               <Grid gutter="md">
                 <GridItem span={ 2 }>
-                  <Text className="data-table-detail heading" component={ TextVariants.h5 }>Group name</Text>
+                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Group name</Text>
                 </GridItem>
                 <GridItem span={ 10 }>
-                  <Text className="data-table-detail content" component={ TextVariants.p }>{ name }</Text>
+                  <Text className="data-table-detail content content pf-u-mb-md" component={ TextVariants.p }>{ name }</Text>
                 </GridItem>
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading" component={ TextVariants.h5 }>Group description</Text>
+                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Group description</Text>
                 </GridItem>
                 <GridItem span = { 10 }>
-                  <Text className="data-table-detail content" component={ TextVariants.p }>{ description }</Text>
+                  <Text className="data-table-detail content content pf-u-mb-md" component={ TextVariants.p }>{ description }</Text>
                 </GridItem>
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading" component={ TextVariants.h5 }>Member(s)</Text>
+                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Member(s)</Text>
                 </GridItem>
                 <GridItem span= { 10 }>
                   <Text
@@ -63,7 +63,7 @@ const SummaryContent = (formData) => {
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading" component={ TextVariants.h5 }>Role(s)</Text>
+                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Role(s)</Text>
                 </GridItem>
                 <GridItem span= { 10 }>
                   <Text

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -21,41 +21,42 @@ const SummaryContent = (formData) => {
   return (
     <Fragment>
       <Stack gutter="md">
-        <StackItem className="pf-u-mb-md">
-          <Title size="xl"> Review </Title>
-        </StackItem>
         <StackItem>
           <Stack gutter="md">
             <StackItem>
               <TextContent>
-                <Text className="data-table-detail heading" component={ TextVariants.h5 }>
-                Review and confirm your inputs. If there is anything incorrect, click Back and revise.</Text>
+                <Title headingLevel="h4" size="xl"> Add members to the group </Title>
+                <Text
+                  className="pf-u-mt-0"
+                  component={ TextVariants.h6 }>
+                 Confirm the details for this group, or click Back to revise.
+                </Text>
               </TextContent>
             </StackItem>
-            <StackItem>
+            <StackItem className="ins-c-rbac__summary">
               <Grid gutter="md">
                 <GridItem span={ 2 }>
-                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Group name</Text>
+                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Group name</Text>
                 </GridItem>
                 <GridItem span={ 10 }>
-                  <Text className="data-table-detail content content pf-u-mb-md" component={ TextVariants.p }>{ name }</Text>
+                  <Text className="data-table-detail content content" component={ TextVariants.p }>{ name }</Text>
                 </GridItem>
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Group description</Text>
+                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Group description</Text>
                 </GridItem>
                 <GridItem span = { 10 }>
-                  <Text className="data-table-detail content content pf-u-mb-md" component={ TextVariants.p }>{ description }</Text>
+                  <Text className="data-table-detail content content" component={ TextVariants.p }>{ description }</Text>
                 </GridItem>
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Member(s)</Text>
+                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Member(s)</Text>
                 </GridItem>
                 <GridItem span= { 10 }>
                   <Text
-                    className="groups-table-detail content pf-u-mb-md"
+                    className="groups-table-detail content"
                     component={ TextVariants.h5 }>
                     { selectedUsers.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{ role.label }</Text>) }
                   </Text>
@@ -63,7 +64,7 @@ const SummaryContent = (formData) => {
               </Grid>
               <Grid gutter="md">
                 <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading content pf-u-mb-md" component={ TextVariants.h5 }>Role(s)</Text>
+                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Role(s)</Text>
                 </GridItem>
                 <GridItem span= { 10 }>
                   <Text

--- a/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
+++ b/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
@@ -27,21 +27,6 @@ exports[`<SummaryContent /> should render correctly 1`] = `
         <div
           className="pf-l-stack__item"
         >
-          <Title
-            size="xl"
-          >
-            <h1
-              className="pf-c-title pf-m-xl"
-            >
-               Review 
-            </h1>
-          </Title>
-        </div>
-      </StackItem>
-      <StackItem>
-        <div
-          className="pf-l-stack__item"
-        >
           <Stack
             gutter="md"
           >
@@ -56,24 +41,36 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                     <div
                       className="pf-c-content"
                     >
-                      <Text
-                        className="data-table-detail heading"
-                        component="h5"
+                      <Title
+                        headingLevel="h4"
+                        size="xl"
                       >
-                        <h5
-                          className="data-table-detail heading"
+                        <h4
+                          className="pf-c-title pf-m-xl"
+                        >
+                           Add members to the group 
+                        </h4>
+                      </Title>
+                      <Text
+                        className="pf-u-mt-0"
+                        component="h6"
+                      >
+                        <h6
+                          className="pf-u-mt-0"
                           data-pf-content={true}
                         >
-                          Review and confirm your inputs. If there is anything incorrect, click Back and revise.
-                        </h5>
+                          Confirm the details for this group, or click Back to revise.
+                        </h6>
                       </Text>
                     </div>
                   </TextContent>
                 </div>
               </StackItem>
-              <StackItem>
+              <StackItem
+                className="ins-c-rbac__summary"
+              >
                 <div
-                  className="pf-l-stack__item"
+                  className="pf-l-stack__item ins-c-rbac__summary"
                 >
                   <Grid
                     gutter="md"
@@ -88,11 +85,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-2-col"
                         >
                           <Text
-                            className="data-table-detail heading"
+                            className="data-table-detail heading content"
                             component="h5"
                           >
                             <h5
-                              className="data-table-detail heading"
+                              className="data-table-detail heading content"
                               data-pf-content={true}
                             >
                               Group name
@@ -107,11 +104,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-10-col"
                         >
                           <Text
-                            className="data-table-detail content"
+                            className="data-table-detail content content"
                             component="p"
                           >
                             <p
-                              className="data-table-detail content"
+                              className="data-table-detail content content"
                               data-pf-content={true}
                             />
                           </Text>
@@ -132,11 +129,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-2-col"
                         >
                           <Text
-                            className="data-table-detail heading"
+                            className="data-table-detail heading content"
                             component="h5"
                           >
                             <h5
-                              className="data-table-detail heading"
+                              className="data-table-detail heading content"
                               data-pf-content={true}
                             >
                               Group description
@@ -151,11 +148,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-10-col"
                         >
                           <Text
-                            className="data-table-detail content"
+                            className="data-table-detail content content"
                             component="p"
                           >
                             <p
-                              className="data-table-detail content"
+                              className="data-table-detail content content"
                               data-pf-content={true}
                             />
                           </Text>
@@ -176,11 +173,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-2-col"
                         >
                           <Text
-                            className="data-table-detail heading"
+                            className="data-table-detail heading content"
                             component="h5"
                           >
                             <h5
-                              className="data-table-detail heading"
+                              className="data-table-detail heading content"
                               data-pf-content={true}
                             >
                               Member(s)
@@ -220,11 +217,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-2-col"
                         >
                           <Text
-                            className="data-table-detail heading"
+                            className="data-table-detail heading content"
                             component="h5"
                           >
                             <h5
-                              className="data-table-detail heading"
+                              className="data-table-detail heading content"
                               data-pf-content={true}
                             >
                               Role(s)


### PR DESCRIPTION
Display roles and users in columns under each other. Also I change compact navigation, so `Group  description` fits one line.
![Screenshot from 2020-02-20 11-17-19](https://user-images.githubusercontent.com/9535558/74924845-77b86700-53d3-11ea-9497-3bf5ea260177.png)
![Screenshot from 2020-02-20 11-16-46](https://user-images.githubusercontent.com/9535558/74924846-7850fd80-53d3-11ea-9d87-4e77fb3efdab.png)
