### PR TITLE
fix page header on groups page

### DIFF
--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -67,7 +67,7 @@ const Group = ({
           <SplitItem isFilled>
             <TopToolbarTitle
               title={ !isFetching && group
-                ? <div>{ group.platform_default && !group.system ? defaultGroupChangedIcon(group.name) : group.name }</div>
+                ? <Fragment>{ group.platform_default && !group.system ? defaultGroupChangedIcon(group.name) : group.name }</Fragment>
                 : undefined }
               description={ !isFetching && group ? group.description : undefined } />
           </SplitItem>


### PR DESCRIPTION
There should not be a `div` inside of the h1. This removes that in place of a fragment.

No visual changes