### PR TITLE
Rename "(Custom) default user access" group

### DIFF
--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -53,8 +53,8 @@ const Group = ({
           aria-label="default-group-icon"
           bodyContent={
             <div>
-              Now that you have edited the <b>Default user access</b> group, the system will no longer update it with new default access roles. The
-              group name has changed to <b>Custom default user access</b>.
+              Now that you have edited the <b>Default access</b> group, the system will no longer update it with new default access roles. The group
+              name has changed to <b>Custom default access</b>.
             </div>
           }
         >
@@ -100,12 +100,12 @@ const Group = ({
           <Alert
             variant="info"
             isInline
-            title="Default user access group has changed"
+            title="Default access group has changed"
             action={<AlertActionCloseButton onClose={() => setShowDefaultGroupChangedInfo(false)} />}
             className="pf-u-mb-lg pf-u-mt-sm"
           >
-            Now that you have edited the <b>Default user access</b> group, the system will no longer update it with new default access roles. The
-            group name has changed to <b>Custom default user access</b>.
+            Now that you have edited the <b>Default access</b> group, the system will no longer update it with new default access roles. The group
+            name has changed to <b>Custom default access</b>.
           </Alert>
         ) : null}
       </TopToolbar>

--- a/src/smart-components/group/role/default-group-change-modal.js
+++ b/src/smart-components/group/role/default-group-change-modal.js
@@ -9,8 +9,8 @@ const DefaultGroupChange = ({ isOpen, onClose, onSubmit }) => {
       text={
         <TextContent>
           <Text>
-            Once you edit the <b>Default user access</b> group, the system will no longer update it with new default access roles. The group name will
-            change to <b>Custom default user access</b>.
+            Once you edit the <b>Default access</b> group, the system will no longer update it with new default access roles. The group name will
+            change to <b>Custom default access</b>.
           </Text>
         </TextContent>
       }

--- a/src/test/smart-components/group/add-group-roles.test.js
+++ b/src/test/smart-components/group/add-group-roles.test.js
@@ -31,7 +31,7 @@ describe('<AddGroupRoles />', () => {
             },
           },
           uuid: '1234',
-          name: 'Custom default user access',
+          name: 'Custom default access',
           system: false,
           roles: [],
         },

--- a/src/test/smart-components/group/groups.test.js
+++ b/src/test/smart-components/group/groups.test.js
@@ -26,7 +26,7 @@ describe('<Groups />', () => {
       data: [
         {
           uuid: '19eccddf-7e6a-41a2-b050-3e67f0af4ed1',
-          name: 'Custom default user access',
+          name: 'Custom default access',
           description: 'Default group that contains default permissions for new users.',
           principalCount: 0,
           platform_default: true,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-8201

Renamed "Default user access" and "Custom default user access" group as "Default access" or "Custom default access" in UI.

![001](https://user-images.githubusercontent.com/50696716/99511125-25b76880-2988-11eb-8f54-db8665766301.png)

![002](https://user-images.githubusercontent.com/50696716/99511130-2819c280-2988-11eb-9bf9-470237143761.png)

@mmenestr