### PR TITLE
Change "Submit" to "Save" on Group Edit button 

### DIFF
--- a/src/smart-components/common/FormButtons.js
+++ b/src/smart-components/common/FormButtons.js
@@ -11,7 +11,7 @@ const FormButtons = ({ dirtyFieldsSinceLastSubmit, submitSucceeded, pristine }) 
   return (
     <ActionGroup className="pf-u-mt-0">
       <Button ouiaId="primary-submit-button" type="submit" isDisabled={noChanges} variant="primary">
-        Submit
+        Save
       </Button>
       <Button ouiaId="secondary-cancel-button" variant="link" onClick={() => onCancel()}>
         Cancel


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-9548
This PR changes "Submit" to "Save" in the Group edit modal (and anywhere else it might be used.)

<img width="878" alt="Screen Shot 2020-10-13 at 4 01 54 PM" src="https://user-images.githubusercontent.com/1287144/95910039-72969680-0d6d-11eb-9697-8f77953618f4.png">

cc @mmenestr


