### PR TITLE
Fix saving/loading/relaoding permissions

### DIFF
--- a/src/smart-components/role/add-role-new/add-permissions-template.js
+++ b/src/smart-components/role/add-role-new/add-permissions-template.js
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Chip, ChipGroup, Text, TextContent, Title } from '@patternfly/react-core';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 
 import './add-role-wizard.scss';
 
 const AddPermissionTemplate = ({ formFields }) => {
-  const [selectedPermissions, setSelectedPermissions] = useState([]);
+  const formOptions = useFormApi();
+  const [selectedPermissions, setSelectedPermissions] = useState(formOptions.getState().values['add-permissions-table'] || []);
+  console.log('SELECTED:', selectedPermissions);
 
   const addPermissions = formFields[0][0];
   return (

--- a/src/smart-components/role/add-role-new/add-permissions-template.js
+++ b/src/smart-components/role/add-role-new/add-permissions-template.js
@@ -8,7 +8,6 @@ import './add-role-wizard.scss';
 const AddPermissionTemplate = ({ formFields }) => {
   const formOptions = useFormApi();
   const [selectedPermissions, setSelectedPermissions] = useState(formOptions.getState().values['add-permissions-table'] || []);
-  console.log('SELECTED:', selectedPermissions);
 
   const addPermissions = formFields[0][0];
   return (

--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -117,6 +117,7 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
       dispatch(fetchRole(baseRoleUuid));
     }
 
+    formOptions.change('has-cost-resources', false);
     fetchData(pagination);
     fetchOptions({ field: 'application', limit: 50 });
     fetchOptions({ field: 'resource_type', limit: 50 });

--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -143,7 +143,7 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
   }, [selectedPermissions]);
 
   useEffect(() => {
-    if (baseRole && roleType === 'copy') {
+    if (baseRole && roleType === 'copy' && selectedPermissions.length === 0) {
       setSelectedPermissions(() =>
         resolveSplats(
           (baseRole?.access || []).map((permission) => ({ uuid: permission.permission })),
@@ -182,7 +182,6 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
   };
 
   const filterItemOverflow = preparedFilterItems[Object.keys(preparedFilterItems)[value ? value : 0]].length > maxFilterItems;
-  console.log('RENDER', permissions);
   return (
     <div className="ins-c-rbac-permissions-table">
       <TableToolbarView

--- a/src/smart-components/role/add-role-new/add-role-wizard.js
+++ b/src/smart-components/role/add-role-new/add-role-wizard.js
@@ -12,6 +12,7 @@ import BaseRoleTable from './base-role-table';
 import AddPermissionsTable from './add-permissions';
 import ReviewStep from './review';
 import CostResources from './cost-resources';
+import TypeSelector from './type-selector';
 import './add-role-wizard.scss';
 
 const FormTemplate = (props) => <Pf4FormTemplate {...props} showFormControls={false} />;
@@ -25,6 +26,7 @@ export const mapperExtension = {
   'cost-resources': CostResources,
   review: ReviewStep,
   description: Description,
+  'type-selector': TypeSelector,
 };
 
 const AddRoleWizard = ({ history: { push } }) => {

--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -47,6 +47,7 @@ const BaseRoleTable = (props) => {
                   input.onChange(role);
                   formOptions.change('role-copy-name', `Copy of ${role.display_name || role.name}`);
                   formOptions.change('role-copy-description', role.description);
+                  formOptions.change('add-permissions-table', []);
                 });
               }}
             />

--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -96,6 +96,7 @@ const CostResources = (props) => {
       resources.map((resource) => permissions.includes(permission) && dispatchLocaly({ type: 'select', selection: resource, key: permission }))
     );
     fetchData();
+    formOptions.change('has-cost-resources', true);
   }, []);
 
   useEffect(() => {

--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -92,6 +92,9 @@ const CostResources = (props) => {
   const permissionToResource = (permission) => resourceTypes.find((r) => r.value === permission.split(':')?.[1])?.path.split('/')?.[5];
 
   useEffect(() => {
+    (formOptions.getState().values['resource-definitions'] || []).map(({ permission, resources }) =>
+      resources.map((resource) => permissions.includes(permission) && dispatchLocaly({ type: 'select', selection: resource, key: permission }))
+    );
     fetchData();
   }, []);
 

--- a/src/smart-components/role/add-role-new/review.js
+++ b/src/smart-components/role/add-role-new/review.js
@@ -33,6 +33,7 @@ const ReviewStep = () => {
     'role-copy-description': copyDescription,
     'add-permissions-table': permissions,
     'resource-definitions': resourceDefinitions,
+    'has-cost-resources': hasCostResources,
   } = formOptions.getState().values;
   const columns = ['Application', 'Resource type', 'Operation'];
   const rows = permissions.map((permission) => ({
@@ -77,7 +78,7 @@ const ReviewStep = () => {
               {stickyTable(columns, rows)}
             </GridItem>
           </Grid>
-          {resourceDefinitions && (
+          {hasCostResources && (
             <Grid>
               <GridItem sm={12} md={2}>
                 <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">

--- a/src/smart-components/role/add-role-new/schema.js
+++ b/src/smart-components/role/add-role-new/schema.js
@@ -25,19 +25,9 @@ export default (container) => ({
           },
           fields: [
             {
-              component: 'radio',
+              component: 'type-selector',
               name: 'role-type',
               isRequired: true,
-              options: [
-                {
-                  label: 'Create a role from scratch',
-                  value: 'create',
-                },
-                {
-                  label: 'Copy an existing role',
-                  value: 'copy',
-                },
-              ],
               validate: [
                 {
                   type: 'required',

--- a/src/smart-components/role/add-role-new/type-selector.js
+++ b/src/smart-components/role/add-role-new/type-selector.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Radio } from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
+
+const TypeSelector = (props) => {
+  const { input } = useFieldApi(props);
+  const formOptions = useFormApi();
+  const [checked, setChecked] = useState(formOptions.getState().values['role-type']);
+  const handleChange = (val) => {
+    setChecked(val);
+    input.onChange(val);
+    formOptions.change('add-permissions-table', []);
+  };
+
+  return (
+    <div>
+      <Radio
+        isChecked={checked === 'create'}
+        name="role-type-create"
+        onChange={() => handleChange('create')}
+        label="Create a role from scratch"
+        id="role-type-create"
+        value="create"
+      />
+      <Radio
+        isChecked={checked === 'copy'}
+        name="role-type-copy"
+        onChange={() => handleChange('copy')}
+        label="Copy an existing role"
+        id="role-type-copy"
+        value="copy"
+      />
+    </div>
+  );
+};
+
+export default TypeSelector;


### PR DESCRIPTION
When user switches Copy/Create radio Add permissions data are reset. Also when user changes the base role selection, Add permission data are reset. In other cases they should be remembered. Cost resources should also be remembered.

Fixes issues 4, 5, 10 from https://issues.redhat.com/browse/RHCLOUD-9983