### PR TITLE
Fix styling in wizards & warning modal

### DIFF
--- a/src/smart-components/common/warningModal.js
+++ b/src/smart-components/common/warningModal.js
@@ -13,7 +13,7 @@ export const WarningModal = ({ type, isOpen, onModalCancel, onConfirmCancel, cus
       </span>
     }
     variant={ModalVariant.small}
-    className="ins-c-wizard__cancel-warning"
+    className="rbac ins-c-wizard__cancel-warning"
     isOpen={isOpen}
     onClose={onModalCancel}
     actions={[

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid, GridItem, Stack, StackItem, Text, TextVariants } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
@@ -13,7 +13,7 @@ const SummaryContent = () => {
   } = formOptions.getState().values;
 
   return (
-    <Fragment>
+    <div className="rbac">
       <Stack hasGutter>
         <StackItem>
           <Stack hasGutter>
@@ -74,7 +74,7 @@ const SummaryContent = () => {
           </Stack>
         </StackItem>
       </Stack>
-    </Fragment>
+    </div>
   );
 };
 

--- a/src/smart-components/role/add-role-new/add-permissions-template.js
+++ b/src/smart-components/role/add-role-new/add-permissions-template.js
@@ -14,7 +14,7 @@ const AddPermissionTemplate = ({ formFields }) => {
     [];
   const addPermissions = formFields[0][0];
   return (
-    <React.Fragment>
+    <div className="rbac">
       {selectedPermissions.length > 0 ? (
         <div className="ins-c-rbac-seleted-chips">
           <ChipGroup categoryName="Selected permissions">
@@ -59,7 +59,7 @@ const AddPermissionTemplate = ({ formFields }) => {
           },
         ],
       ]}
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/smart-components/role/add-role-new/review-template.js
+++ b/src/smart-components/role/add-role-new/review-template.js
@@ -36,7 +36,7 @@ const ReviewTemplate = ({ formFields }) => {
   }
 
   return (
-    <React.Fragment>
+    <div className="rbac">
       <Title headingLevel="h1" size="xl" className="ins-c-rbac__gutter-sm">
         Review details
       </Title>
@@ -44,7 +44,7 @@ const ReviewTemplate = ({ formFields }) => {
         <Text>Review and confirm the details for your role, or click Back to revise.</Text>
       </TextContent>
       {[[{ ...formFields?.[0]?.[0] }]]}
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/test/role/__snapshots__/edit-resource-definitions-modal.test.js.snap
+++ b/src/test/role/__snapshots__/edit-resource-definitions-modal.test.js.snap
@@ -25,7 +25,7 @@ Array [
     aria-describedby=""
     aria-label=""
     aria-labelledby=""
-    className="ins-c-wizard__cancel-warning"
+    className="rbac ins-c-wizard__cancel-warning"
     hasNoBodyWrapper={false}
     isOpen={false}
     onClose={[Function]}
@@ -78,7 +78,7 @@ Array [
         aria-label=""
         aria-labelledby=""
         boxId="pf-modal-part-0"
-        className="ins-c-wizard__cancel-warning"
+        className="rbac ins-c-wizard__cancel-warning"
         descriptorId="pf-modal-part-2"
         hasNoBodyWrapper={false}
         isOpen={false}


### PR DESCRIPTION
This should fix not working styling in add group & add role wizards as well as in WarningModal.

![001](https://user-images.githubusercontent.com/50696716/109983438-1e338980-7d03-11eb-98a2-e14b54633f8f.png)
![002](https://user-images.githubusercontent.com/50696716/109983443-1f64b680-7d03-11eb-92c3-efb862190d94.png)
![003](https://user-images.githubusercontent.com/50696716/109983448-1f64b680-7d03-11eb-9ae1-633e05f156a5.png)


Caused by CSS scoping - needed to wrap inside elements with "rbac" className. Thanks @Hyperkid123 

@john-dupuy 
@mmenestr

