### PR TITLE
Fix bulk select semi selected state

### DIFF
--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -23,10 +23,7 @@ export const mappedProps = (apiProps) =>
 export const debouncedFetch = debouncePromise((callback) => callback());
 
 export const calculateChecked = (rows = [], selected) => {
-  return (
-    (rows.length !== 0 && rows.every(({ uuid }) => selected.find((row) => row.uuid === uuid))) ||
-    (rows.length !== 0 && rows.some(({ uuid }) => selected.find((row) => row.uuid === uuid)) ? null : false)
-  );
+  return (rows.length !== 0 && rows.every(({ uuid }) => selected.find((row) => row.uuid === uuid))) || (selected.length > 0 ? null : false);
 };
 
 export const selectedRows = (newSelection, isSelected) => (selected) => {

--- a/src/test/presentional-components/shared/__snapshots__/toolbar.test.js.snap
+++ b/src/test/presentional-components/shared/__snapshots__/toolbar.test.js.snap
@@ -86,7 +86,7 @@ exports[`<Toolbar> checkedRows is loading - false NO DATA 1`] = `
   }
   bulkSelect={
     Object {
-      "checked": false,
+      "checked": null,
       "count": 1,
       "items": Array [
         Object {
@@ -205,7 +205,7 @@ exports[`<Toolbar> checkedRows is loading - true NO DATA 1`] = `
   }
   bulkSelect={
     Object {
-      "checked": false,
+      "checked": null,
       "count": 1,
       "items": Array [
         Object {


### PR DESCRIPTION
When there are items selected on different page than currently displayed, bulk select doesn't shows empty checkbox. This pr changes bulk select behavior to show empty checkbox when 0 items are selected. Show check when all items on current page are displayed (not changed). And if there is at least one item selected, on any page it shows semi selected state.

IMPORTANT: This changes bulk select for the whole RBAC.

Short video is attached to Jira.
@mmenestr 
https://issues.redhat.com/browse/RHCLOUD-10372