### PR TITLE
fix incorrect param order in users query

### DIFF
--- a/src/helpers/user/user-helper.js
+++ b/src/helpers/user/user-helper.js
@@ -9,7 +9,7 @@ const principalStatusApiMap = {
 export function fetchUsers({ limit, offset, username, orderBy, email, status = [] }) {
   const sortOrder = orderBy === '-username' ? 'desc' : 'asc';
   const mappedStatus = status.length === 2 ? 'all' : principalStatusApiMap[status[0]] || 'all';
-  return principalApi.listPrincipals(limit, offset, username, sortOrder, email, mappedStatus).then(({ data, meta }) => {
+  return principalApi.listPrincipals(limit, offset, undefined, username, sortOrder, email, mappedStatus).then(({ data, meta }) => {
     return {
       data,
       meta: {


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/RHCLOUD-11848

There is a new `matchCriteria` argument before the username filter. That caused the wrong query to be generated.