### PR TITLE
Dont use empty filters

### DIFF
--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -199,7 +199,7 @@ const GroupRoles = ({
           textFilters={ [
             { key: 'name', value: filterValue },
             { key: 'description', value: descriptionValue }
-          ] }
+          ].filter(filter => filter.value && filter.value.length > 0) }
         />
       </Section>
     </React.Fragment>


### PR DESCRIPTION
We were passing empty filters to `ToolbarTableView` component so it showed state for empty search.

https://projects.engineering.redhat.com/browse/RHCLOUD-4785

