### PR TITLE
Make Roles default tab for roles

### DIFF
--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -110,7 +110,7 @@ const Group = ({
           path={ `/groups/detail/:uuid/roles` }
           render={ props => <GroupRoles { ...props } onDefaultGroupChanged={ setShowDefaultGroupChangedInfo }/> } />
         <Route path={ `/groups/detail/:uuid/members` } component={ GroupPrincipals } />
-        <Route render={ () => <Redirect to={ `/groups/detail/${uuid}/members` } /> } />
+        <Route render={ () => <Redirect to={ `/groups/detail/${uuid}/roles` } /> } />
       </Switch>
       { !group && <ListLoader/> }
     </Fragment>


### PR DESCRIPTION
When clicking into a group, the user is currently brought to the member's tab by default, but they should actually be brought to the ROLES tab by default.

https://projects.engineering.redhat.com/browse/RHCLOUD-4797