### PR TITLE
Apply sorting to groups table

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -4,7 +4,7 @@ const groupApi = getGroupApi();
 
 export async function fetchGroups({ limit, offset, name, orderBy }) {
   const [ groups, auth ] = await Promise.all([
-    groupApi.listGroups(limit, offset, name, orderBy),
+    groupApi.listGroups(limit, offset, name, undefined, undefined, orderBy),
     insights.chrome.auth.getUser()
   ]);
   return {

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components';
@@ -34,9 +34,17 @@ export const TableToolbarView = ({
   emptyProps,
   filterPlaceholder,
   rowWrapper,
-  textFilters
+  textFilters,
+  sortBy
 }) => {
   const [ opened, openRow ] = useState({});
+  const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
+  useEffect(() => {
+    setSortByState({
+      ...sortByState,
+      ...sortBy
+    });
+  }, [ sortBy ]);
 
   const rows = createRows(data, opened, checkedRows);
 
@@ -113,6 +121,18 @@ export const TableToolbarView = ({
         { ...rows.length > 0 && { actionResolver } }
         areActionsDisabled={ areActionsDisabled }
         rowWrapper={ rowWrapper }
+        sortBy={ sortByState }
+        onSort={ (e, index, direction) => {
+          const key = columns[index - 1].key;
+          setSortByState({ index, direction });
+          fetchData({
+            ...pagination,
+            offset: 0,
+            name: '',
+            orderBy: direction === 'desc' ? `-${key}` : key
+          });
+        }
+        }
       >
         <TableHeader />
         <TableBody />

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -123,13 +123,12 @@ export const TableToolbarView = ({
         rowWrapper={ rowWrapper }
         sortBy={ sortByState }
         onSort={ (e, index, direction) => {
-          const key = columns[index - isSelectable].key;
           setSortByState({ index, direction });
           fetchData({
             ...pagination,
             offset: 0,
             name: '',
-            orderBy: direction === 'desc' ? `-${key}` : key
+            orderBy: `${direction === 'desc' ? '-' : ''}${columns[index - isSelectable].key}`
           });
         }
         }

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -123,7 +123,7 @@ export const TableToolbarView = ({
         rowWrapper={ rowWrapper }
         sortBy={ sortByState }
         onSort={ (e, index, direction) => {
-          const key = columns[index - 1].key;
+          const key = columns[index - isSelectable].key;
           setSortByState({ index, direction });
           fetchData({
             ...pagination,

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -18,8 +18,8 @@ import './groups.scss';
 
 const columns = [
   { title: 'Name', key: 'name', transforms: [ sortable ]},
-  { title: 'Description', key: 'description', transforms: [ sortable ]},
-  { title: 'Members', key: 'principalCount', transforms: [ sortable ]},
+  { title: 'Roles' },
+  { title: 'Members' },
   { title: 'Last modified', key: 'modified', transforms: [ sortable ]}
 ];
 

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import { Link, Route, Switch, useHistory } from 'react-router-dom';
-import { expandable } from '@patternfly/react-table';
+import { sortable } from '@patternfly/react-table';
 import { Button, Stack, StackItem } from '@patternfly/react-core';
 import AddGroupWizard from './add-group/add-group-wizard';
 import EditGroup from './edit-group-modal';
@@ -16,7 +16,12 @@ import Role from '../role/role';
 import GroupRowWrapper from './group-row-wrapper';
 import './groups.scss';
 
-const columns = [{ title: 'Name', cellFormatters: [ expandable ]}, 'Roles', 'Members', 'Last modified' ];
+const columns = [
+  { title: 'Name', key: 'name', transforms: [ sortable ]},
+  { title: 'Description', key: 'description', transforms: [ sortable ]},
+  { title: 'Members', key: 'principalCount', transforms: [ sortable ]},
+  { title: 'Last modified', key: 'modified', transforms: [ sortable ]}
+];
 
 const Groups = () => {
   const [ filterValue, setFilterValue ] = useState('');

--- a/src/test/role/__snapshots__/role.test.js.snap
+++ b/src/test/role/__snapshots__/role.test.js.snap
@@ -31,9 +31,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -73,9 +76,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -115,9 +121,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -157,9 +166,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -234,9 +246,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -276,9 +291,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -318,9 +336,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -360,9 +381,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -437,9 +461,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -479,9 +506,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -521,9 +551,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],
@@ -563,9 +596,12 @@ Array [
             "onCollapse": undefined,
             "onExpand": undefined,
             "onSelect": undefined,
-            "onSort": undefined,
+            "onSort": [Function],
             "rowLabeledBy": "simple-node",
-            "sortBy": undefined,
+            "sortBy": Object {
+              "direction": undefined,
+              "index": undefined,
+            },
           },
           "header": Object {
             "formatters": Array [],

--- a/src/test/smart-components/group/groups.test.js
+++ b/src/test/smart-components/group/groups.test.js
@@ -141,4 +141,29 @@ describe('<Groups />', () => {
     ];
     expect(store.getActions()).toEqual(expectedCancelPayload);
   });
+
+  it('should fetch groups on sort click', async() => {
+    const store = mockStore(initialState);
+    mock.onGet(`/api/rbac/v1/groups/?limit=10&offset=0&name=`).replyOnce(200, {});
+    mock.onGet(`/api/rbac/v1/groups/?limit=10&offset=0&name=&order_by=name`).replyOnce(200, {});
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <Provider store={ store }>
+          <Router initialEntries={ [ '/groups' ] }>
+            <Groups />
+          </Router>
+        </Provider>
+      );
+    });
+    store.clearActions();
+    await act(async () => {
+      wrapper.find('span.pf-c-table__sort-indicator').first().simulate('click');
+    });
+    const expectedPayloadAfter = [
+      { type: 'FETCH_GROUPS_PENDING' },
+      { type: 'FETCH_GROUPS_FULFILLED', payload: {}}
+    ];
+    expect(store.getActions()).toEqual(expectedPayloadAfter);
+  });
 });


### PR DESCRIPTION
![002](https://user-images.githubusercontent.com/50696716/75367535-c5940a00-58c0-11ea-87c8-8b05467441a6.png)

- added sorting to table-toolbar-view
- applied sorting to groups table
- tested fetching groups on sorting button click

@karelhala 