### PR TITLE
Serve from http

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -5,7 +5,7 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
-  https: true,
+  https: false,
   sassPrefix: '.rbac, .my-user-access',
 });
 


### PR DESCRIPTION
Webpack proxy can route to https because of invalid certs