### PR TITLE
Sync Empty State styling for mobile

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -12,12 +12,20 @@
   }
 }
 
+.pf-c-toolbar .pf-c-dropdown__menu .ins-c-primary-toolbar__first-action {
+  display: none;
+}
+
 @media only screen and (max-width: 768px) {
   .ins-c-rbac__user-row .pf-c-label{
     width: max-content;
   }
-}
-
-.pf-c-toolbar .pf-c-dropdown__menu .ins-c-primary-toolbar__first-action {
-  display: none;
+  .pf-c-empty-state__content {
+    h4.pf-c-title {
+      font-size: var(--pf-c-title--m-2xl--FontSize);
+    }
+    .pf-c-empty-state__icon {
+      font-size: var(--pf-c-empty-state--m-xl__icon--FontSize);
+    }
+  }
 }

--- a/src/presentational-components/shared/empty-filter.js
+++ b/src/presentational-components/shared/empty-filter.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { EmptyState, Title, EmptyStateVariant, EmptyStateBody, EmptyStateIcon } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 const EmptyWithFilter = ({ title, icon, description, actions, ...props }) => (
   <EmptyState variant={EmptyStateVariant.full} {...props}>
     <EmptyStateIcon icon={icon || SearchIcon} />
-    <Title headingLevel="h5" size="lg">
-      {title}
-    </Title>
+    <Title headingLevel="h4">{title}</Title>
     <EmptyStateBody>
       {description.map((text, key) => (
         <React.Fragment key={key}>

--- a/src/presentational-components/states/DeniedState.js
+++ b/src/presentational-components/states/DeniedState.js
@@ -16,9 +16,7 @@ const DeniedState = () => {
       <Main>
         <EmptyState variant={EmptyStateVariant.full} className="ins-c-rbac-denied-state">
           <EmptyStateIcon icon={LockIcon} />
-          <Title headingLevel="h5" size="lg">
-            You do not have permissions to view or manage User access
-          </Title>
+          <Title headingLevel="h4">You do not have permissions to view or manage User access</Title>
           <EmptyStateBody>Contact your organization administrator(s) for more information.</EmptyStateBody>
           {document.referrer ? (
             <Button variant="primary" onClick={() => history.back()}>

--- a/src/smart-components/group/add-group/group-name-error-state.js
+++ b/src/smart-components/group/add-group/group-name-error-state.js
@@ -15,9 +15,7 @@ const GroupNameErrorState = ({ setHideFooter }) => {
   return (
     <EmptyState variant={EmptyStateVariant.small}>
       <EmptyStateIcon color={global_palette_red_100.value} icon={ExclamationCircleIcon} />
-      <Title headingLevel="h4" size="lg">
-        Group name already taken
-      </Title>
+      <Title headingLevel="h4">Group name already taken</Title>
       <EmptyStateBody>Please return to Step 1: Group information and choose a&nbsp;unique name for your group.</EmptyStateBody>
       <Button variant="primary" onClick={() => document.getElementsByClassName('pf-c-wizard__nav-link')[0].click()}>
         Return to Step 1

--- a/src/smart-components/myUserAccess/MUAHome.scss
+++ b/src/smart-components/myUserAccess/MUAHome.scss
@@ -22,7 +22,7 @@
     height: calc(100vh - 111px - 70px);
     padding: 0 var(--pf-global--spacer--lg);
     overflow-x: auto;
-    .pf-c-title {padding: var(--pf-global--spacer--lg) 0;}
+    h3 {padding: var(--pf-global--spacer--lg) 0;}
   }
   .ins-l-myUserAccess-section__cards {border-right: 1px solid var(--pf-global--BorderColor--100);}
 
@@ -62,12 +62,6 @@
         > td::before {display: none;}
       }
       > .pf-c-title {display: none;}
-      .pf-c-empty-state__content {
-        .pf-c-title {font-size: var(--pf-c-title--m-2xl--FontSize);}
-        .pf-c-empty-state__icon {
-          font-size: var(--pf-c-empty-state--m-xl__icon--FontSize);
-        }
-      }
     }
   }   
 }

--- a/src/smart-components/myUserAccess/bundles/openshift.js
+++ b/src/smart-components/myUserAccess/bundles/openshift.js
@@ -7,9 +7,7 @@ import './MUABundles.scss';
 const OpenshiftBundle = () => (
   <EmptyState variant="large" className="ins-l-myUserAccess-bundle-emptyState">
     <EmptyStateIcon icon={CogsIcon} />
-    <Title headingLevel="h4" size="lg">
-      OpenShift Cluster Manager permissions are not managed with User Access
-    </Title>
+    <Title headingLevel="h4">OpenShift Cluster Manager permissions are not managed with User Access</Title>
     <EmptyStateBody>
       All users in the organization may view everything, but only Org. Administrators and cluster owners can perform actions on clusters.
     </EmptyStateBody>

--- a/src/test/smart-components/group/add-group/__snapshots__/group-name-error-state.test.js.snap
+++ b/src/test/smart-components/group/add-group/__snapshots__/group-name-error-state.test.js.snap
@@ -48,10 +48,9 @@ exports[`<GroupNameErrorState /> should render correctly 1`] = `
         </EmptyStateIcon>
         <Title
           headingLevel="h4"
-          size="lg"
         >
           <h4
-            className="pf-c-title pf-m-lg"
+            className="pf-c-title pf-m-md"
           >
             Group name already taken
           </h4>


### PR DESCRIPTION
This PR syncs the styling of the various empty states for mobile. It's also fixing a styling bug introduced in the previous MUA PR.

Follow-up to: https://github.com/RedHatInsights/insights-rbac-ui/pull/490

![Screen Shot 2020-09-29 at 3 51 45 PM](https://user-images.githubusercontent.com/1287144/94609095-5d4d4280-026c-11eb-8881-6b1e31453acb.png)
![Screen Shot 2020-09-29 at 3 56 12 PM](https://user-images.githubusercontent.com/1287144/94609098-5de5d900-026c-11eb-8b4b-c27b0901851c.png)
![Screen Shot 2020-09-29 at 3 53 37 PM](https://user-images.githubusercontent.com/1287144/94609099-5de5d900-026c-11eb-90b1-6a7157298077.png)
