### PR TITLE
Utils v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4281,9 +4281,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.9.tgz",
-      "integrity": "sha512-+rtCdi/fi89+DE1RO8Jvq9Vh026u9qStKagGFO+wZUspvDwAxkT3CvsOksQadocwj4J4d9znm8URHSDumBYeSw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.0.0.tgz",
+      "integrity": "sha512-i7Eh+k1/25Yrx2FZvRGAWGsMpZPUm7jYezFiyQldBIq3Dauc3lZJ2PTVNGowx8AwNZdxSIx1utRomXnMvzq76Q==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@redhat-cloud-services/cost-management-client": "^1.0.77",
     "@redhat-cloud-services/frontend-components": "2.4.9",
     "@redhat-cloud-services/frontend-components-notifications": "^3.0.0",
-    "@redhat-cloud-services/frontend-components-utilities": "2.2.9",
+    "@redhat-cloud-services/frontend-components-utilities": "^3.0.0",
     "@redhat-cloud-services/rbac-client": "^1.0.90",
     "axios-mock-adapter": "^1.18.1",
     "babel-loader": "^8.1.0",

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import store from './utilities/store';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const InsightsRbac = () => (
   <Provider store={store}>

--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -1,4 +1,4 @@
-import debouncePromise from '@redhat-cloud-services/frontend-components-utilities/files/debounce';
+import debouncePromise from '@redhat-cloud-services/frontend-components-utilities/debounce';
 
 export const scrollToTop = () =>
   document.getElementById('root').scrollTo({

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
+import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { GroupApi, PrincipalApi, RoleApi, PolicyApi, AccessApi, PermissionApi } from '@redhat-cloud-services/rbac-client';
 import { BaseAPI } from '@redhat-cloud-services/rbac-client/dist/base';
 

--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
-import debouncePromise from '@redhat-cloud-services/frontend-components-utilities/files/debounce';
+import debouncePromise from '@redhat-cloud-services/frontend-components-utilities/debounce';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { listPermissions, listPermissionOptions, expandSplats, resetExpandSplats } from '../../../redux/actions/permission-action';
 import { getResourceDefinitions } from '../../../redux/actions/cost-management-actions';

--- a/src/test/helpers/group/group-helper.test.js
+++ b/src/test/helpers/group/group-helper.test.js
@@ -1,6 +1,6 @@
 import * as GroupsHelper from '../../../helpers/group/group-helper';
 
-import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
+import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { getUserMock } from '../../../../config/setupTests';
 import * as UserLogin from '../../../helpers/shared/user-login';
 
@@ -10,7 +10,7 @@ import * as UserLogin from '../../../helpers/shared/user-login';
  * I will migrate this one to the jest mock style just for reference. Martin.
  */
 
-jest.mock('@redhat-cloud-services/frontend-components-utilities/files/interceptors', () => ({
+jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors', () => ({
   __esModule: true, // mark it as es module
   default: { get: jest.fn(), request: jest.fn(), post: jest.fn() },
 }));

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -1,7 +1,7 @@
 import promiseMiddleware from 'redux-promise-middleware';
-import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 
 import reduxLogger from 'redux-logger';
 import thunk from 'redux-thunk';


### PR DESCRIPTION
Brings in the new utils build from: https://github.com/RedHatInsights/frontend-components/pull/897

~~Also depends on: https://github.com/RedHatInsights/insights-rbac-ui/pull/638~~

Introduces about 50% size reduction for the utils package. Which is quite nice.

### Before
![Screenshot from 2021-01-20 14-51-56](https://user-images.githubusercontent.com/22619452/105184118-45594180-5b2f-11eb-8e42-f110c706a8d9.png)


### After
![Screenshot from 2021-01-20 14-45-19](https://user-images.githubusercontent.com/22619452/105184130-48ecc880-5b2f-11eb-94c4-498dbd971180.png)

Now the big bad boy of utils package is actually the Axios. Actual FEC source code has 4kb only.