### PR TITLE
MUA mobile layout

### DIFF
--- a/src/smart-components/myUserAccess/MUAContent.js
+++ b/src/smart-components/myUserAccess/MUAContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Stack, StackItem, Title } from '@patternfly/react-core';
+import { Grid, GridItem, Stack, StackItem, Title } from '@patternfly/react-core';
 
 import MUACard from '../../presentational-components/myUserAccess/MUACard';
 
@@ -15,25 +15,27 @@ const MUAContent = ({ entitlements, isOrgAdmin }) => {
 
   return (
     <OrgAdminContext.Provider value={isOrgAdmin}>
-      <section className="ins-l-myUserAccess-section ins-l-myUserAccess-section__cards">
-        <Stack hasGutter className="pf-u-pr-lg pf-u-pl-lg">
-          <StackItem className="ins-l-myUserAccess-section__cards--entitled">
-            {/* No conditional here because you have to have a subscription to get to /settings */}
-            <MUACard header={`Your organization's subscriptions`} entitlements={entitledBundles} />
-          </StackItem>
-          {unEntitledBundles.length > 0 && (
-            <StackItem className="ins-l-myUserAccess-section__cards--unentitled">
-              <MUACard header="Not subscribed" entitlements={unEntitledBundles} isDisabled />
+      <Grid>
+        <GridItem className="pf-m-3-col-on-md ins-l-myUserAccess-section__cards">
+          <Stack>
+            <StackItem className="ins-l-myUserAccess-section__cards--entitled">
+              {/* No conditional here because you have to have a subscription to get to /settings */}
+              <MUACard header={`Your organization's subscriptions`} entitlements={entitledBundles} />
             </StackItem>
-          )}
-        </Stack>
-      </section>
-      <section className="ins-l-myUserAccess-section ins-l-myUserAccess-section__table">
-        <Title headingLevel="h3" size="xl">
-          Your {isOrgAdmin ? 'roles' : 'permissions'}
-        </Title>
-        <MuaBundleRoute />
-      </section>
+            {unEntitledBundles.length > 0 && (
+              <StackItem className="ins-l-myUserAccess-section__cards--unentitled">
+                <MUACard header="Not subscribed" entitlements={unEntitledBundles} isDisabled />
+              </StackItem>
+            )}
+          </Stack>
+        </GridItem>
+        <GridItem className="pf-m-9-col-on-md ins-l-myUserAccess-section__table">
+          <Title headingLevel="h3" size="xl">
+            Your {isOrgAdmin ? 'roles' : 'permissions'}
+          </Title>
+          <MuaBundleRoute />
+        </GridItem>
+      </Grid>
     </OrgAdminContext.Provider>
   );
 };

--- a/src/smart-components/myUserAccess/MUAContent.scss
+++ b/src/smart-components/myUserAccess/MUAContent.scss
@@ -7,7 +7,6 @@
         color: var(--pf-global--Color--400);
         span {
             text-transform: capitalize;
-            width: max-content;
             & + span { margin-top: var(--pf-global--spacer--sm); }
         }
     }

--- a/src/smart-components/myUserAccess/MUAHome.js
+++ b/src/smart-components/myUserAccess/MUAHome.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
-import { Text, TextContent, Spinner } from '@patternfly/react-core';
+import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { Text, Spinner } from '@patternfly/react-core';
 import StatusLabel from '../../presentational-components/myUserAccess/StatusLabel';
 
 import './MUAHome.scss';
@@ -17,22 +17,29 @@ const MyUserAccess = () => {
     <React.Fragment>
       {Object.prototype.hasOwnProperty.call(user, 'entitlements') && Object.prototype.hasOwnProperty.call(user, 'isOrgAdmin') ? (
         <React.Fragment>
-          <PageHeader>
-            <TextContent>
-              <PageHeaderTitle
-                title={
-                  <React.Fragment>
-                    <span> My User Access </span>
-                    <StatusLabel isOrgAdmin={user.isOrgAdmin} />
-                  </React.Fragment>
-                }
-              />
-              <Text component="p" className="ins-p-myUserAccess--subtitle">
-                <span>Understand your Red Hat access by exploring your organization&apos;s entitlements and your individual user roles.</span>
-              </Text>
-            </TextContent>
-          </PageHeader>
-          <section className="ins-l-myUserAccess-split">
+          <PageHeaderTitle
+            className="ins-p-myUserAccess--title sticky"
+            title={
+              <React.Fragment>
+                <span> My User Access </span>
+                <StatusLabel isOrgAdmin={user.isOrgAdmin} />
+              </React.Fragment>
+            }
+          />
+          <Text component="p" className="ins-p-myUserAccess--subtitle">
+            Select from your organization&apos;s subscriptions below to discover your individual application-specific roles and permissions.
+          </Text>
+          <div className="ins-p-myUserAccess--dropdown sticky">
+            <div className="pf-c-dropdown pf-m-expanded">
+              <button className="pf-c-dropdown__toggle" type="button">
+                <span className="pf-c-dropdown__toggle-text">Choose a subscription...</span>
+                <span className="pf-c-dropdown__toggle-icon">
+                  <i className="fas fa-caret-down"></i>
+                </span>
+              </button>
+            </div>
+          </div>
+          <section>
             <MUAContent entitlements={user.entitlements} isOrgAdmin={user.isOrgAdmin} />
           </section>
         </React.Fragment>

--- a/src/smart-components/myUserAccess/MUAHome.scss
+++ b/src/smart-components/myUserAccess/MUAHome.scss
@@ -1,30 +1,73 @@
 .page__myUserAccess {
-    .pf-c-page-header {
-        .ins-p-myUserAccess--subtitle span { display: block; }
+  .ins-p-myUserAccess--title {
+    display: flex;      
+    align-items: center;
+    background-color: var(--pf-global--BackgroundColor--100);
+    padding: var(--pf-global--spacer--md);
+    .pf-c-label { margin-left: var(--pf-global--spacer--md); }
+  }
+  .ins-p-myUserAccess--subtitle {
+    position: relative;
+    background-color: var(--pf-global--BackgroundColor--100);
+    box-shadow: var(--pf-global--BoxShadow--md-bottom);
+    padding: 0 var(--pf-global--spacer--md);
+    padding-bottom: var(--pf-global--spacer--md);
+  }
+  .ins-p-myUserAccess--dropdown {
+    display: none;
+  }
+  .ins-l-myUserAccess-section__cards,
+  .ins-l-myUserAccess-section__table {
+    background-color: var(--pf-global--BackgroundColor--100);
+    height: calc(100vh - 111px - 70px);
+    padding: 0 var(--pf-global--spacer--lg);
+    overflow-x: auto;
+    .pf-c-title {padding: var(--pf-global--spacer--lg) 0;}
+  }
+  .ins-l-myUserAccess-section__cards {border-right: 1px solid var(--pf-global--BorderColor--100);}
 
-        .pf-c-title {
-            display: flex;
-            align-items: center;
-            .pf-c-label { margin-left: var(--pf-global--spacer--md); }
+  @media only screen and (max-width: 768px) {
+    .sticky {
+      position: sticky;
+      position: -webkit-sticky;
+      background-color: var(--pf-global--BackgroundColor--100);
+      height: 60px;
+      width: 100%;
+      z-index: 200;
+    }
+    .ins-p-myUserAccess--title {
+      padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--lg) var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
+      top: 0;
+    }
+    .ins-p-myUserAccess--subtitle {
+      box-shadow: none;
+      padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--lg);
+      background-color: var(--pf-global--BackgroundColor--100);
+    } 
+    .ins-p-myUserAccess--dropdown {
+      display: block;
+      padding: 0 var(--pf-global--spacer--lg);
+      top: 60px;
+    }
+    .ins-l-myUserAccess-section__cards {
+      display: none;
+    }
+    .ins-l-myUserAccess-section__table {
+      height: auto;
+      margin: var(--pf-global--spacer--md);
+      padding: 0;
+      .pf-c-table__expandable-row {
+        max-height: none;
+        overflow-y: visible;
+        > td::before {display: none;}
+      }
+      > .pf-c-title {display: none;}
+      .pf-c-empty-state__content {
+        .pf-c-title {font-size: var(--pf-c-title--m-2xl--FontSize);}
+        .pf-c-empty-state__icon {
+          font-size: var(--pf-c-empty-state--m-xl__icon--FontSize);
         }
-        box-shadow: var(--pf-global--BoxShadow--md);
-        position: relative;
+      }
     }
-
-    .ins-l-myUserAccess-split {
-        display: grid;
-        grid-template-columns: 1fr 2fr;
-        column-gap: 24px;
-        background: white;
-        .ins-l-myUserAccess-section .pf-c-title { margin-top: 15px; }
-        .ins-l-myUserAccess-section:first-of-type {
-            border-right: 1px solid var(--pf-global--BorderColor--100);
-        }
-    }
-
-    .ins-l-myUserAccess-section {
-        height: calc(100vh - 111px - 76px);
-        overflow-x: auto;
-        .pf-c-title { margin-bottom: var(--pf-global--spacer--md); }
-    }
+  }   
 }


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9193

This PR uses the responsive grid to handle both the desktop and new mobile layout, per the mocks here: https://marvelapp.com/prototype/11gc312j/screen/72960978

Follow-up items:
- the dropdown in the header is a placeholder 
- the bottom toolbar (pagination) is broken in RBAC
- Table Toolbar filter should work just like this example: https://www.patternfly.org/v4/documentation/react/demos/filtertabledemo#component-title with  filter icon as a toggle in the mobile layout

"Sticky" Elements

I ran into a challenging situation: sticky elements can't be nested.  They have to stick to their parent - any hierarchy has to be squashed:

Original :

```
<Section>
  <Header>		                    
     <Title>
         My User Access
        <span>Understand your Red Hat access...</span>
     </Title>
  </Header>
</Section>
<Section>
  Rest of the screen
</Section>
```

This PR:
```
<sticky title />
<non-sticky subtitle />
<sticky dropdown />

<Section>
  Rest of the screen
</section>
```

![Screen Shot 2020-09-27 at 9 37 25 AM](https://user-images.githubusercontent.com/1287144/94366271-18c37a80-00a5-11eb-8120-489ee144df61.png)

@karelhala @Hyperkid123  Since we are likely to be creating complex mobile layouts going forward, how about we investigate using [react-sizeme](https://github.com/ctrlplusb/react-sizeme)  or [react-measure](https://github.com/souporserious/react-measure), so we can render different elements or completely different layouts depending on screen size rather than hacking to make something like sticky elements work?


