### PR TITLE
Add initial values to create-role-copy

### DIFF
--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -45,8 +45,8 @@ const BaseRoleTable = (props) => {
                         onChange={ () => {
                             setBaseRole(role);
                             input.onChange(role);
-                            formOptions.change('role-name', `Copy of ${role.name}`);
-                            formOptions.change('role-description', role.description);
+                            formOptions.change('role-copy-name', `Copy of ${role.name}`);
+                            formOptions.change('role-copy-description', role.description);
                         } }
                     />
                 },

--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -4,7 +4,8 @@ import { Radio } from '@patternfly/react-core';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { fetchRolesForWizard } from '../../../redux/actions/role-actions';
 import { mappedProps } from '../../../helpers/shared/helpers';
-import { useFieldApi } from '@data-driven-forms/react-form-renderer/dist/cjs/';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 
 const columns = [ '', 'Name', 'Description' ];
 const selector = ({ roleReducer: { rolesForWizard, isLoading }}) => ({
@@ -21,6 +22,7 @@ const BaseRoleTable = (props) => {
     const [ baseRole, setBaseRole ] = useState({});
     const { roles, pagination } = useSelector(selector, shallowEqual);
     const { input } = useFieldApi(props);
+    const formOptions = useFormApi();
 
     useEffect(()=> {
         fetchData({
@@ -43,6 +45,8 @@ const BaseRoleTable = (props) => {
                         onChange={ () => {
                             setBaseRole(role);
                             input.onChange(role);
+                            formOptions.change('role-name', `Copy of ${role.name}`);
+                            formOptions.change('role-description', role.description);
                         } }
                     />
                 },

--- a/src/smart-components/role/add-role-new/schema.js
+++ b/src/smart-components/role/add-role-new/schema.js
@@ -67,7 +67,7 @@ export default {
                         },
                         {
                             component: 'base-role-table',
-                            name: 'base-role',
+                            name: 'copy-base-role',
                             label: 'Base role',
                             isRequired: true,
                             condition: {
@@ -88,7 +88,7 @@ export default {
                     fields: [
                         {
                             component: 'text-field',
-                            name: 'role-name',
+                            name: 'role-copy-name',
                             type: 'text',
                             label: 'Role name',
                             isRequired: true,
@@ -100,7 +100,7 @@ export default {
                         },
                         {
                             component: 'text-field',
-                            name: 'role-description',
+                            name: 'role-copy-description',
                             type: 'text',
                             label: 'Role description'
                         }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHCLOUD-7259

- role name and description are now predefined according to the role selected for making a copy
- role creation field names were separated from the "copy" ones - to prevent the default value from being retained when the type of new role creation is changed

![001](https://user-images.githubusercontent.com/50696716/86229434-fe562f80-bb8f-11ea-9cb5-9d754bf9983c.png)

@karelhala 
@PanSpagetka 