### PR TITLE
fix 'Add group' wizard review mobile styling

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2,10 +2,12 @@
 
 .ins-c-rbac__summary {
   .pf-l-grid {
-    .pf-l-grid__item {
-      margin-bottom: var(--pf-global--gutter--md);
-    }
+    margin-bottom: var(--pf-global--gutter--md);
   }
+}
+
+.ins-c-rbac__bold-text {
+    font-weight: var(--pf-global--FontWeight--bold);
 }
 
 .pf-c-toolbar .pf-c-dropdown__menu .ins-c-primary-toolbar__first-action {

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -19,33 +19,33 @@ const SummaryContent = (formData) => {
               </TextContent>
             </StackItem>
             <StackItem className="ins-c-rbac__summary">
-              <Grid hasGutter>
-                <GridItem span={3}>
-                  <Text className="pf-c-title" component={TextVariants.h6}>
+              <Grid>
+                <GridItem md={3}>
+                  <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
                     Group name
                   </Text>
                 </GridItem>
-                <GridItem span={9}>
+                <GridItem md={9}>
                   <Text component={TextVariants.p}>{name}</Text>
                 </GridItem>
               </Grid>
-              <Grid hasGutter>
-                <GridItem span={3}>
-                  <Text className="pf-c-title" component={TextVariants.h6}>
+              <Grid>
+                <GridItem md={3}>
+                  <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
                     Group description
                   </Text>
                 </GridItem>
-                <GridItem span={9}>
+                <GridItem md={9}>
                   <Text component={TextVariants.p}>{description}</Text>
                 </GridItem>
               </Grid>
-              <Grid hasGutter>
-                <GridItem span={3}>
-                  <Text className="pf-c-title" component={TextVariants.h6}>
+              <Grid>
+                <GridItem md={3}>
+                  <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
                     Roles
                   </Text>
                 </GridItem>
-                <GridItem span={9}>
+                <GridItem md={9}>
                   <Text component={TextVariants.p}>
                     {selectedRoles.map((role, index) => (
                       <Text className="pf-u-mb-0" key={index}>
@@ -55,13 +55,13 @@ const SummaryContent = (formData) => {
                   </Text>
                 </GridItem>
               </Grid>
-              <Grid hasGutter>
-                <GridItem span={3}>
-                  <Text className="pf-c-title" component={TextVariants.h6}>
+              <Grid>
+                <GridItem md={3}>
+                  <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
                     Members
                   </Text>
                 </GridItem>
-                <GridItem span={9}>
+                <GridItem md={9}>
                   <Text component={TextVariants.p}>
                     {selectedUsers.map((role, index) => (
                       <Text className="pf-u-mb-0" key={index}>

--- a/src/smart-components/role/add-role-new/review.scss
+++ b/src/smart-components/role/add-role-new/review.scss
@@ -22,18 +22,10 @@
     }
 }
 
-.ins-c-rbac__summary .pf-l-grid .pf-l-grid__item {
-    margin-bottom: var(--pf-global--spacer--md)
-}
-
 .ins-c-rbac__gutter-sm {
     margin-bottom: var(--pf-global--spacer--sm)
 }
 
 .ins-c-rbac__gutter-md {
     margin-bottom: var(--pf-global--spacer--md)
-}
-
-.ins-c-rbac__bold-text {
-    font-weight: var(--pf-global--FontWeight--bold);
 }

--- a/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
+++ b/src/test/smart-components/group/add-group/__snapshots__/summary-content.test.js.snap
@@ -61,36 +61,34 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                 <div
                   className="pf-l-stack__item ins-c-rbac__summary"
                 >
-                  <Grid
-                    hasGutter={true}
-                  >
+                  <Grid>
                     <div
-                      className="pf-l-grid pf-m-gutter"
+                      className="pf-l-grid"
                     >
                       <GridItem
-                        span={3}
+                        md={3}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-3-col"
+                          className="pf-l-grid__item pf-m-3-col-on-md"
                         >
                           <Text
-                            className="pf-c-title"
-                            component="h6"
+                            className="ins-c-rbac__bold-text"
+                            component="h4"
                           >
-                            <h6
-                              className="pf-c-title"
+                            <h4
+                              className="ins-c-rbac__bold-text"
                               data-pf-content={true}
                             >
                               Group name
-                            </h6>
+                            </h4>
                           </Text>
                         </div>
                       </GridItem>
                       <GridItem
-                        span={9}
+                        md={9}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-9-col"
+                          className="pf-l-grid__item pf-m-9-col-on-md"
                         >
                           <Text
                             component="p"
@@ -104,36 +102,34 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                       </GridItem>
                     </div>
                   </Grid>
-                  <Grid
-                    hasGutter={true}
-                  >
+                  <Grid>
                     <div
-                      className="pf-l-grid pf-m-gutter"
+                      className="pf-l-grid"
                     >
                       <GridItem
-                        span={3}
+                        md={3}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-3-col"
+                          className="pf-l-grid__item pf-m-3-col-on-md"
                         >
                           <Text
-                            className="pf-c-title"
-                            component="h6"
+                            className="ins-c-rbac__bold-text"
+                            component="h4"
                           >
-                            <h6
-                              className="pf-c-title"
+                            <h4
+                              className="ins-c-rbac__bold-text"
                               data-pf-content={true}
                             >
                               Group description
-                            </h6>
+                            </h4>
                           </Text>
                         </div>
                       </GridItem>
                       <GridItem
-                        span={9}
+                        md={9}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-9-col"
+                          className="pf-l-grid__item pf-m-9-col-on-md"
                         >
                           <Text
                             component="p"
@@ -147,36 +143,34 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                       </GridItem>
                     </div>
                   </Grid>
-                  <Grid
-                    hasGutter={true}
-                  >
+                  <Grid>
                     <div
-                      className="pf-l-grid pf-m-gutter"
+                      className="pf-l-grid"
                     >
                       <GridItem
-                        span={3}
+                        md={3}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-3-col"
+                          className="pf-l-grid__item pf-m-3-col-on-md"
                         >
                           <Text
-                            className="pf-c-title"
-                            component="h6"
+                            className="ins-c-rbac__bold-text"
+                            component="h4"
                           >
-                            <h6
-                              className="pf-c-title"
+                            <h4
+                              className="ins-c-rbac__bold-text"
                               data-pf-content={true}
                             >
                               Roles
-                            </h6>
+                            </h4>
                           </Text>
                         </div>
                       </GridItem>
                       <GridItem
-                        span={9}
+                        md={9}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-9-col"
+                          className="pf-l-grid__item pf-m-9-col-on-md"
                         >
                           <Text
                             component="p"
@@ -190,36 +184,34 @@ exports[`<SummaryContent /> should render correctly 1`] = `
                       </GridItem>
                     </div>
                   </Grid>
-                  <Grid
-                    hasGutter={true}
-                  >
+                  <Grid>
                     <div
-                      className="pf-l-grid pf-m-gutter"
+                      className="pf-l-grid"
                     >
                       <GridItem
-                        span={3}
+                        md={3}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-3-col"
+                          className="pf-l-grid__item pf-m-3-col-on-md"
                         >
                           <Text
-                            className="pf-c-title"
-                            component="h6"
+                            className="ins-c-rbac__bold-text"
+                            component="h4"
                           >
-                            <h6
-                              className="pf-c-title"
+                            <h4
+                              className="ins-c-rbac__bold-text"
                               data-pf-content={true}
                             >
                               Members
-                            </h6>
+                            </h4>
                           </Text>
                         </div>
                       </GridItem>
                       <GridItem
-                        span={9}
+                        md={9}
                       >
                         <div
-                          className="pf-l-grid__item pf-m-9-col"
+                          className="pf-l-grid__item pf-m-9-col-on-md"
                         >
                           <Text
                             component="p"


### PR DESCRIPTION
This PR fixes the broken mobile styling of the 'Add group' wizard review step , syncing it with the 'Add Role' wizard styling.
Jira: https://issues.redhat.com/browse/RHCLOUD-10034

Old
![Screen Shot 2020-10-28 at 10 48 41 AM](https://user-images.githubusercontent.com/1287144/97452884-95977d80-190b-11eb-834b-ab44710cb6f2.png)

New
![Screen Shot 2020-10-28 at 11 00 21 AM](https://user-images.githubusercontent.com/1287144/97454139-cf1cb880-190c-11eb-9be7-a36e218b6991.png)


