### PR TITLE
Use static ouia id for create role button.

### DIFF
--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -89,6 +89,9 @@ const Roles = () => {
             onClick: () => {
               push(paths['add-role']);
             },
+            props: {
+              ouiaId: 'create-role-button',
+            },
           }
         : undefined,
     ].filter((x) => x);


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-11997

TLDR: the pendo guide is attached to dynamically generated ouiaID which is valid only on the first render of the create role button. Static ID can fix the problem.

cc @mmenestr