### PR TITLE
Fix path to notification portal

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -77,7 +77,7 @@ module.exports = {
       'transform-imports',
       {
         '@redhat-cloud-services/frontend-components-notifications': {
-          transform: (importName) => `@redhat-cloud-services/frontend-components-notifications/${importName}`,
+          transform: (importName) => `@redhat-cloud-services/frontend-components-notifications/${importName}/`,
           preventFullImport: true,
         },
       },

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Routes } from './routes';
 import { Main } from '@redhat-cloud-services/frontend-components';
-import NotificationPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
+import NotificationPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal/';
 import { AppPlaceholder } from './presentational-components/shared/loader-placeholders';
 import { IntlProvider } from 'react-intl';
 import DeniedState from './presentational-components/states/DeniedState';


### PR DESCRIPTION
After one of the updates for notifications package which adds backwards compatibility to older FEC packages, there is a conflict between file path and folder path (they have the same name). And that causes the component to be `undefined` because its referencing the wrong asset (v2 asset).

Appending the path with `/` will resolve the folder (which we want) as the source of the asset.