### PR TITLE
Add info messages to add role table to show why some perms are missing

### DIFF
--- a/src/smart-components/role/add-role-new/add-permissions-template.js
+++ b/src/smart-components/role/add-role-new/add-permissions-template.js
@@ -10,7 +10,7 @@ const AddPermissionTemplate = ({ formFields }) => {
   const [selectedPermissions, setSelectedPermissions] = useState(formOptions.getState().values['add-permissions-table'] || []);
 
   const unresolvedSplats =
-    formOptions.getState().values?.['copy-base-role']?.applications?.filter((app) => selectedPermissions?.find(({ uuid }) => uuid.includes(app))) ||
+    formOptions.getState().values?.['copy-base-role']?.applications?.filter((app) => !selectedPermissions?.find(({ uuid }) => uuid.includes(app))) ||
     [];
   const addPermissions = formFields[0][0];
   return (

--- a/src/smart-components/role/add-role-new/add-permissions-template.js
+++ b/src/smart-components/role/add-role-new/add-permissions-template.js
@@ -1,14 +1,17 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Chip, ChipGroup, Text, TextContent, Title } from '@patternfly/react-core';
+import { Chip, ChipGroup, Text, TextContent, Title, Button, Popover } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
-
+import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import './add-role-wizard.scss';
 
 const AddPermissionTemplate = ({ formFields }) => {
   const formOptions = useFormApi();
   const [selectedPermissions, setSelectedPermissions] = useState(formOptions.getState().values['add-permissions-table'] || []);
 
+  const unresolvedSplats =
+    formOptions.getState().values?.['copy-base-role']?.applications?.filter((app) => selectedPermissions?.find(({ uuid }) => uuid.includes(app))) ||
+    [];
   const addPermissions = formFields[0][0];
   return (
     <React.Fragment>
@@ -30,9 +33,32 @@ const AddPermissionTemplate = ({ formFields }) => {
         Add permissions
       </Title>
       <TextContent>
-        <Text>Select permissions to add to your role</Text>
+        <Text>
+          Select permissions to add to your role
+          {unresolvedSplats.length !== 0 && (
+            <Popover
+              headerContent="Custom roles only support granular permissions"
+              bodyContent="Wildcard permissions (for example, approval:*:*) aren’t included in this table and can’t be added to your custom role."
+            >
+              <Button variant="link">
+                Why am I not seeing all of my permissions? <QuestionCircleIcon />
+              </Button>
+            </Popover>
+          )}
+        </Text>
       </TextContent>
-      {[[{ ...addPermissions, props: { ...addPermissions.props, selectedPermissions, setSelectedPermissions } }]]}
+      {[
+        [
+          {
+            ...addPermissions,
+            props: {
+              ...addPermissions.props,
+              selectedPermissions,
+              setSelectedPermissions,
+            },
+          },
+        ],
+      ]}
     </React.Fragment>
   );
 };

--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -199,6 +199,12 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
         createRows={createRows}
         data={permissions}
         filterValue={''}
+        noData={permissions?.length === 0}
+        noDataDescription={[
+          'Adjust your filters and try again. Note: Applications that only have wildcard \
+          permissions (for example, patch:*:*) aren’t included in this table and can’t be \
+          added to your custom role.',
+        ]}
         fetchData={({ limit, offset, applications, resources, operations }) => {
           fetchData({
             limit,

--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
-import { Radio } from '@patternfly/react-core';
+import { Radio, Alert } from '@patternfly/react-core';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { fetchRolesForWizard } from '../../../redux/actions/role-actions';
 import { mappedProps } from '../../../helpers/shared/helpers';
@@ -63,6 +63,14 @@ const BaseRoleTable = (props) => {
     }));
   return (
     <div>
+      <Alert
+        variant="info"
+        isInline
+        title={`Only granular permissions will be copied into a custom role \
+        (for example, approval:requests:read). Wildcard permissions will not \
+        be copied into a custom role (for example, approval:*:read).
+        `}
+      />
       <TableToolbarView
         columns={columns}
         createRows={createRows}


### PR DESCRIPTION
### Implements RHCLOUD-10392

When user copies role with unresolvable splats these permissions won't be shown in the table, so in order to avoid confusion users see info msg when copying a role

![Screenshot from 2020-11-16 10-49-04](https://user-images.githubusercontent.com/3439771/99237950-6cc32380-27f9-11eb-92b9-17a0a77739bb.png)

If user picks any role with unresolvable splats a popover is shown
![Screenshot from 2020-11-16 10-48-57](https://user-images.githubusercontent.com/3439771/99237988-764c8b80-27f9-11eb-97e1-99d82650be5f.png)

And finally, if user filters down the list and nothing is found more descritive empty message is shown
![Screenshot from 2020-11-16 10-48-37](https://user-images.githubusercontent.com/3439771/99238003-7ba9d600-27f9-11eb-89a8-4b51b28b494b.png)


### Recording
![animation](https://user-images.githubusercontent.com/3439771/99238081-954b1d80-27f9-11eb-8382-50289c15a5a4.gif)


### Note

I've added the unresolved apps so we could potentionally either show those permissions that can't be resolved or add them, but this is for more deep discussion on the JIRA issue.