### PR TITLE
Hide add permission button in non beta and for system roles.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -10,10 +10,6 @@
     font-weight: var(--pf-global--FontWeight--bold);
 }
 
-.pf-c-toolbar .pf-c-dropdown__menu .ins-c-primary-toolbar__first-action {
-  display: none;
-}
-
 @media only screen and (max-width: 768px) {
   .ins-m-hide-on-sm {display: none;}
 

--- a/src/smart-components/role/role-permissions.js
+++ b/src/smart-components/role/role-permissions.js
@@ -141,7 +141,7 @@ const Permissions = () => {
   ];
 
   const toolbarButtons = () => [
-    window.insights.chrome.isBeta()
+    ...(window.insights.chrome.isBeta() && !role.system
       ? [
           // eslint-disable-next-line react/jsx-key
           <Link to={`/roles/detail/${role.uuid}/role-add-permission`} key="role-add-permission" className="pf-m-visible-on-md">
@@ -149,17 +149,17 @@ const Permissions = () => {
               Add Permission
             </Button>
           </Link>,
+          {
+            label: 'Add Permission',
+            props: {
+              className: 'pf-m-hidden-on-md',
+            },
+            onClick: () => {
+              history.push(`/roles/detail/${role.uuid}/role-add-permission`);
+            },
+          },
         ]
-      : [],
-    {
-      label: 'Add Permission',
-      props: {
-        className: 'pf-m-hidden-on-md',
-      },
-      onClick: () => {
-        history.push(`/roles/detail/${role.uuid}/role-add-permission`);
-      },
-    },
+      : []),
     {
       label: 'Remove',
       props: {

--- a/src/smart-components/role/role-permissions.js
+++ b/src/smart-components/role/role-permissions.js
@@ -140,10 +140,9 @@ const Permissions = () => {
     },
   ];
 
-  const toolbarButtons = () => [
-    ...(window.insights.chrome.isBeta() && !role.system
+  const toolbarButtons = () =>
+    window.insights.chrome.isBeta() && !role.system
       ? [
-          // eslint-disable-next-line react/jsx-key
           <Link to={`/roles/detail/${role.uuid}/role-add-permission`} key="role-add-permission" className="pf-m-visible-on-md">
             <Button variant="primary" aria-label="Add Permission">
               Add Permission
@@ -158,31 +157,30 @@ const Permissions = () => {
               history.push(`/roles/detail/${role.uuid}/role-add-permission`);
             },
           },
-        ]
-      : []),
-    {
-      label: 'Remove',
-      props: {
-        isDisabled: !selectedPermissions.length > 0,
-      },
-      onClick: () => {
-        const multiplePermissionsSelected = selectedPermissions.length > 1;
-        internalDispatch({
-          type: INITIATE_REMOVE_PERMISSION,
-          confirmDelete: () => () => removePermissions([...selectedPermissions]),
-          deleteInfo: {
-            title: multiplePermissionsSelected ? 'Remove permissions?' : 'Remove permission?',
-            text: removeModalText(
-              multiplePermissionsSelected ? selectedPermissions.length : selectedPermissions[0].uuid,
-              role,
-              selectedPermissions.length > 1
-            ),
-            confirmButtonLabel: multiplePermissionsSelected ? 'Remove permissions' : 'Remove permission',
+          {
+            label: 'Remove',
+            props: {
+              isDisabled: !selectedPermissions.length > 0,
+            },
+            onClick: () => {
+              const multiplePermissionsSelected = selectedPermissions.length > 1;
+              internalDispatch({
+                type: INITIATE_REMOVE_PERMISSION,
+                confirmDelete: () => () => removePermissions([...selectedPermissions]),
+                deleteInfo: {
+                  title: multiplePermissionsSelected ? 'Remove permissions?' : 'Remove permission?',
+                  text: removeModalText(
+                    multiplePermissionsSelected ? selectedPermissions.length : selectedPermissions[0].uuid,
+                    role,
+                    selectedPermissions.length > 1
+                  ),
+                  confirmButtonLabel: multiplePermissionsSelected ? 'Remove permissions' : 'Remove permission',
+                },
+              });
+            },
           },
-        });
-      },
-    },
-  ];
+        ]
+      : [];
 
   const routes = () => (
     <Route exact path={paths['role-add-permission']}>

--- a/src/smart-components/role/role-permissions.js
+++ b/src/smart-components/role/role-permissions.js
@@ -141,45 +141,47 @@ const Permissions = () => {
   ];
 
   const toolbarButtons = () => [
-    ...[
-      // eslint-disable-next-line react/jsx-key
-      <Link to={`/roles/detail/${role.uuid}/role-add-permission`} key="role-add-permission" className="pf-m-visible-on-md">
-        <Button variant="primary" aria-label="Add Permission">
-          Add Permission
-        </Button>
-      </Link>,
-      {
-        label: 'Add Permission',
-        props: {
-          className: 'pf-m-hidden-on-md',
-        },
-        onClick: () => {
-          history.push(`/roles/detail/${role.uuid}/role-add-permission`);
-        },
+    window.insights.chrome.isBeta()
+      ? [
+          // eslint-disable-next-line react/jsx-key
+          <Link to={`/roles/detail/${role.uuid}/role-add-permission`} key="role-add-permission" className="pf-m-visible-on-md">
+            <Button variant="primary" aria-label="Add Permission">
+              Add Permission
+            </Button>
+          </Link>,
+        ]
+      : [],
+    {
+      label: 'Add Permission',
+      props: {
+        className: 'pf-m-hidden-on-md',
       },
-      {
-        label: 'Remove',
-        props: {
-          isDisabled: !selectedPermissions.length > 0,
-        },
-        onClick: () => {
-          const multiplePermissionsSelected = selectedPermissions.length > 1;
-          internalDispatch({
-            type: INITIATE_REMOVE_PERMISSION,
-            confirmDelete: () => () => removePermissions([...selectedPermissions]),
-            deleteInfo: {
-              title: multiplePermissionsSelected ? 'Remove permissions?' : 'Remove permission?',
-              text: removeModalText(
-                multiplePermissionsSelected ? selectedPermissions.length : selectedPermissions[0].uuid,
-                role,
-                selectedPermissions.length > 1
-              ),
-              confirmButtonLabel: multiplePermissionsSelected ? 'Remove permissions' : 'Remove permission',
-            },
-          });
-        },
+      onClick: () => {
+        history.push(`/roles/detail/${role.uuid}/role-add-permission`);
       },
-    ],
+    },
+    {
+      label: 'Remove',
+      props: {
+        isDisabled: !selectedPermissions.length > 0,
+      },
+      onClick: () => {
+        const multiplePermissionsSelected = selectedPermissions.length > 1;
+        internalDispatch({
+          type: INITIATE_REMOVE_PERMISSION,
+          confirmDelete: () => () => removePermissions([...selectedPermissions]),
+          deleteInfo: {
+            title: multiplePermissionsSelected ? 'Remove permissions?' : 'Remove permission?',
+            text: removeModalText(
+              multiplePermissionsSelected ? selectedPermissions.length : selectedPermissions[0].uuid,
+              role,
+              selectedPermissions.length > 1
+            ),
+            confirmButtonLabel: multiplePermissionsSelected ? 'Remove permissions' : 'Remove permission',
+          },
+        });
+      },
+    },
   ];
 
   const routes = () => (

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -13,7 +13,6 @@ import { Section } from '@redhat-cloud-services/frontend-components';
 import Role from './role';
 import { routes as paths } from '../../../package.json';
 import EditRole from './edit-role-modal';
-import './roles.scss';
 import PageActionRoute from '../common/page-action-route';
 import ResourceDefinitions from './role-resource-definitions';
 import { Suspense } from 'react';

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -83,23 +83,9 @@ const Roles = () => {
 
   const toolbarButtons = () =>
     [
-      <Fragment key="add-role">
-        {insights.chrome.isBeta() && userIdentity?.user?.is_org_admin ? (
-          <Link to={paths['add-role']}>
-            <Button ouiaId="create-role-button" variant="primary" aria-label="Create role" className="pf-m-visible-on-md">
-              Create role
-            </Button>
-          </Link>
-        ) : (
-          <Fragment />
-        )}
-      </Fragment>,
       insights.chrome.isBeta() && userIdentity?.user?.is_org_admin
         ? {
             label: 'Create role',
-            props: {
-              className: 'pf-m-hidden-on-md',
-            },
             onClick: () => {
               push(paths['add-role']);
             },
@@ -117,6 +103,15 @@ const Roles = () => {
       <StackItem>
         <Section type="content" id={'tab-roles'}>
           <TableToolbarView
+            dedicatedAction={
+              insights.chrome.isBeta() && userIdentity?.user?.is_org_admin ? (
+                <Link to={paths['add-role']}>
+                  <Button ouiaId="create-role-button" variant="primary" aria-label="Create role" className="pf-m-visible-on-md">
+                    Create role
+                  </Button>
+                </Link>
+              ) : undefined
+            }
             actionResolver={actionResolver}
             sortBy={{ index: 0, direction: 'asc' }}
             columns={columns}

--- a/src/smart-components/role/roles.scss
+++ b/src/smart-components/role/roles.scss
@@ -1,5 +1,0 @@
-@media only screen and (min-width: 769px) {
-  .ins-c-primary-toolbar__actions {
-  	display: none;
-  }
-}

--- a/src/test/role/__snapshots__/roles.test.js.snap
+++ b/src/test/role/__snapshots__/roles.test.js.snap
@@ -149,6 +149,20 @@ exports[`<Roles /> should render correctly in org admin 1`] = `
       },
     ]
   }
+  dedicatedAction={
+    <Link
+      to="/roles/add-role"
+    >
+      <Button
+        aria-label="Create role"
+        className="pf-m-visible-on-md"
+        ouiaId="create-role-button"
+        variant="primary"
+      >
+        Create role
+      </Button>
+    </Link>
+  }
   fetchData={[Function]}
   filterItems={Array []}
   filterPlaceholder="name"


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-10977
fixes: https://issues.redhat.com/browse/RHCLOUD-11126

### Changes
- hide the add permission in non beta env
- hide the add permission button for system roles

It is missing from acceptance criteria but belongs to custom roles stuff (thanks @john-dupuy). Waiting for confirmation that we should also hide this behind the beta flag.