### PR TITLE
adjust ext link icon

### DIFF
--- a/src/presentational-components/shared/ActiveUsers.js
+++ b/src/presentational-components/shared/ActiveUsers.js
@@ -13,9 +13,9 @@ const ActiveUser = ({ description, linkTitle }) => (
         rel="noopener noreferrer"
       >
         {linkTitle}
-        &nbsp;
         <ExternalLinkAltIcon />
       </Text>
+      .
     </Text>
   </TextContent>
 );
@@ -27,7 +27,7 @@ ActiveUser.propTypes = {
 
 ActiveUser.defaultProps = {
   description: '',
-  linkTitle: ' user management list.',
+  linkTitle: ' user management list ',
 };
 
 export default ActiveUser;

--- a/src/test/presentional-components/shared/__snapshots__/ActiveUsers.test.js.snap
+++ b/src/test/presentional-components/shared/__snapshots__/ActiveUsers.test.js.snap
@@ -11,14 +11,14 @@ exports[`<ActiveUsers /> should render correctly 1`] = `
       rel="noopener noreferrer"
       target="_blank"
     >
-       user management list.
-       
+       user management list 
       <ExternalLinkAltIcon
         color="currentColor"
         noVerticalAlign={false}
         size="sm"
       />
     </Text>
+    .
   </Text>
 </TextContent>
 `;
@@ -35,14 +35,14 @@ exports[`<ActiveUsers /> should render correctly with description 1`] = `
       rel="noopener noreferrer"
       target="_blank"
     >
-       user management list.
-       
+       user management list 
       <ExternalLinkAltIcon
         color="currentColor"
         noVerticalAlign={false}
         size="sm"
       />
     </Text>
+    .
   </Text>
 </TextContent>
 `;
@@ -59,13 +59,13 @@ exports[`<ActiveUsers /> should render correctly with link title 1`] = `
       target="_blank"
     >
       some title
-       
       <ExternalLinkAltIcon
         color="currentColor"
         noVerticalAlign={false}
         size="sm"
       />
     </Text>
+    .
   </Text>
 </TextContent>
 `;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-9548

This PR moves the period after the icon.

Follow-up to: https://github.com/RedHatInsights/insights-rbac-ui/pull/511

![Screen Shot 2020-10-07 at 10 09 43 AM](https://user-images.githubusercontent.com/1287144/95342272-410d5f00-0885-11eb-94a1-e39902d91422.png)


![Screen Shot 2020-10-07 at 10 04 04 AM](https://user-images.githubusercontent.com/1287144/95341629-782f4080-0884-11eb-9c02-816f3a4e8d7d.png)

