### PR TITLE
Fix submit for custom roles

### DIFF
--- a/src/smart-components/role/add-role-new/add-role-wizard.js
+++ b/src/smart-components/role/add-role-new/add-role-wizard.js
@@ -68,8 +68,8 @@ const AddRoleWizard = ({ history: { push } }) => {
       'role-type': type,
     } = formData;
     const roleData = {
-      applications: [formData.application],
-      description: (type === 'create' ? description : copyDescription) || '',
+      applications: [...new Set(permissions.map(({ uuid: permission }) => permission.split(':')[0]))],
+      description: (type === 'create' ? description : copyDescription) || null,
       name: type === 'create' ? name : copyName,
       access: permissions.map(({ uuid: permission }) => ({
         permission,


### PR DESCRIPTION
Fixes two issues with submit. Firstly send `null`instead of empty string when description is empty. Secondly parse applications from permissions, before it was sending `undefined`.

Fixes issue 12: https://issues.redhat.com/browse/RHCLOUD-9983