### PR TITLE
Add is org admin column to users list.

### DIFF
--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -11,29 +11,36 @@ import { sortable, cellWidth } from '@patternfly/react-table';
 import UsersRow from '../../../presentational-components/shared/UsersRow';
 import { defaultCompactSettings, defaultSettings } from '../../../helpers/shared/pagination';
 import classNames from 'classnames';
+import { CheckIcon, CloseIcon } from '@patternfly/react-icons';
 
 const columns = [
-  { title: 'Status', transforms: [ cellWidth(10), () => ({ className: 'ins-m-width-5' }) ]},
+  { title: 'Org. Administrator', key: 'org-admin' },
   { title: 'Username', key: 'username', transforms: [ sortable ]},
   { title: 'Email' },
   { title: 'First name' },
-  { title: 'Last name' }
+  { title: 'Last name' },
+  { title: 'Status', transforms: [ cellWidth(10), () => ({ className: 'ins-m-width-5' }) ]}
 ];
 
-const createRows = (userLinks) => (data, expanded, checkedRows = []) => {
-  return data ? data.reduce((acc, { username, is_active: isActive, email, first_name: firstName, last_name: lastName }) => ([
+const createRows = (userLinks) => (data, _expanded, checkedRows = []) => {
+  return data ? data.reduce((acc, { username, is_active: isActive, email, first_name: firstName, last_name: lastName, is_org_admin: isOrgAdmin }) => ([
     ...acc, {
       uuid: username,
-      cells: [{
-          title: (
-            <Label isCompact color={ isActive && 'green' } className={ classNames('ins-c-rbac__user-label', { 'ins-m-inactive': !isActive }) }>
-              {isActive ? 'Active' : 'Inactive'}
-            </Label>
+      cells: [
+        isOrgAdmin ? <Fragment><CheckIcon className="pf-u-mr-sm" />Yes</Fragment> : <Fragment><CloseIcon className="pf-u-mr-sm" />No</Fragment>,
+        { title: userLinks ? <Link to={ `/users/detail/${username}` }>{username}</Link> : username },
+       email,
+       firstName,
+       lastName, {
+        title: (
+          <Label isCompact color={ isActive && 'green' } className={ classNames('ins-c-rbac__user-label', { 'ins-m-inactive': !isActive }) }>
+            {isActive ? 'Active' : 'Inactive'}
+          </Label>
         ),
         props: {
           'data-is-active': isActive
         }
-      }, { title: userLinks ? <Link to={ `/users/detail/${username}` }>{username}</Link> : username }, email, firstName, lastName ],
+       }],
       selected: Boolean(checkedRows && checkedRows.find(row => row.uuid === username))
     }
   ]), []) : [];


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/RHCLOUD-6124

### Changes
- moved the status column as the last column
- added is org admin indicator as a first column

@ryelo the Jira ticket mentions filtering by org admin, but the API does not support that just yet. Do you want to wait for that feature before merging this?

![screenshot-ci foo redhat com_1337-2020 09 02-11_11_41](https://user-images.githubusercontent.com/22619452/91962966-87fbb800-ed0d-11ea-9b88-31bf10915bcb.png)

![screenshot-ci foo redhat com_1337-2020 09 02-11_10_58](https://user-images.githubusercontent.com/22619452/91962973-892ce500-ed0d-11ea-99b5-9e87c371954d.png)

![screenshot-ci foo redhat com_1337-2020 09 02-11_10_17](https://user-images.githubusercontent.com/22619452/91962979-8af6a880-ed0d-11ea-92ea-9cbafbeb3489.png)
