### PR TITLE
Use display name for roles sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4293,9 +4293,9 @@
       }
     },
     "@redhat-cloud-services/rbac-client": {
-      "version": "1.0.86",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.86.tgz",
-      "integrity": "sha512-IYLQH1dovp19iJLSEHT3pAFz6187i+T7Tq6vnXVQ+r0uHeX7+O8lIPYBgKze9Z7LkkRkg9HKGVg7Wx5CcaZHwQ==",
+      "version": "1.0.87",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.87.tgz",
+      "integrity": "sha512-HuN3364m11kTUlSogJXvqr+C6LTa4MYPnSgDzpSyWl79M1NRB9IShL8ChyuwPC+BjiP1XCUAgqDjB3TNqN8V5A==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4293,9 +4293,9 @@
       }
     },
     "@redhat-cloud-services/rbac-client": {
-      "version": "1.0.78",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.78.tgz",
-      "integrity": "sha512-zoSXvhNzAsSNB1fVakxJCPBasgTCI7KP63WtbgkmcT2QBLCeALZqabdm8uDcyLShwWi8pifHzdhBnFppe+AfLQ==",
+      "version": "1.0.86",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.86.tgz",
+      "integrity": "sha512-IYLQH1dovp19iJLSEHT3pAFz6187i+T7Tq6vnXVQ+r0uHeX7+O8lIPYBgKze9Z7LkkRkg9HKGVg7Wx5CcaZHwQ==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@redhat-cloud-services/frontend-components": "2.4.9",
     "@redhat-cloud-services/frontend-components-notifications": "2.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "2.2.7",
-    "@redhat-cloud-services/rbac-client": "^1.0.86",
+    "@redhat-cloud-services/rbac-client": "^1.0.87",
     "axios-mock-adapter": "^1.18.1",
     "babel-loader": "^8.1.0",
     "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@redhat-cloud-services/frontend-components": "2.4.9",
     "@redhat-cloud-services/frontend-components-notifications": "2.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "2.2.7",
-    "@redhat-cloud-services/rbac-client": "^1.0.78",
+    "@redhat-cloud-services/rbac-client": "^1.0.86",
     "axios-mock-adapter": "^1.18.1",
     "babel-loader": "^8.1.0",
     "classnames": "^2.2.6",

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -49,7 +49,7 @@ export async function addPrincipalsToGroup(groupId, users) {
 }
 
 export async function fetchRolesForGroup(groupId, excluded, { limit, offset, name, description }, options = {}) {
-  return await groupApi.listRolesForGroup(groupId, excluded, name, description, limit, offset, undefined, options);
+  return await groupApi.listRolesForGroup(groupId, excluded, name, description, limit, offset, 'display_name', options);
 }
 
 export async function deleteRolesFromGroup(groupId, roles) {

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -6,17 +6,34 @@ export async function createRole(data) {
   return await roleApi.createRoles(data);
 }
 
-export function fetchRoles({ limit, offset, name, nameMatch, scope, orderBy, addFields, username, application, permission, options }) {
+export function fetchRoles({
+  limit,
+  offset,
+  name,
+  nameMatch,
+  scope,
+  orderBy = 'display_name',
+  addFields,
+  username,
+  application,
+  permission,
+  options,
+}) {
   return roleApi.listRoles(limit, offset, name, nameMatch, scope, orderBy, addFields, username, application, permission, options);
 }
 
+/**
+ * TO DO: filter by display_name when possible
+ * Roles endpoint currently does not allow filtering by display_name
+ * see: https://github.com/RedHatInsights/insights-rbac/blob/master/docs/source/specs/openapi.json#L1111
+ */
 export async function fetchRolesWithPolicies({
   limit,
   offset,
   name,
   nameMatch,
   scope = 'account',
-  orderBy,
+  orderBy = 'display_name',
   addFields = ['groups_in_count'],
   username,
   options,

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -19,14 +19,9 @@ export function fetchRoles({
   permission,
   options,
 }) {
-  return roleApi.listRoles(limit, offset, name, nameMatch, scope, orderBy, addFields, username, application, permission, options);
+  return roleApi.listRoles(limit, offset, undefined, name, nameMatch, scope, orderBy, addFields, username, application, permission, options);
 }
 
-/**
- * TO DO: filter by display_name when possible
- * Roles endpoint currently does not allow filtering by display_name
- * see: https://github.com/RedHatInsights/insights-rbac/blob/master/docs/source/specs/openapi.json#L1111
- */
 export async function fetchRolesWithPolicies({
   limit,
   offset,
@@ -41,7 +36,7 @@ export async function fetchRolesWithPolicies({
   application,
 }) {
   return {
-    ...(await roleApi.listRoles(limit, offset, name, nameMatch, scope, orderBy, addFields, username, application, permission, options)),
+    ...(await roleApi.listRoles(limit, offset, undefined, name, nameMatch, scope, orderBy, addFields, username, application, permission, options)),
     ...(await insights.chrome.auth.getUser()),
   };
 }

--- a/src/smart-components/myUserAccess/MUARolesTable.js
+++ b/src/smart-components/myUserAccess/MUARolesTable.js
@@ -139,6 +139,7 @@ const MUARolesTable = ({
         fetchData={({ limit, offset, name, application, permission, orderBy = 'display_name' }) => {
           debouncedFetch(limit, offset, name, application, permission, orderBy);
         }}
+        sortBy={{ index: 0, direction: 'asc' }}
         setFilterValue={setFilters}
         isLoading={isLoading}
         pagination={roles.meta}

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -117,6 +117,7 @@ const Roles = () => {
         <Section type="content" id={'tab-roles'}>
           <TableToolbarView
             actionResolver={actionResolver}
+            sortBy={{ index: 0, direction: 'asc' }}
             columns={columns}
             createRows={createRows}
             data={roles}

--- a/src/test/role/__snapshots__/roles.test.js.snap
+++ b/src/test/role/__snapshots__/roles.test.js.snap
@@ -77,6 +77,12 @@ exports[`<Roles /> should render correctly 1`] = `
   routes={[Function]}
   setCheckedItems={[Function]}
   setFilterValue={[Function]}
+  sortBy={
+    Object {
+      "direction": "asc",
+      "index": 0,
+    }
+  }
   titlePlural="roles"
   titleSingular="role"
   toolbarButtons={[Function]}
@@ -166,6 +172,12 @@ exports[`<Roles /> should render correctly in org admin 1`] = `
   routes={[Function]}
   setCheckedItems={[Function]}
   setFilterValue={[Function]}
+  sortBy={
+    Object {
+      "direction": "asc",
+      "index": 0,
+    }
+  }
   titlePlural="roles"
   titleSingular="role"
   toolbarButtons={[Function]}

--- a/src/test/role/roles.test.js
+++ b/src/test/role/roles.test.js
@@ -131,6 +131,7 @@ describe('<Roles />', () => {
       wrapper.find('span.pf-c-table__sort-indicator').first().simulate('click');
     });
     expect(fetchRolesWithPoliciesSpy).toHaveBeenCalledTimes(2);
-    expect(fetchRolesWithPoliciesSpy).toHaveBeenLastCalledWith({ limit: 20, orderBy: 'display_name' });
+    expect(fetchRolesWithPoliciesSpy).toHaveBeenNthCalledWith(1, { name: '' });
+    expect(fetchRolesWithPoliciesSpy).toHaveBeenNthCalledWith(2, { limit: 20, orderBy: '-display_name' });
   });
 });


### PR DESCRIPTION
~~waiting for: https://github.com/RedHatInsights/insights-rbac/pull/380~~

jira: https://issues.redhat.com/browse/RHCLOUD-10219

### Changes
- set display name as a default sorting attribute for roles
- add default `sortBy` prop roles tables (user had to click twice to start ordering in descending order before)
- use display_name to filter roles
