### PR TITLE
Groups mobile pop-over styling fix

### DIFF
--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -15,27 +15,29 @@ export const createRows = (data, opened, selectedRows = []) => {
         isPlatformDefault,
         cells: [
           <Fragment key={uuid}>
-            <Link key={`${uuid}-link`} to={`/groups/detail/${uuid}`}>
-              {name}
-            </Link>
-            {isPlatformDefault && (
-              <span key={`${uuid}-popover`} id="default-group-popover">
-                <Popover
-                  zIndex="110"
-                  position="right"
-                  isVisible={isPopoverVisible}
-                  shouldClose={() => setPopoverVisible(false)}
-                  hideOnOutsideClick={true}
-                  bodyContent="This group contains the roles that all users in your organization inherit by default."
-                  appendTo={document.getElementById('default-group-popover')}
-                >
-                  <OutlinedQuestionCircleIcon
-                    onClick={() => setPopoverVisible(!isPopoverVisible)}
-                    className={classNames('pf-c-question-circle-icon', { 'icon-active': isPopoverVisible })}
-                  />
-                </Popover>
-              </span>
-            )}
+            <div className="pf-m-inline-flex">
+              <Link key={`${uuid}-link`} to={`/groups/detail/${uuid}`}>
+                {name}
+              </Link>
+              {isPlatformDefault && (
+                <span key={`${uuid}-popover`} id="default-group-popover">
+                  <Popover
+                    zIndex="110"
+                    position="right"
+                    isVisible={isPopoverVisible}
+                    shouldClose={() => setPopoverVisible(false)}
+                    hideOnOutsideClick={true}
+                    bodyContent="This group contains the roles that all users in your organization inherit by default."
+                    appendTo={document.getElementById('default-group-popover')}
+                  >
+                    <OutlinedQuestionCircleIcon
+                      onClick={() => setPopoverVisible(!isPopoverVisible)}
+                      className={classNames('pf-c-question-circle-icon', { 'icon-active': isPopoverVisible })}
+                    />
+                  </Popover>
+                </span>
+              )}
+            </div>
           </Fragment>,
           roleCount,
           principalCount,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-9548
This PR stops the pop-over icon from wrapping unnecessarily.

![Screen Shot 2020-10-07 at 11 34 23 AM](https://user-images.githubusercontent.com/1287144/95353336-280aab00-0891-11eb-86e8-5e2f29bf5f76.png)
![Screen Shot 2020-10-07 at 11 32 07 AM](https://user-images.githubusercontent.com/1287144/95353340-280aab00-0891-11eb-95d0-e95cec58c71b.png)

cc @mmenestr 
