### PR TITLE
Delete legacy color classes

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -38,16 +38,6 @@
   }
 }
 
-.disabled-color {
-  color: #d2d2d2;
-}
-
-.danger-color {
-  &:not(:disabled) {
-    color: var(--pf-global--danger-color--100) !important;
-  }
-}
-
 .ins-c-rbac__dialog--warning {
   .ins-c-rbac__delete-icon {
     color: var(--pf-global--warning-color--100);


### PR DESCRIPTION
Removing unused color classes used previously in the old "principle_action_dropdown.js" file