### PR TITLE
Fix wrong preselected permissions

### DIFF
--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -144,7 +144,12 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
   }, [selectedPermissions]);
 
   useEffect(() => {
-    if (baseRole && roleType === 'copy' && selectedPermissions.length === 0) {
+    if (
+      baseRole &&
+      roleType === 'copy' &&
+      selectedPermissions.length === 0 &&
+      formOptions.getState().values['copy-base-role']?.uuid === baseRole?.uuid
+    ) {
       setSelectedPermissions(() =>
         resolveSplats(
           (baseRole?.access || []).map((permission) => ({ uuid: permission.permission })),


### PR DESCRIPTION
When you select base role, got o permission step, go back, select different role go back to permission steps. Permissions from first role are selected. That should be fixed by this pr