### PR TITLE
Fix cost resource step in Custom Role wizard

### DIFF
--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -153,7 +153,7 @@ const CostResources = (props) => {
             onClear={() => clearSelection(permission)}
             selections={state[permission].selected}
             isOpen={state[permission].isOpen}
-            onFilter={(e) => dispatchLocaly({ type: 'setFilter', key: permission, filtervalue: e.target.value })}
+            onFilter={(e) => e && dispatchLocaly({ type: 'setFilter', key: permission, filtervalue: e.target.value })}
             aria-labelledby={permission}
             placeholderText="Select resources"
             hasInlineFilter


### PR DESCRIPTION
When Resource step in custom roles wizard was open, on Filter was called with null. Don't filter if  `e` is null.