### PR TITLE
Fix infinit loading when no splats are calculated

### DIFF
--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -166,7 +166,7 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
     }
 
     const basePermissions = baseRole?.access || [];
-    if (expandedPermissions.length === 0) {
+    if (expandedPermissions.length === 0 && typeof isLoadingExpandSplats === 'undefined') {
       const applications = [...new Set(basePermissions.map(({ permission }) => permission.split(':')[0]))];
       dispatch(expandSplats({ application: applications.join() }));
     } else {


### PR DESCRIPTION
### Inifinite loading when no splats calculated

When copying role with no splats the wizard ends in infinite loop of trying to calculate splats. This is caused because API returns empty array and we think that the splats were not calculated so we try to fetch it again and end in inifinite loop.

Fixes: RHCLOUD-10913