### PR TITLE
Add entryDelay to disabled row tooltip

### DIFF
--- a/src/smart-components/role/add-role-new/DisabledRowWrapper.js
+++ b/src/smart-components/role/add-role-new/DisabledRowWrapper.js
@@ -12,7 +12,8 @@ export const DisabledRowWrapper = ({ row, ...props }) =>
           <a href="./settings/sources">Configure sources for Cost Management</a>
         </div>
       }
-      exitDelay={2000}
+      exitDelay={1500}
+      entryDelay={1500}
     >
       <RowWrapper className="ins-c-rbac-disabled-row" row={row} {...props} />
     </Tooltip>


### PR DESCRIPTION
Add 1500 ms entry delay and change exit delay to 1500ms, so there is only one tooltip displayed at the time.

https://issues.redhat.com/browse/RHCLOUD-10914