### PR TITLE
Remove User label from MUA header

### DIFF
--- a/src/presentational-components/myUserAccess/StatusLabel.js
+++ b/src/presentational-components/myUserAccess/StatusLabel.js
@@ -3,17 +3,14 @@ import PropTypes from 'prop-types';
 
 import { Label, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
-const StatusLabel = ({ isOrgAdmin }) => (
-  <React.Fragment>
-    {isOrgAdmin ? (
-      <Tooltip position={TooltipPosition.right} content={<span> You can manage other users&apos; permissions with &apos;User access&apos; </span>}>
-        <Label color="purple"> Org. Administrator </Label>
-      </Tooltip>
-    ) : (
-      <Label color="purple"> User </Label>
-    )}
-  </React.Fragment>
-);
+const StatusLabel = ({ isOrgAdmin }) =>
+  isOrgAdmin ? (
+    <Tooltip position={TooltipPosition.right} content={<span> You can manage other users&apos; permissions with &apos;User access&apos; </span>}>
+      <Label color="purple"> Org. Administrator </Label>
+    </Tooltip>
+  ) : (
+    <React.Fragment />
+  );
 
 StatusLabel.propTypes = {
   isOrgAdmin: PropTypes.bool,

--- a/src/test/presentional-components/myUserAccess/__snapshots__/StatusLabel.test.js.snap
+++ b/src/test/presentional-components/myUserAccess/__snapshots__/StatusLabel.test.js.snap
@@ -1,22 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<StatusLabel /> should render correctly 1`] = `
-<StatusLabel>
-  <Label
-    color="purple"
-  >
-    <span
-      className="pf-c-label pf-m-purple"
-    >
-      <span
-        className="pf-c-label__content"
-      >
-         User 
-      </span>
-    </span>
-  </Label>
-</StatusLabel>
-`;
+exports[`<StatusLabel /> should render correctly 1`] = `<StatusLabel />`;
 
 exports[`<StatusLabel /> should render correctly as admin 1`] = `
 <StatusLabel


### PR DESCRIPTION
### No need to show `User` label

We don't want to show user label (it's obvious that you are a user) and just show label if user is an org. admin.