### PR TITLE
Use ref for popover root instead of HTML element.

### DIFF
--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -1,12 +1,40 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+const DefaultPlatformPopover = ({ uuid }) => {
+  const [isPopoverVisible, setPopoverVisible] = useState(false);
+  const popoverRootRef = useRef(null);
+
+  return (
+    <span ref={popoverRootRef} key={`${uuid}-popover`} id="default-group-popover">
+      <Popover
+        zIndex="110"
+        position="right"
+        isVisible={isPopoverVisible}
+        shouldClose={() => setPopoverVisible(false)}
+        hideOnOutsideClick
+        bodyContent="This group contains the roles that all users in your organization inherit by default."
+        appendTo={popoverRootRef.current}
+      >
+        <OutlinedQuestionCircleIcon
+          onClick={() => setPopoverVisible(!isPopoverVisible)}
+          className={classNames('pf-c-question-circle-icon', { 'icon-active': isPopoverVisible })}
+        />
+      </Popover>
+    </span>
+  );
+};
+
+DefaultPlatformPopover.propTypes = {
+  uuid: PropTypes.string.isRequired,
+};
 
 export const createRows = (data, opened, selectedRows = []) => {
-  const [isPopoverVisible, setPopoverVisible] = useState(false);
   return data.reduce(
     (acc, { uuid, name, roleCount, principalCount, modified, platform_default: isPlatformDefault }) => [
       ...acc,
@@ -19,24 +47,7 @@ export const createRows = (data, opened, selectedRows = []) => {
               <Link key={`${uuid}-link`} to={`/groups/detail/${uuid}`}>
                 {name}
               </Link>
-              {isPlatformDefault && (
-                <span key={`${uuid}-popover`} id="default-group-popover">
-                  <Popover
-                    zIndex="110"
-                    position="right"
-                    isVisible={isPopoverVisible}
-                    shouldClose={() => setPopoverVisible(false)}
-                    hideOnOutsideClick={true}
-                    bodyContent="This group contains the roles that all users in your organization inherit by default."
-                    appendTo={document.getElementById('default-group-popover')}
-                  >
-                    <OutlinedQuestionCircleIcon
-                      onClick={() => setPopoverVisible(!isPopoverVisible)}
-                      className={classNames('pf-c-question-circle-icon', { 'icon-active': isPopoverVisible })}
-                    />
-                  </Popover>
-                </span>
-              )}
+              {isPlatformDefault && <DefaultPlatformPopover uuid={uuid} />}
             </div>
           </Fragment>,
           roleCount,


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-10594

The UI was crashing because the popover root (span) was not rendered in DOM because the first render did not happen yet but the popover was still opened. I have moved the opened state to the child component so it gets reset when the popover is destroyed and also used ref instead of `document` API to find the element.

![popover-crash](https://user-images.githubusercontent.com/22619452/99511223-48498180-2988-11eb-8ac2-875ef98240db.gif)

