### PR TITLE
Make role to copy selection persistent

### DIFF
--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -25,6 +25,7 @@ const BaseRoleTable = (props) => {
     const formOptions = useFormApi();
 
     useEffect(()=> {
+        setBaseRole(input.value);
         fetchData({
             limit: 50,
             offset: 0,


### PR DESCRIPTION
**Issue:** (from https://github.com/RedHatInsights/insights-rbac-ui/pull/335)
"If I click the option "Copy an existing role" and make a selection, the "Next" button turns blue. Which is correct.
But if I do that, and THEN change my mind and say "Create a role from scratch" and then go back to "Copy an existing role", the role has been unselected, but the "Next" button remains blue. Since nothing is selected though, the user shouldn't be able to press the "Next" button anymore."

**Solution:**
the selection in the table remains even if radio buttons are switched

@PanSpagetka 
@mmenestr