### PR TITLE
Use correct fallback route when not in beta env.

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -28,8 +28,10 @@ export const Routes = () => {
         <InsightsRoute path={routes.groups} component={Groups} rootClass="groups" />
         <InsightsRoute path={routes.roles} component={Roles} rootClass="roles" />
         <InsightsRoute path={routes.users} component={Users} rootClass="users" />
-        <InsightsRoute path={[routes.myUserAccess, routes.rbac]} component={MyUserAccess} rootClass="myUserAccess" />
-        <Route render={() => <Redirect to={routes.myUserAccess} />} />
+        <InsightsRoute path={routes['my-user-access']} component={MyUserAccess} rootClass="myUserAccess" />
+        <Route>
+          <Redirect to={window.insights.chrome.isBeta() ? routes['my-user-access'] : routes.groups} />
+        </Route>
       </Switch>
     </Suspense>
   );


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-10644

### Changes
- MUA route was path was `undefined` because of wrong value key from paths definition
- the fallback route was always pointing towards MUA route
  - now it points to groups if the app is not in beta env