### PR TITLE
Use composed filters when making sort requests in TableToolbar

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -160,12 +160,25 @@ export const TableToolbarView = ({
           ouiaId={ouiaId}
           onSort={(e, index, direction) => {
             setSortByState({ index, direction });
-            fetchData({
-              ...pagination,
-              offset: 0,
-              name: filterValue,
-              orderBy: `${direction === 'desc' ? '-' : ''}${columns[index - isSelectable].key}`,
-            });
+            filters && filters.length > 0
+              ? fetchData({
+                  ...pagination,
+                  offset: 0,
+                  ...filters.reduce(
+                    (acc, curr) => ({
+                      ...acc,
+                      [curr.key]: curr.value,
+                    }),
+                    {}
+                  ),
+                  orderBy: `${direction === 'desc' ? '-' : ''}${columns[index - isSelectable].key}`,
+                })
+              : fetchData({
+                  ...pagination,
+                  offset: 0,
+                  name: filterValue,
+                  orderBy: `${direction === 'desc' ? '-' : ''}${columns[index - isSelectable].key}`,
+                });
           }}
         >
           {!hideHeader && <TableHeader />}
@@ -222,6 +235,7 @@ TableToolbarView.propTypes = {
   hideFilterChips: propTypes.bool,
   hideHeader: propTypes.bool,
   noDataDescription: propTypes.arrayOf(propTypes.node),
+  filters: propTypes.array,
 };
 
 TableToolbarView.defaultProps = {

--- a/src/test/smart-components/user/users.test.js
+++ b/src/test/smart-components/user/users.test.js
@@ -103,7 +103,6 @@ describe('<Users />', () => {
     expect(fetchUsersSpy).toHaveBeenLastCalledWith({
       count: 39,
       limit: 10,
-      name: [],
       orderBy: '-username',
       status: ['Active'],
     });


### PR DESCRIPTION
It worked for simple filters where you are filtering by name (Roles,Groups) but when there was multiple different filters present. Sort request didn't reflect that. Now onSort request are using same logic as onFIliter requests.

https://issues.redhat.com/browse/RHCLOUD-11475
https://issues.redhat.com/browse/RHCLOUD-11553