### PR TITLE
Replace custom form group class with PF margin

### DIFF
--- a/src/smart-components/common/FormButtons.js
+++ b/src/smart-components/common/FormButtons.js
@@ -5,12 +5,11 @@ import { isEmpty } from 'lodash';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 import FormSpy from '@data-driven-forms/react-form-renderer/dist/cjs/form-spy';
 import { ActionGroup } from '@patternfly/react-core';
-import './formButtons.scss';
 
 const FormButtons = ({ dirtyFieldsSinceLastSubmit, submitSucceeded, pristine }) => {
     const { onCancel } = useFormApi();
     const noChanges = isEmpty(dirtyFieldsSinceLastSubmit) || !submitSucceeded && pristine;
-    return (<ActionGroup className="ins-m__action-group">
+    return (<ActionGroup className="pf-u-mt-0">
         <Button
             type="submit"
             isDisabled={ noChanges }

--- a/src/smart-components/common/formButtons.scss
+++ b/src/smart-components/common/formButtons.scss
@@ -1,3 +1,0 @@
-.ins-m__action-group {
-  margin-top: 0px !important;
-}


### PR DESCRIPTION
This PR replaces the custom "ins-m__action-group" class with a standard PF margin class.

Old
![Screen Shot 2020-09-08 at 4 04 09 PM](https://user-images.githubusercontent.com/1287144/92522833-57c08780-f1ed-11ea-9628-a581084322d1.png)

New
![Screen Shot 2020-09-08 at 4 03 14 PM](https://user-images.githubusercontent.com/1287144/92522834-57c08780-f1ed-11ea-9497-23fe97eb353d.png)
