### PR TITLE
Fix removing group member selections

### DIFF
--- a/src/redux/actions/group-actions.js
+++ b/src/redux/actions/group-actions.js
@@ -121,7 +121,7 @@ export const removeMembersFromGroup = (groupId, members) => ({
       },
       rejected: {
         variant: 'danger',
-        title: 'Failed removing members to group',
+        title: 'Failed removing members from group',
         dismissDelay: 8000,
         dismissable: false,
         description: 'The members were not removed successfully.'
@@ -182,7 +182,7 @@ export const removeRolesFromGroup = (groupId, roles) => ({
       },
       rejected: {
         variant: 'danger',
-        title: 'Failed removing roles to group',
+        title: 'Failed removing roles from group',
         dismissDelay: 8000,
         dismissable: false,
         description: 'The roles were not removed successfully.'

--- a/src/smart-components/group/principal/principals.js
+++ b/src/smart-components/group/principal/principals.js
@@ -122,12 +122,13 @@ const GroupPrincipals = () => {
           },
           onClick: () => {
             const multipleMembersSelected = selectedPrincipals.length > 1;
-            setConfirmDelete(() => () => removeMembers(selectedPrincipals.map(user => user.name || user.username)));
+            const removeText = multipleMembersSelected ? 'Remove members?' : 'Remove member?';
+            setConfirmDelete(() => () => removeMembers(selectedPrincipals.map(user => user.uuid)));
             setDeleteInfo({
-              title: 'Remove members?',
-              confirmButtonLabel: multipleMembersSelected ? 'Remove members' : 'Remove member',
+              title: removeText,
+              confirmButtonLabel: removeText,
               text: removeModalText(
-                multipleMembersSelected ? selectedPrincipals.length : (selectedPrincipals[0].name || selectedPrincipals[0].username),
+                multipleMembersSelected ? selectedPrincipals.length : selectedPrincipals[0].uuid,
                 groupName,
                 multipleMembersSelected
               )


### PR DESCRIPTION
- Fixed removing of members from group via action kebab in toolbar
- Fixed inappropriate modal title ("members" -> "member") when slected just one member and remove clicked on kebab
- Fixed text in error notification message ("Failed removing members **to** group" -> "Failed removing members **from** group")

The problem was that attribute "username" is not present in selectedUsers anymore - objects are modified during the selection process. So, using uuid instead, it should be the same value.

![001](https://user-images.githubusercontent.com/50696716/84289319-a143fc80-ab42-11ea-9301-59da28431726.png)

![001](https://user-images.githubusercontent.com/50696716/84313403-c480a300-ab66-11ea-9fe2-1194b4907446.png)

@karelhala 