### PR TITLE
Update member list filtering in 3 places

### DIFF
--- a/src/helpers/user/user-helper.js
+++ b/src/helpers/user/user-helper.js
@@ -2,9 +2,9 @@ import { getPrincipalApi } from '../shared/user-login';
 
 const principalApi = getPrincipalApi();
 
-export function fetchUsers({ limit, offset, name, orderBy }) {
+export function fetchUsers({ limit, offset, username, orderBy, email }) {
   const sortOrder = orderBy === '-username' ? ('desc') : ('asc');
-  return principalApi.listPrincipals(limit, offset, name, sortOrder).then(({ data, meta }) => {
+  return principalApi.listPrincipals(limit, offset, username, sortOrder, email).then(({ data, meta }) => {
     return {
       data,
       meta: {

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -163,7 +163,7 @@ export const TableToolbarView = ({
           title={ `Configure ${titlePlural}` }
           icon={ PlusCircleIcon }
           description={ [
-            `To configure user access to applicastions`,
+            `To configure user access to applications`,
             `create at least one ${titleSingular}`
           ] }
           actions={ toolbarButtons()[0] }

--- a/src/presentational-components/shared/toolbar.js
+++ b/src/presentational-components/shared/toolbar.js
@@ -69,13 +69,13 @@ export const filterConfigBuilder = (
   textFilters,
   sortBy
 ) => ({
-  items: [ ...textFilters && textFilters.length > 0 ? textFilters.map(({ key, value }) => ({
+  items: [ ...textFilters && textFilters.length > 0 ? textFilters.map(({ key, value, isExact }) => ({
     label: firstUpperCase(key),
     type: 'text',
     filterValues: {
       id: `filter-by-${key}`,
       key: `filter-by-${key}`,
-      placeholder: `Filter by ${key}`,
+      placeholder: `Filter by ${isExact ? 'exact ' : '' }${key}`,
       value,
       onChange: (_e, filterBy) => {
         setFilterValue({
@@ -217,7 +217,8 @@ Toolbar.propTypes = {
   setFilterValue: PropTypes.func,
   textFilters: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
-    key: PropTypes.string
+    key: PropTypes.string,
+    isExact: PropTypes.bool
   })),
   pagination: PropTypes.shape({
     limit: PropTypes.number,

--- a/src/presentational-components/shared/toolbar.js
+++ b/src/presentational-components/shared/toolbar.js
@@ -69,13 +69,13 @@ export const filterConfigBuilder = (
   textFilters,
   sortBy
 ) => ({
-  items: [ ...textFilters && textFilters.length > 0 ? textFilters.map(({ key, value, isExact }) => ({
+  items: [ ...textFilters && textFilters.length > 0 ? textFilters.map(({ key, value, placeholder }) => ({
     label: firstUpperCase(key),
     type: 'text',
     filterValues: {
       id: `filter-by-${key}`,
       key: `filter-by-${key}`,
-      placeholder: `Filter by ${isExact ? 'exact ' : '' }${key}`,
+      placeholder: placeholder ? placeholder : `Filter by ${key}`,
       value,
       onChange: (_e, filterBy) => {
         setFilterValue({
@@ -218,7 +218,7 @@ Toolbar.propTypes = {
   textFilters: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
     key: PropTypes.string,
-    isExact: PropTypes.bool
+    placeholder: PropTypes.string
   })),
   pagination: PropTypes.shape({
     limit: PropTypes.number,

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -80,8 +80,8 @@ const UsersList = ({ users, fetchUsers, isLoading, pagination, selectedUsers, se
     titlePlural="users"
     titleSingular="user"
     textFilters={ [
-      { key: 'username', value: filterValue, isExact: true },
-      { key: 'email', value: emailValue, isExact: true }
+      { key: 'username', value: filterValue, placeholder: 'Filter by exact username' },
+      { key: 'email', value: emailValue, placeholder: 'Filter by exact email' }
     ] }
     { ...props }
   />;

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -41,6 +41,7 @@ const createRows = (userLinks) => (data, expanded, checkedRows = []) => {
 
 const UsersList = ({ users, fetchUsers, isLoading, pagination, selectedUsers, setSelectedUsers, userLinks, props }) => {
   const [ filterValue, setFilterValue ] = useState('');
+  const [ emailValue, setEmailValue ] = useState('');
 
   useEffect(() => {
     fetchUsers();
@@ -60,8 +61,13 @@ const UsersList = ({ users, fetchUsers, isLoading, pagination, selectedUsers, se
     createRows={ createRows(userLinks) }
     data={ users }
     filterValue={ filterValue }
-    fetchData={ (config) => fetchUsers(mappedProps(config)) }
-    setFilterValue={ ({ name }) => setFilterValue(name) }
+    fetchData={ (config) => {
+      fetchUsers(mappedProps(config));
+    } }
+    setFilterValue={ ({ username, email }) => {
+      typeof username !== 'undefined' && setFilterValue(username);
+      typeof email !== 'undefined' && setEmailValue(email);
+    } }
     isLoading={ isLoading }
     pagination={ pagination }
     checkedRows={ selectedUsers }
@@ -71,9 +77,12 @@ const UsersList = ({ users, fetchUsers, isLoading, pagination, selectedUsers, se
       direction: 'asc'
     } }
     rowWrapper={ UsersRow }
-    filterPlaceholder="exact username"
     titlePlural="users"
     titleSingular="user"
+    textFilters={ [
+      { key: 'username', value: filterValue, isExact: true },
+      { key: 'email', value: emailValue, isExact: true }
+    ] }
     { ...props }
   />;
 };

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -228,8 +228,8 @@ const GroupRoles = ({
           routes={ routes }
           emptyProps={ { title: 'There are no roles in this group', description: [ 'Add a role to configure user access.', '' ]} }
           textFilters={ [
-            { key: 'name', value: filterValue, isExact: false },
-            { key: 'description', value: descriptionValue, isExact: false }
+            { key: 'name', value: filterValue },
+            { key: 'description', value: descriptionValue }
           ] }
         />
       </Section>

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -228,8 +228,8 @@ const GroupRoles = ({
           routes={ routes }
           emptyProps={ { title: 'There are no roles in this group', description: [ 'Add a role to configure user access.', '' ]} }
           textFilters={ [
-            { key: 'name', value: filterValue },
-            { key: 'description', value: descriptionValue }
+            { key: 'name', value: filterValue, isExact: false },
+            { key: 'description', value: descriptionValue, isExact: false }
           ] }
         />
       </Section>

--- a/src/test/smart-components/user/users.test.js
+++ b/src/test/smart-components/user/users.test.js
@@ -100,4 +100,26 @@ describe('<Users />', () => {
     ];
     expect(store.getActions()).toEqual(expectedPayload);
   });
+
+  it('should fetch users on filter', async() => {
+    const store = mockStore(initialState);
+    mock.onGet('/api/rbac/v1/principals/?limit=20&sort_order=asc').replyOnce(200, {});
+    mock.onGet('/api/rbac/v1/principals/?limit=10&sort_order=desc').replyOnce(200, {});
+    const wrapper = mount(<Provider store={ store }>
+      <Router initialEntries={ [ '/users' ] }>
+        <Users />
+      </Router>
+    </Provider>);
+    const target = wrapper.find('input#filter-by-username');
+    target.getDOMNode().value = 'something';
+    await act(async () => {
+      target.simulate('change');
+    });
+    const expectedPayload = [
+      expect.objectContaining({ type: 'FETCH_USERS_PENDING' }),
+
+      expect.objectContaining({ type: 'FETCH_USERS_FULFILLED' })
+    ];
+    expect(store.getActions()).toEqual(expectedPayload);
+  });
 });


### PR DESCRIPTION
- changed basic filter to be "Username" AND "Email" attribute filter in 
    - "Add member" to a group modal
    - Users page
    - Add member page in the "create group" wizard flow
- changed filter "description" to say "Filter by exact username" and "Filter by exact email"
- fixed typo in table-toolbar-view empty state
- enhanced tests

![001](https://user-images.githubusercontent.com/50696716/83045337-b8b0bf00-a045-11ea-9605-5e84724ad3f0.png)

@karelhala 