### PR TITLE
Group detail page kebab & inconsistencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,10 @@
       "description": "Edit single group"
     },
     "group-detail": "/groups/detail/:uuid",
+    "group-detail-members-edit": "/groups/detail/:uuid/members/edit",
+    "group-detail-roles-edit": "/groups/detail/:uuid/roles/edit",
+    "group-detail-members-remove": "/groups/detail/:uuid/members/remove",
+    "group-detail-roles-remove": "/groups/detail/:uuid/roles/remove",
     "group-detail-roles": "/groups/detail/:uuid/roles",
     "group-add-roles": "/groups/detail/:uuid/roles/add_roles",
     "group-detail-members": "/groups/detail/:uuid/members",

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -44,6 +44,13 @@ export const removeRole = (role) => ({
         dismissable: false,
         description: 'The role was removed successfully.',
       },
+      rejected: {
+        variant: 'danger',
+        title: 'Failed removing role',
+        dismissDelay: 8000,
+        dismissable: false,
+        description: 'The role was not removed successfuly.',
+      },
     },
   },
 });
@@ -66,6 +73,24 @@ export const fetchRolesForWizard = (options = {}) => ({
 export const updateRole = (roleId, data, useCustomAccess) => ({
   type: ActionTypes.UPDATE_ROLE,
   payload: RoleHelper.updateRole(roleId, data, useCustomAccess),
+  meta: {
+    notifications: {
+      fulfilled: {
+        variant: 'success',
+        title: 'Success updating role',
+        dismissDelay: 8000,
+        dismissable: false,
+        description: 'The role was updated successfully.',
+      },
+      rejected: {
+        variant: 'danger',
+        title: 'Failed updating role',
+        dismissDelay: 8000,
+        dismissable: false,
+        description: 'The role was not updated successfuly.',
+      },
+    },
+  },
 });
 
 export const removeRolePermissions = (role, permissionsToRemove) => ({

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -1,18 +1,19 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Switch, Redirect } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { Route, Redirect, Link, useLocation } from 'react-router-dom';
+import { connect, useDispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import AppTabs from '../app-tabs/app-tabs';
 import { TopToolbar, TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
 import GroupPrincipals from './principal/principals';
 import GroupRoles from './role/group-roles';
-import { fetchGroup } from '../../redux/actions/group-actions';
+import { fetchGroup, fetchGroups } from '../../redux/actions/group-actions';
 import { ListLoader } from '../../presentational-components/shared/loader-placeholders';
-import { Alert, AlertActionCloseButton, Button, Popover, Split, SplitItem } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, Popover, Split, SplitItem, DropdownItem, Dropdown, KebabToggle } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { routes } from '../../../package.json';
 import EditGroup from './edit-group-modal';
+import RemoveGroup from './remove-group-modal';
 import './group.scss';
 
 const Group = ({
@@ -32,12 +33,16 @@ const Group = ({
     { eventKey: 0, title: 'Roles', name: `/groups/detail/${uuid}/roles` },
     { eventKey: 1, title: 'Members', name: `/groups/detail/${uuid}/members` },
   ];
-  const [showEdit, setShowEdit] = useState(false);
+
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [showDefaultGroupChangedInfo, setShowDefaultGroupChangedInfo] = useState(false);
 
   const fetchData = (apiProps) => {
     fetchGroup(apiProps);
   };
+
+  const dispatch = useDispatch();
+  const location = useLocation();
 
   useEffect(() => {
     fetchData(uuid);
@@ -64,6 +69,36 @@ const Group = ({
     </div>
   );
 
+  const dropdownItems = [
+    <DropdownItem
+      component={
+        <Link
+          to={(location.pathname.includes('members') ? routes['group-detail-members-edit'] : routes['group-detail-roles-edit']).replace(
+            ':uuid',
+            uuid
+          )}
+        >
+          Edit
+        </Link>
+      }
+      key="edit-group"
+    />,
+    <DropdownItem
+      component={
+        <Link
+          to={(location.pathname.includes('members') ? routes['group-detail-members-remove'] : routes['group-detail-roles-remove']).replace(
+            ':uuid',
+            uuid
+          )}
+        >
+          Delete
+        </Link>
+      }
+      className="ins-c-group__action"
+      key="delete-group"
+    />,
+  ];
+
   return (
     <Fragment>
       <TopToolbar breadcrumbs={breadcrumbsList()}>
@@ -80,21 +115,16 @@ const Group = ({
           </SplitItem>
           <SplitItem>
             {group.platform_default ? null : (
-              <Button ouiaId="edit-group-button" onClick={() => setShowEdit(true)} variant="secondary">
-                Edit group
-              </Button>
+              <Dropdown
+                ouiaId="role-title-actions-dropdown"
+                toggle={<KebabToggle onToggle={(isOpen) => setDropdownOpen(isOpen)} id="group-actions-dropdown" />}
+                isOpen={isDropdownOpen}
+                isPlain
+                position="right"
+                dropdownItems={dropdownItems}
+              />
             )}
           </SplitItem>
-          <EditGroup
-            isOpen={showEdit}
-            group={group}
-            closeUrl={`group/detail/${uuid}`}
-            onClose={() => setShowEdit(false)}
-            postMethod={() => {
-              fetchData(uuid);
-              setShowEdit(false);
-            }}
-          />
         </Split>
         {showDefaultGroupChangedInfo ? (
           <Alert
@@ -110,14 +140,39 @@ const Group = ({
         ) : null}
       </TopToolbar>
       <AppTabs isHeader tabItems={tabItems} />
-      <Switch>
-        <Route
-          path={routes['group-detail-roles']}
-          render={(props) => <GroupRoles {...props} onDefaultGroupChanged={setShowDefaultGroupChangedInfo} />}
-        />
-        <Route path={routes['group-detail-members']} component={GroupPrincipals} />
-        <Route render={() => <Redirect to={`/groups/detail/${uuid}/roles`} />} />
-      </Switch>
+      <Route
+        path={[routes['group-detail-roles-remove'], routes['group-detail-members-remove']]}
+        render={(props) => (
+          <RemoveGroup
+            {...props}
+            postMethod={() => {
+              dispatch(fetchGroups());
+            }}
+            isModalOpen
+            groupsUuid={[group]}
+          />
+        )}
+      />
+      <Route
+        path={[routes['group-detail-roles-edit'], routes['group-detail-members-edit']]}
+        render={(props) => (
+          <EditGroup
+            {...props}
+            isOpen
+            group={group}
+            closeUrl={`group/detail/${uuid}`}
+            postMethod={() => {
+              fetchData(uuid);
+            }}
+          />
+        )}
+      />
+      <Route
+        path={routes['group-detail-roles']}
+        render={(props) => <GroupRoles {...props} onDefaultGroupChanged={setShowDefaultGroupChangedInfo} />}
+      />
+      <Route path={routes['group-detail-members']} component={GroupPrincipals} />
+      <Route render={() => <Redirect to={`/groups/detail/${uuid}/roles`} />} />
       {!group && <ListLoader />}
     </Fragment>
   );

--- a/src/smart-components/role/edit-role-modal.js
+++ b/src/smart-components/role/edit-role-modal.js
@@ -8,6 +8,7 @@ import useIsMounted from '../../hooks/useIsMounted';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { roleSelector } from './role-selectors';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/';
 import { fetchRole, fetchRoles } from '../../helpers/role/role-helper';
 import asyncDebounce from '../../utilities/async-debounce';
 import { updateRole } from '../../redux/actions/role-actions';
@@ -64,7 +65,19 @@ const EditRoleModal = ({ routeMatch, cancelRoute, afterSubmit }) => {
   const role = useSelector((state) => roleSelector(state, id));
   const [initialValues, setInitialValues] = useState(role);
 
-  const onCancel = () => replace(cancelRoute);
+  const onCancel = () => {
+    dispatch(
+      addNotification({
+        variant: 'warning',
+        dismissDelay: 8000,
+        dismissable: false,
+        title: 'Editing role',
+        description: 'Edit role was canceled by the user.',
+      })
+    );
+    replace(cancelRoute);
+  };
+
   const handleSubmit = (data) =>
     dispatch(updateRole(id, { ...data, display_name: data.name })).then(() => {
       afterSubmit();


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9499

_1. When editing the name/description of a group, the primary button says "Submit", but when editing the name/description of a role, the primary button says "Save". Since role editing was more recent, I'm guessing "Save" is the proper title here._ 
**Seems to be already fixed**
![01](https://user-images.githubusercontent.com/50696716/99506368-4b417380-2982-11eb-89b3-965c47f66a5a.png)

_2. When editing a group (either by changing name/description or adding roles/members),  a success notification appears when changes are successful. When the user cancels the edit, a warning notification appears. However, no such notification appears for custom roles._
**Added the notification**
![000](https://user-images.githubusercontent.com/50696716/99506680-aecba100-2982-11eb-8812-f7272e003f15.png)
![001](https://user-images.githubusercontent.com/50696716/99507179-5943c400-2983-11eb-89f3-7fa8ff15f652.png)
![2](https://user-images.githubusercontent.com/50696716/99508171-99f00d00-2984-11eb-9e60-c3e7b21e1ffd.png)
**...also added missing failure notification for removing a role**
![1](https://user-images.githubusercontent.com/50696716/99507909-441b6500-2984-11eb-89b8-78310559b8b6.png)


_...3. and 4. already fixed/not issues_

_5. Kebab on the details page of custom roles should also be on the details page of custom groups_
**Added the kebab with edit & remove actions**
![00](https://user-images.githubusercontent.com/50696716/99506900-02d68580-2983-11eb-87ca-3914be126859.png)

_6. When removing more than 1 permission at a time, only the first permission is displayed in the modal text. According to the mocks, the number of permissions should be shown._ 
**Fixed in:** 
https://github.com/RedHatInsights/insights-rbac-ui/pull/482/files

@mmenestr