### PR TITLE
Move "ins-c-rbac__dialog--warning" into own file

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,11 +1,5 @@
 @import '~@redhat-cloud-services/frontend-components/index.css';
 
-.ins-c-rbac__dialog--warning {
-  .ins-c-rbac__delete-icon {
-    color: var(--pf-global--warning-color--100);
-  }
-}
-
 .delete-group-warning-icon {
   color: var(--pf-global--warning-color--100);
 }

--- a/src/presentational-components/shared/RemoveModal.js
+++ b/src/presentational-components/shared/RemoveModal.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-
 import { Button, Checkbox, Modal, ModalVariant, Split, SplitItem, Stack, TextContent } from '@patternfly/react-core';
+import './RemoveModal.scss';
 
 const RemoveModal = ({ title, text, onClose, onSubmit, isOpen, confirmButtonLabel, withCheckbox }) => {
   const [checked, setChecked] = useState(false);

--- a/src/presentational-components/shared/RemoveModal.scss
+++ b/src/presentational-components/shared/RemoveModal.scss
@@ -1,0 +1,5 @@
+.ins-c-rbac__dialog--warning {
+  .ins-c-rbac__delete-icon {
+    color: var(--pf-global--warning-color--100);
+  }
+}


### PR DESCRIPTION
Move "ins-c-rbac__dialog--warning" out of App.scss into its own file (pushing styling down to where needed when feasible)