### PR TITLE
Fix wrong number of group roles on page 1

### DIFF
--- a/src/redux/reducers/group-reducer.js
+++ b/src/redux/reducers/group-reducer.js
@@ -35,7 +35,7 @@ const setGroup = (state, { payload }) => ({
   selectedGroup: {
     ...state.selectedGroup,
     members: { ...state.selectedGroup.members, data: payload.principals },
-    ...omit(payload, 'principals'),
+    ...omit(payload, [ 'principals', 'roles' ]),
     loaded: true,
     pagination: { ...state.selectedGroup.pagination, count: payload.roleCount, offset: 0 }
   }


### PR DESCRIPTION
Although the number of items was displayed correctly, first page contained not 20 but all group roles on initial load.

**Reproduce steps:**
- Open detail of a group with more than 20 roles.
- First page table should contain 20 items.

![001](https://user-images.githubusercontent.com/50696716/80363624-c3c8d180-8884-11ea-8560-954ac234271b.png)

@karelhala 