### PR TITLE
Display name sorting

### DIFF
--- a/src/smart-components/group/add-group/roles-list.js
+++ b/src/smart-components/group/add-group/roles-list.js
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { sortable } from '@patternfly/react-table';
 import { mappedProps } from '../../../helpers/shared/helpers';
 import { defaultCompactSettings, defaultSettings } from '../../../helpers/shared/pagination';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { fetchRolesWithPolicies } from '../../../redux/actions/role-actions';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/';
 import { fetchAddRolesForGroup } from '../../../redux/actions/group-actions';
-
-const columns = [{ title: 'Name', orderBy: 'name' }, { title: 'Description' }];
 
 const createRows = (data, expanded, checkedRows = []) => {
   return data
@@ -26,11 +25,15 @@ const createRows = (data, expanded, checkedRows = []) => {
     : [];
 };
 
-const RolesList = ({ roles, fetchRoles, isLoading, pagination, selectedRoles, setSelectedRoles }) => {
+const RolesList = ({ roles, fetchRoles, isLoading, pagination, selectedRoles, canSort, setSelectedRoles }) => {
   const [filterValue, setFilterValue] = useState('');
+  const { current: columns } = useRef([
+    { title: 'Name', key: 'display_name', ...(canSort ? { transforms: [sortable] } : { orderBy: 'name' }) },
+    { title: 'Description' },
+  ]);
 
   useEffect(() => {
-    fetchRoles({});
+    fetchRoles({ orderBy: 'display_name' });
   }, []);
 
   const setCheckedItems = (newSelection) => {
@@ -92,11 +95,13 @@ RolesList.propTypes = {
     offset: PropTypes.number.isRequired,
     count: PropTypes.number,
   }),
+  canSort: PropTypes.bool,
 };
 
 RolesList.defaultProps = {
   roles: [],
   pagination: defaultCompactSettings,
+  canSort: true,
 };
 
 const mapStateToPropsGroup = ({ groupReducer: { selectedGroup } }) => {
@@ -124,6 +129,7 @@ const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
     ...ownProps,
     ...propsFromState,
     ...propsFromDispatch,
+    canSort: false,
     fetchRoles: (apiProps) => propsFromDispatch.fetchRoles(propsFromState.groupId, apiProps),
   };
 };

--- a/src/smart-components/myUserAccess/MUARolesTable.js
+++ b/src/smart-components/myUserAccess/MUARolesTable.js
@@ -9,11 +9,15 @@ import { ListLoader } from '../../presentational-components/shared/loader-placeh
 
 const ResourceDefinitionsModal = lazy(() => import('./ResourceDefinitionsModal'));
 
-import { Table, TableHeader, TableBody, TableVariant, compoundExpand, cellWidth } from '@patternfly/react-table';
+import { Table, TableHeader, TableBody, TableVariant, compoundExpand, cellWidth, sortable } from '@patternfly/react-table';
 import ResourceDefinitionsLink from '../../presentational-components/myUserAccess/ResourceDefinitionsLink';
 
 const columns = [
-  'Roles',
+  {
+    title: 'Roles',
+    key: 'display_name',
+    transforms: [sortable],
+  },
   'Description',
   {
     title: 'Permissions',
@@ -36,7 +40,7 @@ const MUARolesTable = ({
   const [{ rdOpen, rdPermission, resourceDefinitions }, setRdConfig] = useState({ rdOpen: false });
 
   useEffect(() => {
-    fetchRoles({ limit: 20, offset: 0, scope: 'principal', application: apps.join(',') });
+    fetchRoles({ limit: 20, offset: 0, orderBy: 'display_name', scope: 'principal', application: apps.join(',') });
   }, []);
 
   const createRows = (data) => {
@@ -102,9 +106,9 @@ const MUARolesTable = ({
   };
 
   let debouncedFetch = useCallback(
-    debounce((limit, offset, name, application, permission) => {
+    debounce((limit, offset, name, application, permission, orderBy) => {
       const applicationParam = application?.length > 0 ? application : apps;
-      return fetchRoles({ limit, offset, scope: 'principal', name, application: applicationParam.join(','), permission });
+      return fetchRoles({ limit, offset, scope: 'principal', orderBy, name, application: applicationParam.join(','), permission });
     }, 800),
     []
   );
@@ -132,8 +136,8 @@ const MUARolesTable = ({
         createRows={createRows}
         ouiaId="roles-table"
         data={roles.data}
-        fetchData={({ limit, offset, name, application, permission }) => {
-          debouncedFetch(limit, offset, name, application, permission);
+        fetchData={({ limit, offset, name, application, permission, orderBy = 'display_name' }) => {
+          debouncedFetch(limit, offset, name, application, permission, orderBy);
         }}
         setFilterValue={setFilters}
         isLoading={isLoading}

--- a/src/smart-components/role/add-role-new/base-role-table.js
+++ b/src/smart-components/role/add-role-new/base-role-table.js
@@ -6,8 +6,9 @@ import { fetchRolesForWizard } from '../../../redux/actions/role-actions';
 import { mappedProps } from '../../../helpers/shared/helpers';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
+import { sortable } from '@patternfly/react-table';
 
-const columns = ['', 'Name', 'Description'];
+const columns = ['', { title: 'Name', key: 'display_name', transforms: [sortable] }, 'Description'];
 const selector = ({ roleReducer: { rolesForWizard, isLoading } }) => ({
   roles: rolesForWizard.data,
   pagination: rolesForWizard.meta,
@@ -27,6 +28,7 @@ const BaseRoleTable = (props) => {
       limit: 50,
       offset: 0,
       itemCount: 0,
+      orderBy: 'display_name',
     });
   }, []);
 

--- a/src/test/smart-components/myUserAccess/MUARolesTable.test.js
+++ b/src/test/smart-components/myUserAccess/MUARolesTable.test.js
@@ -229,8 +229,8 @@ describe('<MUARolesTable />', () => {
     });
     expect(fetchRolesSpy).toHaveBeenCalledTimes(2);
     expect(fetchRolesSpy.mock.calls).toEqual([
-      [{ application: 'app1,app2', limit: 20, offset: 0, scope: 'principal' }],
-      [{ application: 'app2', limit: undefined, name: '', offset: 0, permission: '', scope: 'principal' }],
+      [{ application: 'app1,app2', limit: 20, offset: 0, scope: 'principal', orderBy: 'display_name' }],
+      [{ application: 'app2', limit: undefined, name: '', offset: 0, permission: '', scope: 'principal', orderBy: 'display_name' }],
     ]);
   });
 });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-10219

We have an incredible amount of copy-paste code when it comes to roles tables. We should merge them at some point.

Can't add display_name sorting to tables that are using `/groups/<uuid>/roles` [endpoint](https://github.com/RedHatInsights/insights-rbac/blob/master/docs/source/specs/openapi.json#L826) because it does not support it.