### PR TITLE
"Review details" panel cleanup

### DIFF
--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -29,27 +29,26 @@ const SummaryContent = (formData) => {
             <StackItem className="ins-c-rbac__summary">
               <Grid hasGutter>
                 <GridItem span={ 3 }>
-                  <Text className="data-table-detail heading content pf-c-title" component={ TextVariants.h6 }>Group name</Text>
+                  <Text className="pf-c-title" component={ TextVariants.h6 }>Group name</Text>
                 </GridItem>
                 <GridItem span={ 9 }>
-                  <Text className="data-table-detail content content" component={ TextVariants.p }>{ name }</Text>
+                  <Text component={ TextVariants.p }>{ name }</Text>
                 </GridItem>
               </Grid>
               <Grid hasGutter>
                 <GridItem span = { 3 }>
-                  <Text className="data-table-detail heading content pf-c-title" component={ TextVariants.h6 }>Group description</Text>
+                  <Text className="pf-c-title" component={ TextVariants.h6 }>Group description</Text>
                 </GridItem>
                 <GridItem span = { 9 }>
-                  <Text className="data-table-detail content content" component={ TextVariants.p }>{ description }</Text>
+                  <Text component={ TextVariants.p }>{ description }</Text>
                 </GridItem>
               </Grid>
               <Grid hasGutter>
                 <GridItem span={ 3 }>
-                  <Text className="data-table-detail heading content pf-c-title" component={ TextVariants.h6 }>Roles</Text>
+                  <Text className="pf-c-title" component={ TextVariants.h6 }>Roles</Text>
                 </GridItem>
                 <GridItem span={ 9 }>
                   <Text
-                    className="groups-table-detail content"
                     component={ TextVariants.p }>
                     {selectedRoles.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{role.label}</Text>)}
                   </Text>
@@ -57,11 +56,10 @@ const SummaryContent = (formData) => {
               </Grid>
               <Grid hasGutter>
                 <GridItem span = { 3 }>
-                  <Text className="data-table-detail heading content pf-c-title" component={ TextVariants.h6 }>Members</Text>
+                  <Text className="pf-c-title" component={ TextVariants.h6 }>Members</Text>
                 </GridItem>
                 <GridItem span= { 9 }>
                   <Text
-                    className="groups-table-detail content"
                     component={ TextVariants.p }>
                     { selectedUsers.map((role, index) => <Text className="pf-u-mb-0" key={ index }>{ role.label }</Text>) }
                   </Text>

--- a/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
+++ b/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
@@ -74,11 +74,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-3-col"
                         >
                           <Text
-                            className="data-table-detail heading content pf-c-title"
+                            className="pf-c-title"
                             component="h6"
                           >
                             <h6
-                              className="data-table-detail heading content pf-c-title"
+                              className="pf-c-title"
                               data-pf-content={true}
                             >
                               Group name
@@ -93,11 +93,10 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-9-col"
                         >
                           <Text
-                            className="data-table-detail content content"
                             component="p"
                           >
                             <p
-                              className="data-table-detail content content"
+                              className=""
                               data-pf-content={true}
                             />
                           </Text>
@@ -118,11 +117,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-3-col"
                         >
                           <Text
-                            className="data-table-detail heading content pf-c-title"
+                            className="pf-c-title"
                             component="h6"
                           >
                             <h6
-                              className="data-table-detail heading content pf-c-title"
+                              className="pf-c-title"
                               data-pf-content={true}
                             >
                               Group description
@@ -137,11 +136,10 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-9-col"
                         >
                           <Text
-                            className="data-table-detail content content"
                             component="p"
                           >
                             <p
-                              className="data-table-detail content content"
+                              className=""
                               data-pf-content={true}
                             />
                           </Text>
@@ -162,11 +160,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-3-col"
                         >
                           <Text
-                            className="data-table-detail heading content pf-c-title"
+                            className="pf-c-title"
                             component="h6"
                           >
                             <h6
-                              className="data-table-detail heading content pf-c-title"
+                              className="pf-c-title"
                               data-pf-content={true}
                             >
                               Roles
@@ -181,11 +179,10 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-9-col"
                         >
                           <Text
-                            className="groups-table-detail content"
                             component="p"
                           >
                             <p
-                              className="groups-table-detail content"
+                              className=""
                               data-pf-content={true}
                             />
                           </Text>
@@ -206,11 +203,11 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-3-col"
                         >
                           <Text
-                            className="data-table-detail heading content pf-c-title"
+                            className="pf-c-title"
                             component="h6"
                           >
                             <h6
-                              className="data-table-detail heading content pf-c-title"
+                              className="pf-c-title"
                               data-pf-content={true}
                             >
                               Members
@@ -225,11 +222,10 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                           className="pf-l-grid__item pf-m-9-col"
                         >
                           <Text
-                            className="groups-table-detail content"
                             component="p"
                           >
                             <p
-                              className="groups-table-detail content"
+                              className=""
                               data-pf-content={true}
                             />
                           </Text>


### PR DESCRIPTION
This PR removes the unused/redundant classes: "data-table-detail," "groups-table-detail," "heading," and  "content" from the Create Group wizard - "Review details" panel.

Old

![Screen Shot 2020-09-08 at 1 28 06 PM](https://user-images.githubusercontent.com/1287144/92509852-f0004180-f1d8-11ea-8f9a-ad12d76ed9e7.png)

New
![Screen Shot 2020-09-08 at 1 25 46 PM](https://user-images.githubusercontent.com/1287144/92509862-f393c880-f1d8-11ea-9014-3bd4ccafa70d.png)
