### PR TITLE
Persist filters and pagination in Users

### DIFF
--- a/src/helpers/shared/filters.js
+++ b/src/helpers/shared/filters.js
@@ -1,15 +1,13 @@
-export const getFiltersFromUrl = (keys, defaultValues = {}) => {
-  const searchParams = new URLSearchParams(location.search);
+export const getFiltersFromUrl = (history, keys, defaultValues = {}) => {
+  const searchParams = new URLSearchParams(history.location.search);
 
-  let filters = {};
-
-  keys.forEach((key) => {
+  let filters = keys.reduce((acc, key) => {
     const values = searchParams.getAll(key);
-    filters = {
-      ...filters,
+    return {
+      ...acc,
       [key]: values.length > 1 ? values : values[0],
     };
-  });
+  }, {});
 
   Object.keys(defaultValues).forEach((key) => {
     const value = defaultValues[key];
@@ -27,12 +25,12 @@ export const getFiltersFromUrl = (keys, defaultValues = {}) => {
     }
   });
 
-  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
   return filters;
 };
 
-export const setFiltersToUrl = (newValues) => {
-  const searchParams = new URLSearchParams(location.search);
+export const setFiltersToUrl = (history, newValues) => {
+  const searchParams = new URLSearchParams(history.location.search);
   Object.keys(newValues).forEach((key) => searchParams.delete(key));
 
   Object.keys(newValues).forEach((key) => {
@@ -45,5 +43,5 @@ export const setFiltersToUrl = (newValues) => {
     }
   });
 
-  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
 };

--- a/src/helpers/shared/filters.js
+++ b/src/helpers/shared/filters.js
@@ -1,4 +1,4 @@
-export const getFiltersFromUrl = (history, keys, defaultValues = {}) => {
+export const syncDefaultFiltersWithUrl = (history, keys, defaults = {}) => {
   const searchParams = new URLSearchParams(history.location.search);
 
   let filters = keys.reduce((acc, key) => {
@@ -9,8 +9,8 @@ export const getFiltersFromUrl = (history, keys, defaultValues = {}) => {
     };
   }, {});
 
-  Object.keys(defaultValues).forEach((key) => {
-    const value = defaultValues[key];
+  Object.keys(defaults).forEach((key) => {
+    const value = defaults[key];
     filters = {
       ...filters,
       [key]: Array.isArray(filters[key])
@@ -25,11 +25,14 @@ export const getFiltersFromUrl = (history, keys, defaultValues = {}) => {
     }
   });
 
-  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
+  history.replace({
+    pathname: history.location.pathname,
+    search: searchParams.toString(),
+  });
   return filters;
 };
 
-export const setFiltersToUrl = (history, newValues) => {
+export const applyFiltersToUrl = (history, newValues) => {
   const searchParams = new URLSearchParams(history.location.search);
   Object.keys(newValues).forEach((key) => searchParams.delete(key));
 
@@ -43,5 +46,8 @@ export const setFiltersToUrl = (history, newValues) => {
     }
   });
 
-  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
+  history.replace({
+    pathname: history.location.pathname,
+    search: searchParams.toString(),
+  });
 };

--- a/src/helpers/shared/filters.js
+++ b/src/helpers/shared/filters.js
@@ -1,0 +1,49 @@
+export const getFiltersFromUrl = (keys, defaultValues = {}) => {
+  const searchParams = new URLSearchParams(location.search);
+
+  let filters = {};
+
+  keys.forEach((key) => {
+    const values = searchParams.getAll(key);
+    filters = {
+      ...filters,
+      [key]: values.length > 1 ? values : values[0],
+    };
+  });
+
+  Object.keys(defaultValues).forEach((key) => {
+    const value = defaultValues[key];
+    filters = {
+      ...filters,
+      [key]: Array.isArray(filters[key])
+        ? [...new Set([...filters[key], ...(Array.isArray(value) ? value : [value])])]
+        : (value?.length > 0 && value) || filters[key],
+    };
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => searchParams.getAll(key).includes(item) || searchParams.append(key, item));
+    } else {
+      searchParams.get(key) || (value && searchParams.set(key, value));
+    }
+  });
+
+  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  return filters;
+};
+
+export const setFiltersToUrl = (newValues) => {
+  const searchParams = new URLSearchParams(location.search);
+  Object.keys(newValues).forEach((key) => searchParams.delete(key));
+
+  Object.keys(newValues).forEach((key) => {
+    const value = newValues[key];
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => item && searchParams.append(key, item));
+    } else {
+      value && searchParams.set(key, value);
+    }
+  });
+
+  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+};

--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -14,7 +14,7 @@ export const getCurrentPage = (limit = 1, offset = 0) => Math.floor(offset / lim
 
 export const getNewPage = (page = 1, offset) => (page - 1) * offset;
 
-export const getPaginationFromUrl = (history, defaultPagination, initialLoad) => {
+export const syncDefaultPaginationWithUrl = (history, defaultPagination, initialLoad) => {
   const searchParams = new URLSearchParams(history.location.search);
 
   isNaN(parseInt(searchParams.get('per_page'))) && searchParams.set('per_page', defaultPagination.limit);
@@ -22,13 +22,20 @@ export const getPaginationFromUrl = (history, defaultPagination, initialLoad) =>
   isNaN(parseInt(searchParams.get('page'))) && searchParams.set('page', initialLoad ? 1 : defaultPagination.offset / limit + 1);
   const offset = (parseInt(searchParams.get('page')) - 1) * limit;
 
-  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
+  history.replace({
+    pathname: history.location.pathname,
+    search: searchParams.toString(),
+  });
   return { limit, offset };
 };
 
-export const setPaginationToUrl = (history, limit, offset = 0) => {
+export const applyPaginationToUrl = (history, limit, offset = 0) => {
   const searchParams = new URLSearchParams(history.location.search);
   searchParams.set('per_page', limit);
   searchParams.set('page', offset / limit + 1);
-  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
+
+  history.replace({
+    pathname: history.location.pathname,
+    search: searchParams.toString(),
+  });
 };

--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -14,21 +14,21 @@ export const getCurrentPage = (limit = 1, offset = 0) => Math.floor(offset / lim
 
 export const getNewPage = (page = 1, offset) => (page - 1) * offset;
 
-export const getPaginationFromUrl = (defaultPagination, initialLoad) => {
-  const searchParams = new URLSearchParams(location.search);
+export const getPaginationFromUrl = (history, defaultPagination, initialLoad) => {
+  const searchParams = new URLSearchParams(history.location.search);
 
   isNaN(parseInt(searchParams.get('per_page'))) && searchParams.set('per_page', defaultPagination.limit);
   const limit = parseInt(searchParams.get('per_page'));
   isNaN(parseInt(searchParams.get('page'))) && searchParams.set('page', initialLoad ? 1 : defaultPagination.offset / limit + 1);
   const offset = (parseInt(searchParams.get('page')) - 1) * limit;
 
-  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
   return { limit, offset };
 };
 
-export const setPaginationToUrl = (limit, offset = 0) => {
-  const searchParams = new URLSearchParams(location.search);
+export const setPaginationToUrl = (history, limit, offset = 0) => {
+  const searchParams = new URLSearchParams(history.location.search);
   searchParams.set('per_page', limit);
   searchParams.set('page', offset / limit + 1);
-  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  history.replace(`${history.location.pathname}?${searchParams.toString()}`, {});
 };

--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -13,3 +13,22 @@ export const defaultCompactSettings = {
 export const getCurrentPage = (limit = 1, offset = 0) => Math.floor(offset / limit) + 1;
 
 export const getNewPage = (page = 1, offset) => (page - 1) * offset;
+
+export const getPaginationFromUrl = (defaultPagination, initialLoad) => {
+  const searchParams = new URLSearchParams(location.search);
+
+  isNaN(parseInt(searchParams.get('per_page'))) && searchParams.set('per_page', defaultPagination.limit);
+  const limit = parseInt(searchParams.get('per_page'));
+  isNaN(parseInt(searchParams.get('page'))) && searchParams.set('page', initialLoad ? 1 : defaultPagination.offset / limit + 1);
+  const offset = (parseInt(searchParams.get('page')) - 1) * limit;
+
+  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+  return { limit, offset };
+};
+
+export const setPaginationToUrl = (limit, offset = 0) => {
+  const searchParams = new URLSearchParams(location.search);
+  searchParams.set('per_page', limit);
+  searchParams.set('page', offset / limit + 1);
+  window.history.replaceState({}, '', `${location.pathname}?${searchParams.toString()}`);
+};

--- a/src/helpers/user/user-helper.js
+++ b/src/helpers/user/user-helper.js
@@ -6,7 +6,8 @@ const principalStatusApiMap = {
   Active: 'enabled',
   Inactive: 'disabled',
 };
-export function fetchUsers({ limit, offset, username, orderBy, email, status = [] }) {
+export function fetchUsers({ limit, offset, orderBy, filters = {}, inModal }) {
+  const { username, email, status = [] } = filters;
   const sortOrder = orderBy === '-username' ? 'desc' : 'asc';
   const mappedStatus = status.length === 2 ? 'all' : principalStatusApiMap[status[0]] || 'all';
   return principalApi.listPrincipals(limit, offset, undefined, username, sortOrder, email, mappedStatus).then(({ data, meta }) => {
@@ -17,6 +18,7 @@ export function fetchUsers({ limit, offset, username, orderBy, email, status = [
         offset,
         limit,
       },
+      ...(inModal ? {} : { filters }),
     };
   });
 }

--- a/src/helpers/user/user-helper.js
+++ b/src/helpers/user/user-helper.js
@@ -18,7 +18,16 @@ export function fetchUsers({ limit, offset, orderBy, filters = {}, inModal }) {
         offset,
         limit,
       },
-      ...(inModal ? {} : { filters }),
+      ...(inModal
+        ? {}
+        : {
+            filters,
+            pagination: {
+              ...meta,
+              offset,
+              limit,
+            },
+          }),
     };
   });
 }

--- a/src/redux/action-types.js
+++ b/src/redux/action-types.js
@@ -7,6 +7,7 @@ export const UPDATE_GROUP = 'UPDATE_GROUP';
 export const REMOVE_GROUPS = 'REMOVE_GROUPS';
 
 export const FETCH_USERS = 'FETCH_USERS';
+export const UPDATE_USERS_FILTERS = 'UPDATE_USERS_FILTERS';
 
 export const ADD_ROLE = 'ADD_ROLE';
 export const FETCH_ROLE = 'FETCH_ROLE';

--- a/src/redux/actions/user-actions.js
+++ b/src/redux/actions/user-actions.js
@@ -5,3 +5,8 @@ export const fetchUsers = (apiProps) => ({
   type: ActionTypes.FETCH_USERS,
   payload: UserHelper.fetchUsers(apiProps),
 });
+
+export const updateUsersFilters = (filters) => ({
+  type: ActionTypes.UPDATE_USERS_FILTERS,
+  payload: filters,
+});

--- a/src/redux/reducers/user-reducer.js
+++ b/src/redux/reducers/user-reducer.js
@@ -8,6 +8,7 @@ export const usersInitialState = {
   users: {
     meta: defaultSettings,
     filters: {},
+    pagination: defaultSettings,
   },
 };
 

--- a/src/redux/reducers/user-reducer.js
+++ b/src/redux/reducers/user-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_USERS } from '../../redux/action-types';
+import { FETCH_USERS, UPDATE_USERS_FILTERS } from '../../redux/action-types';
 import { defaultSettings } from '../../helpers/shared/pagination';
 
 // Initial State
@@ -7,14 +7,18 @@ export const usersInitialState = {
   isUserDataLoading: false,
   users: {
     meta: defaultSettings,
+    filters: {},
   },
 };
 
 const setLoadingState = (state) => ({ ...state, isUserDataLoading: true });
 
-const setUsers = (state, { payload }) => ({ ...state, users: payload, isUserDataLoading: false });
+const setUsers = (state, { payload }) => ({ ...state, users: { ...state.users, ...payload }, isUserDataLoading: false });
+
+const setFilters = (state, { payload }) => ({ ...state, users: { ...state.users, filters: payload } });
 
 export default {
   [`${FETCH_USERS}_PENDING`]: setLoadingState,
   [`${FETCH_USERS}_FULFILLED`]: setUsers,
+  [UPDATE_USERS_FILTERS]: setFilters,
 };

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { mappedProps } from '../../../helpers/shared/helpers';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 import { fetchUsers, updateUsersFilters } from '../../../redux/actions/user-actions';
@@ -70,6 +70,8 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
     offset: inModal ? users.meta.offset : users.pagination.offset || defaultSettings.offset,
   }));
 
+  const history = useHistory();
+
   const stateFilters = useSelector(({ userReducer }) => userReducer.users.filters);
 
   const [filters, setFilters] = useState({
@@ -83,8 +85,8 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
   }, [stateFilters]);
 
   useEffect(() => {
-    const pagination = inModal ? defaultSettings : getPaginationFromUrl(defaultPagination, true);
-    const fetchFilters = inModal ? { status: filters.status } : getFiltersFromUrl(['username', 'email', 'status'], filters);
+    const pagination = inModal ? defaultSettings : getPaginationFromUrl(history, defaultPagination, true);
+    const fetchFilters = inModal ? { status: filters.status } : getFiltersFromUrl(history, ['username', 'email', 'status'], filters);
     setFilters(fetchFilters);
     fetchUsers({ ...mappedProps({ ...pagination, filters: fetchFilters }), inModal });
   }, []);
@@ -113,8 +115,8 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
         const status = Object.prototype.hasOwnProperty.call(config, 'status') ? config.status : filters.status;
         const { username, email, count, limit, offset, orderBy } = config;
         fetchUsers({ ...mappedProps({ count, limit, offset, orderBy, filters: { username, email, status } }), inModal });
-        inModal || setPaginationToUrl(config.limit, config.offset);
-        inModal || setFiltersToUrl({ username, email, status });
+        inModal || setPaginationToUrl(history, config.limit, config.offset);
+        inModal || setFiltersToUrl(history, { username, email, status });
       }}
       setFilterValue={({ username, email, status }) => {
         typeof username !== 'undefined' && updateFilters({ ...filters, username });

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -65,9 +65,9 @@ const createRows = (userLinks) => (data, _expanded, checkedRows = []) => {
 };
 
 const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, pagination, selectedUsers, setSelectedUsers, userLinks, inModal, props }) => {
-  const defaultPagination = useSelector(({ userReducer }) => ({
-    limit: userReducer.users.meta.limit || defaultSettings.limit,
-    offset: userReducer.users.meta.offset || defaultSettings.offset,
+  const defaultPagination = useSelector(({ userReducer: { users } }) => ({
+    limit: inModal ? users.meta.limit : users.pagination.limit || defaultSettings.limit,
+    offset: inModal ? users.meta.offset : users.pagination.offset || defaultSettings.offset,
   }));
 
   const stateFilters = useSelector(({ userReducer }) => userReducer.users.filters);

--- a/src/smart-components/group/principal/add-group-members.js
+++ b/src/smart-components/group/principal/add-group-members.js
@@ -69,7 +69,7 @@ const AddGroupMembers = ({
           </TextContent>
         </StackItem>
         <StackItem>
-          <CompactUsersList selectedUsers={selectedUsers} setSelectedUsers={setSelectedUsers} />
+          <CompactUsersList selectedUsers={selectedUsers} setSelectedUsers={setSelectedUsers} inModal={true} />
         </StackItem>
       </Stack>
     </Modal>

--- a/src/smart-components/group/principal/add-group-members.js
+++ b/src/smart-components/group/principal/add-group-members.js
@@ -69,7 +69,7 @@ const AddGroupMembers = ({
           </TextContent>
         </StackItem>
         <StackItem>
-          <CompactUsersList selectedUsers={selectedUsers} setSelectedUsers={setSelectedUsers} inModal={true} />
+          <CompactUsersList selectedUsers={selectedUsers} setSelectedUsers={setSelectedUsers} inModal />
         </StackItem>
       </Stack>
     </Modal>

--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -58,7 +58,7 @@ const User = ({
   });
 
   useEffect(() => {
-    fetchUsers({ ...defaultSettings, limit: 0, username });
+    fetchUsers({ ...defaultSettings, limit: 0, filters: { username } });
     insights.chrome.appObjectId(username);
     return () => insights.chrome.appObjectId(undefined);
   }, []);

--- a/src/test/redux/reducers/user-reducer.test.js
+++ b/src/test/redux/reducers/user-reducer.test.js
@@ -1,4 +1,4 @@
-import userReducer, { userInitialState } from '../../../redux/reducers/user-reducer';
+import userReducer, { usersInitialState } from '../../../redux/reducers/user-reducer';
 import { callReducer } from '../redux-helpers';
 
 import { FETCH_USERS } from '../../../redux/action-types';
@@ -8,7 +8,7 @@ describe('User reducer', () => {
   const reducer = callReducer(userReducer);
 
   beforeEach(() => {
-    initialState = userInitialState;
+    initialState = usersInitialState;
   });
 
   it('should set loading state', () => {
@@ -18,7 +18,7 @@ describe('User reducer', () => {
 
   it('should set user data and loading state to false', () => {
     const payload = { data: 'Foo' };
-    const expectedState = { ...initialState, users: payload, isUserDataLoading: false };
+    const expectedState = { ...initialState, users: { ...initialState.users, ...payload }, isUserDataLoading: false };
     expect(reducer(initialState, { type: `${FETCH_USERS}_FULFILLED`, payload })).toEqual(expectedState);
   });
 });

--- a/src/test/smart-components/group/principal/add-group-principals.test.js
+++ b/src/test/smart-components/group/principal/add-group-principals.test.js
@@ -40,6 +40,7 @@ describe('<AddGroupMembers />', () => {
           meta: {
             count: 0,
           },
+          filters: {},
         },
       },
     };
@@ -102,7 +103,8 @@ describe('<AddGroupMembers />', () => {
     expect(wrapper.find(AddGroupMembers)).toHaveLength(1);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
       limit: 20,
-      status: ['Active'],
+      inModal: true,
+      filters: { status: ['Active'] },
     });
   });
 
@@ -133,7 +135,8 @@ describe('<AddGroupMembers />', () => {
     expect(store.getActions()).toEqual(expectedPayload);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
       limit: 20,
-      status: ['Active'],
+      inModal: true,
+      filters: { status: ['Active'] },
     });
   });
 });

--- a/src/test/smart-components/user/users.test.js
+++ b/src/test/smart-components/user/users.test.js
@@ -31,6 +31,7 @@ describe('<Users />', () => {
         limit: 10,
         offset: undefined,
       },
+      filters: {},
     };
     mockStore = configureStore(middlewares);
     initialState = { userReducer: { ...usersInitialState, users: enhanceState } };
@@ -55,8 +56,13 @@ describe('<Users />', () => {
     });
     expect(wrapper.find(TableToolbarView)).toHaveLength(1);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
-      limit: 20,
-      status: ['Active'],
+      limit: 10,
+      filters: {
+        status: ['Active'],
+        email: undefined,
+        username: undefined,
+      },
+      inModal: false,
     });
   });
 
@@ -74,8 +80,13 @@ describe('<Users />', () => {
     const expectedPayload = [{ type: 'FETCH_USERS_PENDING' }];
     expect(store.getActions()).toEqual(expectedPayload);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
-      limit: 20,
-      status: ['Active'],
+      limit: 10,
+      filters: {
+        status: ['Active'],
+        email: undefined,
+        username: undefined,
+      },
+      inModal: false,
     });
   });
 
@@ -104,7 +115,12 @@ describe('<Users />', () => {
       count: 39,
       limit: 10,
       orderBy: '-username',
-      status: ['Active'],
+      filters: {
+        status: ['Active'],
+        email: undefined,
+        username: undefined,
+      },
+      inModal: false,
     });
   });
 
@@ -131,6 +147,7 @@ describe('<Users />', () => {
     wrapper.update();
     const expectedPayload = [
       expect.objectContaining({ type: 'FETCH_USERS_PENDING' }),
+      expect.objectContaining({ type: 'UPDATE_USERS_FILTERS' }),
       expect.objectContaining({ type: 'FETCH_USERS_FULFILLED' }),
       expect.objectContaining({ type: 'FETCH_USERS_PENDING' }),
       expect.objectContaining({ type: 'FETCH_USERS_FULFILLED' }),
@@ -141,8 +158,8 @@ describe('<Users />', () => {
       count: 39,
       limit: 10,
       orderBy: 'username',
-      status: ['Active'],
-      username: 'something',
+      filters: { status: ['Active'], username: 'something', email: undefined },
+      inModal: false,
     });
   });
 });

--- a/src/test/smart-components/user/users.test.js
+++ b/src/test/smart-components/user/users.test.js
@@ -119,8 +119,8 @@ describe('<Users />', () => {
       orderBy: '-username',
       filters: {
         status: ['Active'],
-        email: undefined,
-        username: undefined,
+        email: '',
+        username: '',
       },
       inModal: false,
     });
@@ -160,7 +160,7 @@ describe('<Users />', () => {
       count: 39,
       limit: 10,
       orderBy: 'username',
-      filters: { status: ['Active'], username: 'something', email: undefined },
+      filters: { status: ['Active'], username: 'something', email: '' },
       inModal: false,
     });
   });

--- a/src/test/smart-components/user/users.test.js
+++ b/src/test/smart-components/user/users.test.js
@@ -11,6 +11,7 @@ import { usersInitialState } from '../../../redux/reducers/user-reducer';
 import { TableToolbarView } from '../../../presentational-components/shared/table-toolbar-view';
 
 import * as UserHelper from '../../../helpers/user/user-helper';
+import { defaultSettings } from '../../../helpers/shared/pagination';
 
 describe('<Users />', () => {
   let enhanceState;
@@ -32,6 +33,7 @@ describe('<Users />', () => {
         offset: undefined,
       },
       filters: {},
+      pagination: defaultSettings,
     };
     mockStore = configureStore(middlewares);
     initialState = { userReducer: { ...usersInitialState, users: enhanceState } };
@@ -56,7 +58,7 @@ describe('<Users />', () => {
     });
     expect(wrapper.find(TableToolbarView)).toHaveLength(1);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
-      limit: 10,
+      limit: 20,
       filters: {
         status: ['Active'],
         email: undefined,
@@ -80,7 +82,7 @@ describe('<Users />', () => {
     const expectedPayload = [{ type: 'FETCH_USERS_PENDING' }];
     expect(store.getActions()).toEqual(expectedPayload);
     expect(fetchUsersSpy).toHaveBeenCalledWith({
-      limit: 10,
+      limit: 20,
       filters: {
         status: ['Active'],
         email: undefined,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-13427
https://issues.redhat.com/browse/RHCLOUD-13426

- Created functions for pagination and filters sync with the URL
- Applied new filtering and pagination persisting to RBAC Users
- Updated tests

As long as a user remains within the "User Access" application, filters persist, regardless of whether they are editing/deleting a group/role. Pagination and filters in Group members and Add group members remain not persistent and params are not visible in URL. @mmenestr please, let me know if this behavior is right.

![pagination](https://user-images.githubusercontent.com/50696716/114538479-b9e5dd00-9c53-11eb-88c2-e9d65d78d426.png)

@john-dupuy 