### PR TITLE
Enable deleting custom roles

### DIFF
--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -57,11 +57,7 @@ const Roles = () => {
       {
         title: 'Delete',
         onClick: (_event, _rowId, role) =>
-          push(`/roles/remove/${role.uuid}`),
-        props: {
-          isDisabled: true
-        },
-        isDisabled: true
+          push(`/roles/remove/${role.uuid}`)
       }
     ];
   };

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -52,7 +52,7 @@ const Roles = () => {
   </Fragment>;
 
   const actionResolver = ({ system }) => {
-    const userAllowed = insights.chrome.isBeta() && userIdentity.user.is_org_admin;
+    const userAllowed = insights.chrome.isBeta() && userIdentity && userIdentity.user && userIdentity.user.is_org_admin;
     return (system || !userAllowed) ? [] : [
       {
         title: 'Delete',


### PR DESCRIPTION
For some reason, deleting roles is disabled. It shows the three dot action menu only for custom roles, but with disabled button. I am enabling it with this PR.

Is there any reason why it should stay disabled?
@karelhala @ryelo @shdunning @nicole-campbell12

![Screenshot from 2020-03-09 13-50-13](https://user-images.githubusercontent.com/9535558/76214726-9e690100-620d-11ea-8a88-cb249c06bab5.png)

When i delete role, UI blows up, but role is deleted. I will look into it further if we decide that this button should be enabled.

Also Add role and Confirm delete modals looks like in temporary version when compared to other parts of RBAC UI. Is there a plan to redesign it?  @mmenestr

![Screenshot from 2020-03-09 13-56-11](https://user-images.githubusercontent.com/9535558/76215256-ad9c7e80-620e-11ea-9765-fadf8c4ee587.png)

cc @john-dupuy 