### PR TITLE
Enable add group steps after group name is valid

### DIFF
--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -27,6 +27,7 @@ const AddGroupWizard = ({
   const [ formData, setValues ] = useState({});
   const [ isGroupInfoValid, setIsGroupInfoValid ] = useState(false);
   const [ hideFooter, setHideFooter ] = useState(false);
+  const [ isValidating, setIsValidating ] = useState(false);
 
   const history = useHistory();
 
@@ -36,24 +37,24 @@ const AddGroupWizard = ({
 
   const steps = [
     { name: 'General information',
-      component: new GroupInformation(formData, handleChange, setIsGroupInfoValid, isGroupInfoValid),
-      enableNext: isGroupInfoValid
+      component: new GroupInformation(formData, handleChange, setIsGroupInfoValid, isGroupInfoValid, isValidating, setIsValidating),
+      enableNext: isGroupInfoValid && !isValidating
     },
     {
       name: 'Assign roles',
       component: new SetRoles({ formData, selectedRoles, setSelectedRoles }),
-      canJumpTo: isGroupInfoValid
+      canJumpTo: isGroupInfoValid && !isValidating
     },
     { name: 'Add members',
       component: new SetUsers({ formData, selectedUsers, setSelectedUsers }),
-      canJumpTo: isGroupInfoValid
+      canJumpTo: isGroupInfoValid && !isValidating
     },
     { name: 'Review',
       component: isGroupInfoValid ?
         new SummaryContent({ values: formData, selectedUsers, selectedRoles, setHideFooter }) : <GroupNameErrorState setHideFooter={ setHideFooter }/>,
       nextButtonText: 'Confirm',
-      enableNext: isGroupInfoValid,
-      canJumpTo: isGroupInfoValid
+      enableNext: isGroupInfoValid && !isValidating,
+      canJumpTo: isGroupInfoValid && !isValidating
     }
   ];
 

--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -41,16 +41,19 @@ const AddGroupWizard = ({
     },
     {
       name: 'Assign roles',
-      component: new SetRoles({ formData, selectedRoles, setSelectedRoles })
+      component: new SetRoles({ formData, selectedRoles, setSelectedRoles }),
+      canJumpTo: isGroupInfoValid
     },
     { name: 'Add members',
-      component: new SetUsers({ formData, selectedUsers, setSelectedUsers })
+      component: new SetUsers({ formData, selectedUsers, setSelectedUsers }),
+      canJumpTo: isGroupInfoValid
     },
     { name: 'Review',
       component: isGroupInfoValid ?
         new SummaryContent({ values: formData, selectedUsers, selectedRoles, setHideFooter }) : <GroupNameErrorState setHideFooter={ setHideFooter }/>,
       nextButtonText: 'Confirm',
-      enableNext: isGroupInfoValid
+      enableNext: isGroupInfoValid,
+      canJumpTo: isGroupInfoValid
     }
   ];
 

--- a/src/smart-components/group/add-group/group-information.js
+++ b/src/smart-components/group/add-group/group-information.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   Form,
@@ -11,59 +11,56 @@ import {
 } from '@patternfly/react-core';
 import { debouncedAsyncValidator } from './validators';
 
-const GroupInformation = (formValue, onHandleChange, setIsGroupInfoValid, isGroupInfoValid) => {
-  const [ isLoading, setIsLoading ] = useState(false);
-  return (
-    <Fragment>
-      <Stack hasGutter>
-        <StackItem>
-          <Title headingLevel="h4" size="xl"> Enter group details </Title>
-        </StackItem>
-        <StackItem>
-          <Form>
-            <FormGroup
-              label="Group name"
+const GroupInformation = (formValue, onHandleChange, setIsGroupInfoValid, isGroupInfoValid, isValidating, setIsValidating) => (
+  <Fragment>
+    <Stack hasGutter>
+      <StackItem>
+        <Title headingLevel="h4" size="xl"> Enter group details </Title>
+      </StackItem>
+      <StackItem>
+        <Form>
+          <FormGroup
+            label="Group name"
+            isRequired
+            fieldId="group-name"
+            helperTextInvalid={ formValue.name?.trim().length > 0 && !isValidating ?
+              'This group name already exists. Please input a unique group name.' : 'Required value' }
+            validated={ isGroupInfoValid || formValue.name === undefined ? 'success' : 'error' }
+          >
+            <TextInput
               isRequired
-              fieldId="group-name"
-              helperTextInvalid={ formValue.name?.trim().length > 0 && !isLoading ?
-                'This group name already exists. Please input a unique group name.' : 'Required value' }
-              validated={ isGroupInfoValid || formValue.name === undefined ? 'success' : 'error' }
-            >
-              <TextInput
-                isRequired
-                type="text"
-                id="group-name"
-                name="group-name"
-                aria-describedby="group-name"
-                value={ formValue.name }
-                validated={ isGroupInfoValid || formValue.name === undefined ? 'default' : 'error' }
-                onChange={ (_, event) => {
-                  const { value } = event.currentTarget;
-                  onHandleChange({ name: value });
-                  setIsLoading(true);
-                  (async () => {
-                    const isUnique = formValue.name !== undefined && await debouncedAsyncValidator(value);
-                    setIsGroupInfoValid(value.trim().length > 0 && isUnique);
-                    setIsLoading(false);
-                  })();
-                } }
-              />
-            </FormGroup>
-            <FormGroup label="Group description" fieldId="group-description">
-              <TextArea
-                type="text"
-                id="group-description"
-                name="group-description"
-                value={ formValue.description }
-                onChange={ (_, event) => onHandleChange({ description: event.currentTarget.value }) }
-              />
-            </FormGroup>
-          </Form>
-        </StackItem>
-      </Stack>
-    </Fragment>
-  );
-};
+              type="text"
+              id="group-name"
+              name="group-name"
+              aria-describedby="group-name"
+              value={ formValue.name }
+              validated={ isGroupInfoValid || formValue.name === undefined ? 'default' : 'error' }
+              onChange={ (_, event) => {
+                const { value } = event.currentTarget;
+                onHandleChange({ name: value });
+                setIsValidating(true);
+                (async () => {
+                  const isUnique = formValue.name !== undefined && await debouncedAsyncValidator(value);
+                  setIsGroupInfoValid(value.trim().length > 0 && isUnique);
+                  setIsValidating(false);
+                })();
+              } }
+            />
+          </FormGroup>
+          <FormGroup label="Group description" fieldId="group-description">
+            <TextArea
+              type="text"
+              id="group-description"
+              name="group-description"
+              value={ formValue.description }
+              onChange={ (_, event) => onHandleChange({ description: event.currentTarget.value }) }
+            />
+          </FormGroup>
+        </Form>
+      </StackItem>
+    </Stack>
+  </Fragment>
+);
 
 GroupInformation.propTypes = {
   name: PropTypes.string,


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHCLOUD-8627

**BEFORE:**
"When creating a group, if a user navigates to the "Review" step immediately (without entering any group name) – they see the "Group name already taken" screen."

**NOW:**
Left nav is enabled only if group name is valid

![001](https://user-images.githubusercontent.com/50696716/91830937-b6ad5c00-ec43-11ea-9286-46e428aa05e4.png)

@john-dupuy 
@mmenestr
@karelhala 