### PR TITLE
Chrome filter fix

### DIFF
--- a/src/smart-components/user/user.scss
+++ b/src/smart-components/user/user.scss
@@ -1,3 +1,8 @@
 .ins-c-rbac__user-label-skeleton {
   width: 50px;
 }
+
+// fix for cropped placeholder: https://github.com/patternfly/patternfly/issues/3449
+ input#filter-by-username.ins-c-conditional-filter[type="text"] {
+  width: 230px;
+} 


### PR DESCRIPTION
This PR creates a Chrome-specific fix for the Users screen user name input

@karelhala I opened an issue here: https://github.com/patternfly/patternfly/issues/3449. This is also an issue in frontend-components, but I was not able to find another filter with placeholder text long enough to force cropping.  If we come across one, this is the issue.

Jira: https://projects.engineering.redhat.com/browse/RHCLOUD-8941

Old
![Screen Shot 2020-09-07 at 10 14 22 AM](https://user-images.githubusercontent.com/1287144/92396389-f0bea800-f0f2-11ea-9fda-de252182c660.png)

New
![Screen Shot 2020-09-07 at 10 13 58 AM](https://user-images.githubusercontent.com/1287144/92396390-f0bea800-f0f2-11ea-9218-4a293e198cbf.png)
