### PR TITLE
Disable Add role button action when group contains all roles

### DIFF
--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -153,6 +153,7 @@ const GroupRoles = ({
         <Link
           to={ `/groups/detail/${uuid}/roles/add_roles` }
           key="add-to-group"
+          onClick={ (e) => disableAddRoles && e.preventDefault() }
         >
           { addRoleButton(disableAddRoles) }
         </Link>,


### PR DESCRIPTION
Disabled showing empty state modal on Add role button click when group contains all roles

https://projects.engineering.redhat.com/browse/RHCLOUD-4965

![001](https://user-images.githubusercontent.com/50696716/77299294-8a80cd00-6cec-11ea-8b23-5338b7e71f76.png)

@karelhala 