### PR TITLE
Create group bulk select users fix

### DIFF
--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -33,7 +33,7 @@ const UsersList = ({ users, fetchUsers, isLoading, pagination, selectedUsers, se
 
   const setCheckedItems = (newSelection) => {
     setSelectedUsers((users) => {
-      return newSelection(users).map(({ uuid, name, label }) => ({ uuid, label: label || name }));
+      return newSelection(users).map(({ uuid, name, username, label }) => ({ uuid, label: label || name || username }));
     });
   };
 


### PR DESCRIPTION
Fix users bulk select in Create group wizard. When you bulk select users and go to summary page, you would see list of undefined users. This PR should fix this issue.


https://projects.engineering.redhat.com/browse/RHCLOUD-4615