### PR TITLE
Do not show warning modal on adding group/role cancellation with no data

### DIFF
--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -73,7 +73,7 @@ const AddGroupWizard = ({
     history.push('/groups');
   };
 
-  const [ cancelWarningVisible, setcancelWarningVisible ] = useState(false);
+  const [ cancelWarningVisible, setCancelWarningVisible ] = useState(false);
 
   return (
     <React.Fragment>
@@ -84,14 +84,20 @@ const AddGroupWizard = ({
         title="Create and configure a group"
         description="To give users access permissions, create a group and assign roles to it."
         isOpen
-        onClose={ () => setcancelWarningVisible(true) }
+        onClose={ () => {
+          if (Object.values(formData).filter(Boolean).length > 0 || selectedRoles.length > 0 || selectedUsers.length > 0) {
+            setCancelWarningVisible(true);
+          } else {
+            onCancel();
+          }
+        } }
         onSave={ onSubmit }
         steps={ steps }
       />
       <WarningModal
         type='group'
         isOpen={ cancelWarningVisible }
-        onModalCancel={ () => setcancelWarningVisible(false) }
+        onModalCancel={ () => setCancelWarningVisible(false) }
         onConfirmCancel={ onCancel }/>
     </React.Fragment>
   );

--- a/src/smart-components/role/add-role/add-role-wizard.js
+++ b/src/smart-components/role/add-role/add-role-wizard.js
@@ -107,7 +107,7 @@ const AddRoleWizard = ({
     push('/roles');
   };
 
-  const [ cancelWarningVisible, setcancelWarningVisible ] = useState(false);
+  const [ cancelWarningVisible, setCancelWarningVisible ] = useState(false);
 
   return (
     <React.Fragment>
@@ -116,7 +116,9 @@ const AddRoleWizard = ({
         isLarge
         title="Add role"
         isOpen
-        onClose={ () => setcancelWarningVisible(true) }
+        onClose={ () => {
+          !Object.values(formData).filter(Boolean).length > 0 && onCancel() || setCancelWarningVisible(true);
+        } }
         onNext={ onNext }
         onSave={ onSubmit }
         steps={ steps }
@@ -124,7 +126,7 @@ const AddRoleWizard = ({
       <WarningModal
         type='role'
         isOpen={ cancelWarningVisible }
-        onModalCancel={ () => setcancelWarningVisible(false) }
+        onModalCancel={ () => setCancelWarningVisible(false) }
         onConfirmCancel={ onCancel }/>
     </React.Fragment>
   );

--- a/src/test/role/add-role-wizard.test.js
+++ b/src/test/role/add-role-wizard.test.js
@@ -62,9 +62,9 @@ describe('<AddRoleWizard />', () => {
         payload: expect.objectContaining({ title: 'Creating role was canceled by the user', variant: 'warning' })
       }) ]);
 
-    wrapper.find('Button').at(0).simulate('click');
+    wrapper.find('.pf-c-button.pf-m-primary').simulate('click');
     wrapper.update();
-    wrapper.find('.pf-c-modal-box__footer .pf-m-primary').simulate('click');
+    wrapper.find('.pf-m-link').simulate('click');
 
     setImmediate(() => {
       expect(store.getActions()).toEqual(expectedActions);

--- a/src/test/smart-components/group/add-group/add-group-wizard.test.js
+++ b/src/test/smart-components/group/add-group/add-group-wizard.test.js
@@ -94,9 +94,9 @@ describe('<AddGroupWizard />', () => {
         payload: expect.objectContaining({ title: 'Adding group', variant: 'warning' })
       }) ]);
 
-    wrapper.find('Button').at(0).simulate('click');
+    wrapper.find('.pf-c-button.pf-m-primary').simulate('click');
     wrapper.update();
-    wrapper.find('.pf-c-modal-box__footer .pf-m-primary').simulate('click');
+    wrapper.find('.pf-m-link').simulate('click');
 
     setImmediate(() => {
       expect(store.getActions()).toEqual(expectedActions);


### PR DESCRIPTION
- cancellation modal appears only if the user has actually inputted something into the wizard
- when no inputs, no warning modal is shown
- updated tests

![001](https://user-images.githubusercontent.com/50696716/79246023-3bf0c980-7e79-11ea-8df1-e225fcce57b6.png)

@karelhala 