### PR TITLE
Change Create group wizard order

### DIFF
--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -37,12 +37,12 @@ const AddGroupWizard = ({
       component: new GroupInformation(formData, handleChange, setIsGroupInfoValid),
       enableNext: isGroupInfoValid
     },
-    { name: 'Add members',
-      component: new SetUsers({ formData, selectedUsers, setSelectedUsers })
-    },
     {
       name: 'Assign roles',
       component: new SetRoles({ formData, selectedRoles, setSelectedRoles })
+    },
+    { name: 'Add members',
+      component: new SetUsers({ formData, selectedUsers, setSelectedUsers })
     },
     { name: 'Review',
       component: new SummaryContent({ values: formData, selectedUsers, selectedRoles }),

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -46,6 +46,18 @@ const SummaryContent = (formData) => {
                 </GridItem>
               </Grid>
               <Grid gutter="md">
+                <GridItem span={ 2 }>
+                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Role(s)</Text>
+                </GridItem>
+                <GridItem span={ 10 }>
+                  <Text
+                    className="groups-table-detail content"
+                    component={ TextVariants.h5 }>
+                    {selectedRoles.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{role.label}</Text>)}
+                  </Text>
+                </GridItem>
+              </Grid>
+              <Grid gutter="md">
                 <GridItem span = { 2 }>
                   <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Member(s)</Text>
                 </GridItem>
@@ -54,18 +66,6 @@ const SummaryContent = (formData) => {
                     className="groups-table-detail content"
                     component={ TextVariants.h5 }>
                     { selectedUsers.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{ role.label }</Text>) }
-                  </Text>
-                </GridItem>
-              </Grid>
-              <Grid gutter="md">
-                <GridItem span = { 2 }>
-                  <Text className="data-table-detail heading content" component={ TextVariants.h5 }>Role(s)</Text>
-                </GridItem>
-                <GridItem span= { 10 }>
-                  <Text
-                    className="groups-table-detail content"
-                    component={ TextVariants.h5 }>
-                    { selectedRoles.map((role, index) => <Text className= "pf-u-mb-0" key={ index }>{ role.label }</Text>)  }
                   </Text>
                 </GridItem>
               </Grid>

--- a/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
+++ b/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
@@ -169,7 +169,7 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                               className="data-table-detail heading content"
                               data-pf-content={true}
                             >
-                              Member(s)
+                              Role(s)
                             </h5>
                           </Text>
                         </div>
@@ -213,7 +213,7 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                               className="data-table-detail heading content"
                               data-pf-content={true}
                             >
-                              Role(s)
+                              Member(s)
                             </h5>
                           </Text>
                         </div>


### PR DESCRIPTION
Change order of the steps in Create Group wizard to:
1.  General information
2. Assign Roles
3. Add members 
 4. Review
![Screenshot from 2020-05-06 13-01-18](https://user-images.githubusercontent.com/9535558/81169819-ce2c4f00-8f99-11ea-8c30-9cc25a653775.png)

![Screenshot from 2020-05-06 15-50-19](https://user-images.githubusercontent.com/9535558/81185182-903b2500-8fb1-11ea-82a5-9c4328a3f913.png)



https://projects.engineering.redhat.com/browse/RHCLOUD-4889
