### PR TITLE
Ignore permissions chrome cache.

### DIFF
--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -42,7 +42,7 @@ const Roles = () => {
   useEffect(() => {
     insights.chrome.appNavClick({ id: 'roles', secondaryNav: true });
     fetchData({ ...pagination, name: filterValue });
-    window.insights.chrome.getUserPermissions('cost-management').then((allPermissions) => {
+    window.insights.chrome.getUserPermissions('cost-management', true).then((allPermissions) => {
       const permissionList = allPermissions.map((permissions) => permissions.permission);
       setIsCostAdmin(permissionList.includes('cost-management:*:*'));
     });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9575

Will be effective after https://github.com/RedHatInsights/insights-chrome/pull/991 is merged.

The permission call will ignore the cache and get the newest data from the API.
