### PR TITLE
Gate "Create Role" button to cost admins

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -35,7 +35,7 @@ global.insights = {
     auth: {
       getUser: () => new Promise(resolve => resolve(true))
     },
-    getUserPermissions: () => new Promise(resolve => resolve(true)),
+    getUserPermissions: () => Promise.resolve([]),
     isBeta: () => true
   }
 };

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -35,6 +35,7 @@ global.insights = {
     auth: {
       getUser: () => new Promise(resolve => resolve(true))
     },
+    getUserPermissions: () => new Promise(resolve => resolve(true)),
     isBeta: () => true
   }
 };

--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -66,7 +66,7 @@ const AddGroupWizard = ({
       title: 'Adding group',
       dismissDelay: 8000,
       dismissable: false,
-      description: 'Adding group was cancelled by the user.'
+      description: 'Adding group was canceled by the user.'
     });
     history.push('/groups');
   };

--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -51,7 +51,7 @@ const EditGroupModal = ({
       dismissDelay: 8000,
       dismissable: false,
       title: selectedGroup ? 'Editing group' : 'Adding group',
-      description: selectedGroup ? 'Edit group was cancelled by the user.' : 'Adding group was cancelled by the user.'
+      description: selectedGroup ? 'Edit group was canceled by the user.' : 'Adding group was canceled by the user.'
     });
     onClose();
     history.push(closeUrl);

--- a/src/smart-components/group/principal/add-group-members.js
+++ b/src/smart-components/group/principal/add-group-members.js
@@ -40,7 +40,7 @@ const AddGroupMembers = ({
       title: `Adding member${selectedUsers.length > 1 ? 's' : ''} to group`,
       dismissDelay: 8000,
       dismissable: false,
-      description: `Adding member${selectedUsers.length > 1 ? 's' : ''} to group was cancelled by the user.`
+      description: `Adding member${selectedUsers.length > 1 ? 's' : ''} to group was canceled by the user.`
     });
     push(closeUrl);
   };

--- a/src/smart-components/group/role/add-group-roles.js
+++ b/src/smart-components/group/role/add-group-roles.js
@@ -38,7 +38,7 @@ const AddGroupRoles = ({
       title: 'Adding members to group',
       dismissDelay: 8000,
       dismissable: false,
-      description: 'Adding members to group was cancelled by the user.'
+      description: 'Adding members to group was canceled by the user.'
     });
     push(closeUrl);
   };

--- a/src/smart-components/role/add-role/add-role-wizard.js
+++ b/src/smart-components/role/add-role/add-role-wizard.js
@@ -98,7 +98,7 @@ const AddRoleWizard = ({
   const onCancel = () => {
     addNotification({
       variant: 'warning',
-      title: 'Creating role was cancelled by the user',
+      title: 'Creating role was canceled by the user',
       dismissDelay: 8000,
       dismissable: false
     });

--- a/src/smart-components/role/add-role/add-role-wizard.js
+++ b/src/smart-components/role/add-role/add-role-wizard.js
@@ -98,7 +98,7 @@ const AddRoleWizard = ({
   const onCancel = () => {
     addNotification({
       variant: 'warning',
-      title: 'Creating role was cancelled by the user.',
+      title: 'Creating role was cancelled by the user',
       dismissDelay: 8000,
       dismissable: false
     });

--- a/src/smart-components/role/add-role/add-role-wizard.js
+++ b/src/smart-components/role/add-role/add-role-wizard.js
@@ -98,10 +98,9 @@ const AddRoleWizard = ({
   const onCancel = () => {
     addNotification({
       variant: 'warning',
-      title: 'Adding role',
+      title: 'Creating role was cancelled by the user.',
       dismissDelay: 8000,
-      dismissable: false,
-      description: 'Adding role was cancelled by the user.'
+      dismissable: false
     });
     push('/roles');
   };

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -45,7 +45,7 @@ const Roles = () => {
 
   useEffect(() => {
     fetchData({ ...pagination, name: filterValue });
-    window.insights.chrome.getUserPermissions().then(
+    window.insights.chrome.getUserPermissions('cost-management').then(
       allPermissions => {
         const permissionList = allPermissions.map(permissions => permissions.permission);
         setIsCostAdmin(permissionList.includes('cost-management:*:*'));

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -31,7 +31,7 @@ const selector = ({ roleReducer: { roles, isLoading }}) => ({
 
 const Roles = () => {
   const [ filterValue, setFilterValue ] = useState('');
-  const [ isCostAdmin, setIsCostAdmin ] = useState('false');
+  const [ isCostAdmin, setIsCostAdmin ] = useState(false);
   const dispatch = useDispatch();
   const { push } = useHistory();
   const {
@@ -75,7 +75,7 @@ const Roles = () => {
 
   const toolbarButtons = () => [
     <Fragment key="add-role">
-      { userEntitlements.cost_management && window.insights.chrome.isBeta() && isCostAdmin ?
+      { userEntitlements && userEntitlements.cost_management && window.insights.chrome.isBeta() && isCostAdmin ?
         <Link to="/roles/add-role" >
           <Button
             variant="primary"

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -31,6 +31,7 @@ const selector = ({ roleReducer: { roles, isLoading }}) => ({
 
 const Roles = () => {
   const [ filterValue, setFilterValue ] = useState('');
+  const [ isCostAdmin, setIsCostAdmin ] = useState('false');
   const dispatch = useDispatch();
   const { push } = useHistory();
   const {
@@ -44,6 +45,12 @@ const Roles = () => {
 
   useEffect(() => {
     fetchData({ ...pagination, name: filterValue });
+    window.insights.chrome.getUserPermissions().then(
+      allPermissions => {
+        const permissionList = allPermissions.map(permissions => permissions.permission);
+        setIsCostAdmin(permissionList.includes('cost-management:*:*'));
+      }
+    );
   }, []);
 
   const routes = () => <Fragment>
@@ -68,13 +75,13 @@ const Roles = () => {
 
   const toolbarButtons = () => [
     <Fragment key="add-role">
-      { userEntitlements && userEntitlements.cost_management ?
+      { userEntitlements.cost_management && window.insights.chrome.isBeta() && isCostAdmin ?
         <Link to="/roles/add-role" >
           <Button
             variant="primary"
             aria-label="Create role"
           >
-          Add role
+          Create Role
           </Button>
         </Link> :
         <Fragment /> }

--- a/src/test/role/add-role-wizard.test.js
+++ b/src/test/role/add-role-wizard.test.js
@@ -59,7 +59,7 @@ describe('<AddRoleWizard />', () => {
     const expectedActions = expect.arrayContaining([
       expect.objectContaining({
         type: ADD_NOTIFICATION,
-        payload: expect.objectContaining({ title: 'Adding role', variant: 'warning' })
+        payload: expect.objectContaining({ title: 'Creating role was cancelled by the user', variant: 'warning' })
       }) ]);
 
     wrapper.find('Button').at(0).simulate('click');

--- a/src/test/role/add-role-wizard.test.js
+++ b/src/test/role/add-role-wizard.test.js
@@ -59,7 +59,7 @@ describe('<AddRoleWizard />', () => {
     const expectedActions = expect.arrayContaining([
       expect.objectContaining({
         type: ADD_NOTIFICATION,
-        payload: expect.objectContaining({ title: 'Creating role was cancelled by the user', variant: 'warning' })
+        payload: expect.objectContaining({ title: 'Creating role was canceled by the user', variant: 'warning' })
       }) ]);
 
     wrapper.find('Button').at(0).simulate('click');


### PR DESCRIPTION
## What

The "Create Role", formerly "Add Role", button needs to be gated for cost admins only and gated to beta

## Jira
https://projects.engineering.redhat.com/browse/RHCLOUD-4812
https://projects.engineering.redhat.com/browse/RHCLOUD-4813

## Screenshots
### Cost Admin View on beta
![Screen Shot 2020-03-03 at 12 41 38 PM](https://user-images.githubusercontent.com/12520842/75803410-58fb8e00-5d4c-11ea-90c6-e2c0f30d357a.png)

### Non cost admin OR not beta
![Screen Shot 2020-03-03 at 12 38 24 PM](https://user-images.githubusercontent.com/12520842/75803437-67e24080-5d4c-11ea-94e8-dc3d260dfc44.png)

