### PR TITLE
Mobile SPUR: compound expandable table fix

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -13,6 +13,14 @@
 }
 
 @media only screen and (max-width: 768px) {
+  // fix for mobile layout: https://github.com/patternfly/patternfly-react/issues/4922
+  .pf-c-table__expandable-row.pf-m-expanded {
+    max-height: none !important;
+    overflow-y: visible;
+    tr:first-of-type {padding-top: 0 !important;}
+    > td::before {display: none;}
+  }
+
   .ins-c-rbac__user-row .pf-c-label{
     width: max-content;
   }

--- a/src/smart-components/myUserAccess/MUAHome.scss
+++ b/src/smart-components/myUserAccess/MUAHome.scss
@@ -55,12 +55,6 @@
     .ins-l-myUserAccess-section__table {
       height: auto;
       margin: var(--pf-global--spacer--md);
-      padding: 0;
-      .pf-c-table__expandable-row {
-        max-height: none;
-        overflow-y: visible;
-        > td::before {display: none;}
-      }
       > .pf-c-title {display: none;}
     }
   }   


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-9548
Follow-up to: https://github.com/RedHatInsights/insights-rbac-ui/pull/490

This PR generalizes the fix I added to MUA for the "compound expandable table" where the data-label was being displayed in the mobile viewport and there were double scrollbars. I opened an issue here last week:  https://github.com/patternfly/patternfly-react/issues/4922


Old
![Screen Shot 2020-10-05 at 2 22 44 PM](https://user-images.githubusercontent.com/1287144/95124434-6da86600-0721-11eb-813c-ea5240725c3f.png)


New
![Screen Shot 2020-10-05 at 3 41 44 PM](https://user-images.githubusercontent.com/1287144/95124383-55384b80-0721-11eb-9448-f110e849fccb.png)
