### PR TITLE
Fix roles pagination on Users/Groups/Roles switching

### DIFF
--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -47,11 +47,12 @@ const Roles = () => {
   const [filterValue, setFilterValue] = useState(filters.name || '');
 
   useEffect(() => {
-    setPagination(syncDefaultPaginationWithUrl(history, pagination));
+    const syncedPagination = syncDefaultPaginationWithUrl(history, pagination);
+    setPagination(syncedPagination);
     const { name } = syncDefaultFiltersWithUrl(history, ['name'], { name: filterValue });
     setFilterValue(name);
     insights.chrome.appNavClick({ id: 'roles', secondaryNav: true });
-    fetchData({ ...pagination, filters: { name } });
+    fetchData({ ...syncedPagination, filters: { name } });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This fixes issue in new Roles pagination:

1) load Roles page
2) go to page 2 in Roles
3) go to Groups
4) go to Roles ==> URL shows page 1 but data is displayed for page 2

Now it should show page 1 correctly. Pagination change was not reflected in data fetching.