### PR TITLE
Mua redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5343,27 +5343,6 @@
         "follow-redirects": "1.5.10"
       }
     },
-    "axios-mock-adapter": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.18.2.tgz",
-      "integrity": "sha512-e5aTsPy2Viov22zNpFTlid76W1Scz82pXeEwwCXdtO85LROhHAF8pHF2qDhiyMONLxKyY3lQ+S4UCsKgrlx8Hw==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "is-buffer": "^2.0.3"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
-    },
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -20374,7 +20353,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readdirp": {
           "version": "3.4.0",

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,11 +25,10 @@ export const Routes = () => {
   return (
     <Suspense fallback={<AppPlaceholder />}>
       <Switch>
-        <InsightsRoute exact={true} path={routes.rbac} component={Users} rootClass="users" />
         <InsightsRoute path={routes.groups} component={Groups} rootClass="groups" />
         <InsightsRoute path={routes.roles} component={Roles} rootClass="roles" />
         <InsightsRoute path={routes.users} component={Users} rootClass="users" />
-        <InsightsRoute path={routes.myUserAccess} component={MyUserAccess} rootClass="myUserAccess" />
+        <InsightsRoute path={[routes.myUserAccess, routes.rbac]} component={MyUserAccess} rootClass="myUserAccess" />
         <Route render={() => <Redirect to={routes.myUserAccess} />} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-9881

The users route was eating away the root route.

@ryelo @karelhala is there any additional rule for the MUA route? Is it supposed to be the root only on beta or in every environment? We can obviously change the root route based on that.

Also the lock file change should happen because there is no longer an axios mock adapter library. I guess it was omitted in some previous PR.