### PR TITLE
Fix updating pagination when adding/removing a role in group detail

### DIFF
--- a/src/redux/reducers/group-reducer.js
+++ b/src/redux/reducers/group-reducer.js
@@ -18,7 +18,7 @@ export const groupsInitialState = {
       offset: 0
     }
   },
-  selectedGroup: { addRoles: {}, members: {}},
+  selectedGroup: { addRoles: {}, members: {}, pagination: { limit: 10 }},
   isLoading: false,
   isRecordLoading: false
 };
@@ -35,7 +35,13 @@ const setGroup = (state, { payload }) => ({
       ...payload.uuid === group.uuid && { ...payload, loaded: true }
     }))
   },
-  selectedGroup: { ...state.selectedGroup, members: { ...state.selectedGroup.members, data: payload.principals }, ...omit(payload, 'principals'), loaded: true }
+  selectedGroup: {
+    ...state.selectedGroup,
+    members: { ...state.selectedGroup.members, data: payload.principals },
+    ...omit(payload, 'principals'),
+    loaded: true,
+    pagination: { ...state.selectedGroup.pagination, count: payload.roleCount, offset: 0 }
+  }
 });
 const resetSelectedGroup = state => ({ ...state, selectedGroup: undefined });
 const setRolesForGroup = (state, { payload }) => ({

--- a/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
+++ b/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
@@ -16,11 +16,7 @@ exports[`<GroupPrincipals /> should render correctly 1`] = `
     isLoading={true}
     pagination={
       Object {
-        "count": undefined,
-        "itemCount": 1,
-        "limit": 50,
-        "numberOfItems": 50,
-        "offset": 0,
+        "limit": 10,
       }
     }
     removeRoles={[Function]}
@@ -57,11 +53,7 @@ exports[`<GroupPrincipals /> should render correctly in loading state 1`] = `
     isLoading={true}
     pagination={
       Object {
-        "count": undefined,
-        "itemCount": 1,
-        "limit": 50,
-        "numberOfItems": 50,
-        "offset": 0,
+        "limit": 10,
       }
     }
     removeRoles={[Function]}


### PR DESCRIPTION
- fixed not updating count in pagination after adding/deleting a role
- fixed not going to first page after adding/deleting a role
- changed limit in pagination from 50 to 10 to be the same as it is in group members

![001](https://user-images.githubusercontent.com/50696716/78790970-8ec90d80-79af-11ea-8e08-fbb8c8cbf842.png)

@karelhala 