### PR TITLE
check if {match} exists on edit-group-modal

### DIFF
--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -28,7 +28,7 @@ const EditGroupModal = ({
   };
 
   const fetchData = () => {
-    fetchGroup(match.params.id).payload.then((data) => setGroupData(data)).catch(() => setGroupData(undefined));
+    match && fetchGroup(match.params.id).payload.then((data) => setGroupData(data)).catch(() => setGroupData(undefined));
   };
 
   useEffect(() => {


### PR DESCRIPTION
Right now, the `edit-group-modal` fails when `match` is null. This should just check if it exists before fetching the group.