### PR TITLE
Disable Add role button when group contains all roles

### DIFF
--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -9,7 +9,7 @@ import { mappedProps } from '../../../helpers/shared/helpers';
 import { defaultCompactSettings } from '../../../helpers/shared/pagination';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { fetchRoles } from '../../../redux/actions/role-actions';
-import { removeRolesFromGroup, addRolesToGroup, fetchRolesForGroup } from '../../../redux/actions/group-actions';
+import { removeRolesFromGroup, addRolesToGroup, fetchRolesForGroup, fetchAddRolesForGroup } from '../../../redux/actions/group-actions';
 import AddGroupRoles from './add-group-roles';
 import { defaultSettings } from '../../../helpers/shared/pagination';
 import RemoveRole from './remove-role-modal';
@@ -53,7 +53,9 @@ const GroupRoles = ({
   name,
   isDefault,
   isChanged,
-  onDefaultGroupChanged
+  onDefaultGroupChanged,
+  fetchAddRolesForGroup,
+  disableAddRoles
 }) => {
   const [ descriptionValue, setDescriptionValue ] = useState('');
   const [ filterValue, setFilterValue ] = useState('');
@@ -66,6 +68,11 @@ const GroupRoles = ({
   useEffect(() => {
     fetchRolesForGroup(pagination)(uuid);
   }, []);
+
+  useEffect(() => {
+    fetchAddRolesForGroup(uuid);
+  }, [ roles ]);
+
   const setCheckedItems = (newSelection) => {
     setSelectedRoles((roles) => {
       return newSelection(roles).map(({ uuid, name, label }) => ({ uuid, label: label || name }));
@@ -124,6 +131,7 @@ const GroupRoles = ({
           <Button
             variant="primary"
             aria-label="Add role"
+            isDisabled={ disableAddRoles }
           >
         Add role
           </Button>
@@ -222,7 +230,8 @@ const mapStateToProps = ({ groupReducer: { selectedGroup, groups }}) => {
     userIdentity: groups.identity,
     name: selectedGroup.name,
     isDefault: selectedGroup.platform_default,
-    isChanged: !selectedGroup.system
+    isChanged: !selectedGroup.system,
+    disableAddRoles: !(selectedGroup.addRoles.pagination && selectedGroup.addRoles.pagination.count > 0)
   };};
 
 const mapDispatchToProps = dispatch => {
@@ -233,6 +242,7 @@ const mapDispatchToProps = dispatch => {
     addRoles: (groupId, roles, callback) => dispatch(reloadWrapper(addRolesToGroup(groupId, roles), callback)),
     removeRoles: (groupId, roles, callback) => dispatch(reloadWrapper(removeRolesFromGroup(groupId, roles), callback)),
     fetchRolesForGroup: (config) => (groupId, options) => dispatch(fetchRolesForGroup(groupId, config, options)),
+    fetchAddRolesForGroup: (groupId) => dispatch(fetchAddRolesForGroup(groupId, {}, {})),
     addNotification: (...props) => dispatch(addNotification(...props))
   };
 };
@@ -247,6 +257,7 @@ GroupRoles.propTypes = {
   searchFilter: PropTypes.string,
   fetchRoles: PropTypes.func.isRequired,
   fetchRolesForGroup: PropTypes.func.isRequired,
+  fetchAddRolesForGroup: PropTypes.func.isRequired,
   selectedRoles: PropTypes.array,
   addRoles: PropTypes.func,
   name: PropTypes.string,
@@ -266,7 +277,8 @@ GroupRoles.propTypes = {
   }),
   isDefault: PropTypes.bool,
   isChanged: PropTypes.bool,
-  onDefaultGroupChanged: PropTypes.func
+  onDefaultGroupChanged: PropTypes.func,
+  disableAddRoles: PropTypes.bool.isRequired
 };
 
 GroupRoles.defaultProps = {

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, Route } from 'react-router-dom';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { Section, DateFormat } from '@redhat-cloud-services/frontend-components';
 import { mappedProps } from '../../../helpers/shared/helpers';
 import { defaultCompactSettings } from '../../../helpers/shared/pagination';
@@ -39,6 +39,28 @@ const createRows = (groupUuid, data, expanded, checkedRows = []) => {
     }
   ]), []) : [];
 };
+
+const addRoleButton = (isDisabled) => (isDisabled
+  ? <Tooltip
+    content={ <div>All available roles have already been added to the group</div> }
+
+  >
+    <div>
+      <Button
+        variant="primary"
+        aria-label="Add role"
+        isDisabled={ isDisabled }
+      >
+      Add role
+      </Button>
+    </div>
+  </Tooltip>
+  : <Button
+    variant="primary"
+    aria-label="Add role"
+  >
+    Add role
+  </Button>);
 
 const GroupRoles = ({
   roles,
@@ -128,13 +150,7 @@ const GroupRoles = ({
           to={ `/groups/detail/${uuid}/roles/add_roles` }
           key="add-to-group"
         >
-          <Button
-            variant="primary"
-            aria-label="Add role"
-            isDisabled={ disableAddRoles }
-          >
-        Add role
-          </Button>
+          { addRoleButton(disableAddRoles) }
         </Link>,
         {
           label: 'Remove from group',

--- a/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
+++ b/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
@@ -7,6 +7,8 @@ exports[`<GroupPrincipals /> should render correctly 1`] = `
   <GroupRoles
     addNotification={[Function]}
     addRoles={[Function]}
+    disableAddRoles={true}
+    fetchAddRolesForGroup={[Function]}
     fetchRoles={[Function]}
     fetchRolesForGroup={[Function]}
     isChanged={true}
@@ -45,6 +47,8 @@ exports[`<GroupPrincipals /> should render correctly in loading state 1`] = `
   <GroupRoles
     addNotification={[Function]}
     addRoles={[Function]}
+    disableAddRoles={true}
+    fetchAddRolesForGroup={[Function]}
     fetchRoles={[Function]}
     fetchRolesForGroup={[Function]}
     isChanged={true}


### PR DESCRIPTION
Disable Add role button when group contains all roles. I have created `All users` group under `insights-qa` user. You can use it to test this feature.

https://projects.engineering.redhat.com/browse/RHCLOUD-4799
#### All roles are in the group
![Screenshot from 2020-03-04 07-25-44](https://user-images.githubusercontent.com/9535558/75851235-6581f400-5de9-11ea-9081-97684cebfa30.png)

#### Some roles are NOT in the group
![Screenshot from 2020-03-02 13-12-46](https://user-images.githubusercontent.com/9535558/75675521-98ac7200-5c87-11ea-9563-c313cb630ff2.png)
