### PR TITLE
Fix group name validation

### DIFF
--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -12,6 +12,7 @@ import { addGroup } from '../../../redux/actions/group-actions';
 import SetRoles from './set-roles';
 import SetUsers from './set-users';
 import SummaryContent from './summary-content';
+import { debouncedAsyncValidator } from '../validators';
 
 const FormTemplate = (props) => <Pf4FormTemplate {...props} showFormControls={false} />;
 
@@ -78,6 +79,10 @@ const AddGroupWizard = ({ postMethod }) => {
       });
   };
 
+  const validatorMapper = {
+    'validate-group-name': ({ idKey, id }) => (value) => debouncedAsyncValidator(value, idKey, id),
+  };
+
   return cancelWarningVisible ? (
     <WarningModal
       type="group"
@@ -90,6 +95,7 @@ const AddGroupWizard = ({ postMethod }) => {
       schema={schema}
       subscription={{ values: true }}
       FormTemplate={FormTemplate}
+      validatorMapper={validatorMapper}
       componentMapper={{ ...componentMapper, ...mapperExtension }}
       onSubmit={onSubmit}
       initialValues={groupData}

--- a/src/smart-components/group/add-group/schema.js
+++ b/src/smart-components/group/add-group/schema.js
@@ -6,11 +6,11 @@ export default {
   fields: [
     {
       component: 'wizard',
-      name: 'wizzard',
+      name: 'wizard',
       isDynamic: true,
       inModal: true,
       showTitles: true,
-      title: 'Create role',
+      title: 'Create group',
       fields: [
         {
           name: 'name-and-description',
@@ -20,8 +20,8 @@ export default {
             {
               component: componentTypes.TEXT_FIELD,
               name: 'group-name',
-              type: 'text',
               label: 'Group name',
+              isRequired: true,
               validate: [
                 debouncedAsyncValidator,
                 {

--- a/src/smart-components/group/add-group/schema.js
+++ b/src/smart-components/group/add-group/schema.js
@@ -1,6 +1,5 @@
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/esm/validator-types';
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/esm/component-types';
-import { debouncedAsyncValidator } from '../validators';
 
 export default {
   fields: [
@@ -23,7 +22,7 @@ export default {
               label: 'Group name',
               isRequired: true,
               validate: [
-                debouncedAsyncValidator,
+                { type: 'validate-group-name' },
                 {
                   type: validatorTypes.REQUIRED,
                 },

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -162,7 +162,6 @@ const Group = ({
         render={(props) => (
           <EditGroup
             {...props}
-            isOpen
             group={group}
             closeUrl={`group/detail/${uuid}`}
             postMethod={() => {

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -77,7 +77,6 @@ const Groups = () => {
             dispatch(fetchGroups(config));
             setFilterValue('');
           }}
-          isOpen
         />
       </Route>
       <Route exact path={paths['remove-group']}>

--- a/src/smart-components/group/validators.js
+++ b/src/smart-components/group/validators.js
@@ -15,7 +15,7 @@ const asyncValidator = async (groupName, idKey, id) => {
     return undefined;
   });
 
-  if (response?.data?.some((item) => item[idKey] !== id)) {
+  if (id ? response?.data?.some((item) => item[idKey] !== id) : response?.data?.length > 0) {
     throw 'Name has already been taken.';
   }
 

--- a/src/smart-components/group/validators.js
+++ b/src/smart-components/group/validators.js
@@ -1,7 +1,7 @@
 import { fetchGroups } from '../../helpers/group/group-helper';
 import asyncDebounce from '../../utilities/async-debounce';
 
-export const asyncValidator = async (groupName) => {
+const asyncValidator = async (groupName, idKey, id) => {
   if (!groupName) {
     return undefined;
   }
@@ -15,11 +15,11 @@ export const asyncValidator = async (groupName) => {
     return undefined;
   });
 
-  if (response?.data?.length > 0) {
-    throw 'Name has already been taken';
+  if (response?.data?.some((item) => item[idKey] !== id)) {
+    throw 'Name has already been taken.';
   }
 
   return undefined;
 };
 
-export const debouncedAsyncValidator = asyncDebounce(asyncValidator);
+export const debouncedAsyncValidator = asyncDebounce((value, idKey, id) => asyncValidator(value, idKey, id));

--- a/src/test/smart-components/group/__snapshots__/edit-group-modal.test.js.snap
+++ b/src/test/smart-components/group/__snapshots__/edit-group-modal.test.js.snap
@@ -34,7 +34,7 @@ exports[`<EditGroupModal /> should render correctly 1`] = `
 >
   <Connect(EditGroupModal)
     closeUrl="/groups"
-    groupData={
+    group={
       Object {
         "id": "1",
         "name": "Foo",

--- a/src/test/smart-components/group/edit-group-modal.test.js
+++ b/src/test/smart-components/group/edit-group-modal.test.js
@@ -5,7 +5,6 @@ import { Provider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import { shallowToJson } from 'enzyme-to-json';
-import { Button } from '@patternfly/react-core';
 import { MemoryRouter, Route } from 'react-router-dom';
 import promiseMiddleware from 'redux-promise-middleware';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
@@ -31,7 +30,7 @@ describe('<EditGroupModal />', () => {
   beforeEach(() => {
     initialProps = {
       closeUrl: '/groups',
-      groupData: {
+      group: {
         name: 'Foo',
         id: '1',
       },
@@ -70,13 +69,13 @@ describe('<EditGroupModal />', () => {
     await act(async () => {
       wrapper = mount(
         <GroupWrapper store={store} initialEntries={['/groups/edit/:id']}>
-          <Route to="/groups/edit/:id" render={(args) => <EditGroupModal {...initialProps} {...args} isOpen />} />
+          <Route to="/groups/edit/:id" render={(args) => <EditGroupModal {...initialProps} {...args} />} />
         </GroupWrapper>
       );
     });
     wrapper.update();
 
-    wrapper.find(Button).first().simulate('click');
+    wrapper.find('button').first().simulate('click');
     expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/groups');
   });
 });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-12166

- fixed group's name validation so that submit button is enabled only if the form is valid
- removed unnecessary modal on loading and replaced with skeletons
- added ModalFormTemplate usage (+ made some further refactoring and code cleaning)
- fixed wrong Add group wizard's title 
- updated tests

@john-dupuy please verify not only the edit group modal but also group name validation in Add group wizard. The changes affect it as well so that we make sure that everything really works. Thank you