### PR TITLE
Use FED moduled access request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,32 +3735,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.11.2.tgz",
       "integrity": "sha512-uLEj6mUknX2vE1z79c28cY+/GBVh0SjS3T6s+bG9ZVP7rGopSgtEQDfejSIEBAwD/t0u1gHW/ncWZ1kyIeVMGg=="
     },
-    "@redhat-cloud-services/access-requests-frontend": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/access-requests-frontend/-/access-requests-frontend-1.2.11.tgz",
-      "integrity": "sha512-V+3ZhX54HHWYxUR1X1KH8J+H68pe6kEyXSFi/V3uf+XBSDHlHToHKeK5zDSqcK8x1/CE2NLhnEJt85iH5tY7zA==",
-      "requires": {
-        "@babel/runtime": "7.10.0",
-        "@patternfly/react-core": "^4.101.3",
-        "@patternfly/react-table": "^4.23.14",
-        "@redhat-cloud-services/frontend-components-notifications": "^3.1.0",
-        "react": "^16.0.0 || ^17.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0",
-        "react-redux": "^7.2.0",
-        "react-router-dom": "^5.2.0",
-        "redux": "^4.0.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.10.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.0.tgz",
-          "integrity": "sha512-tgYb3zVApHbLHYOPWtVwg25sBqHhfBXRKeKoTIyoheIxln1nA7oBl7SfHfiTG2GhDPI8EUBkOD/0wJCP/3HN4Q==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
     "@redhat-cloud-services/cost-management-client": {
       "version": "1.0.77",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/cost-management-client/-/cost-management-client-1.0.77.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@patternfly/react-icons": "^4.9.9",
     "@patternfly/react-table": "^4.23.14",
     "@patternfly/react-tokens": "^4.11.2",
-    "@redhat-cloud-services/access-requests-frontend": "^1.2.11",
     "@redhat-cloud-services/cost-management-client": "^1.0.77",
     "@redhat-cloud-services/frontend-components": "^3.1.11",
     "@redhat-cloud-services/frontend-components-notifications": "^3.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ class App extends Component {
   componentDidMount() {
     const { history } = this.props;
     insights.chrome.init();
+    insights.chrome.registerModule('access-requests');
     !insights.chrome.getApp() && history.push('/my-user-access'); // redirect to MUA if url is "/settings"
     insights.chrome.auth.getUser().then((user) => this.setState({ userReady: true, isAdmin: user.identity.user.is_org_admin }));
     insights.chrome.identifyApp(insights.chrome.getApp());

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,16 +1,22 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import store from './utilities/store';
+import registry, { RegistryContext } from './utilities/store';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const InsightsRbac = () => (
-  <Provider store={store}>
-    <Router basename={getBaseName(location.pathname, 2).includes('rbac') ? getBaseName(location.pathname, 2) : getBaseName(location.pathname, 1)}>
-      <App />
-    </Router>
-  </Provider>
+  <RegistryContext.Provider
+    value={{
+      getRegistry: () => registry,
+    }}
+  >
+    <Provider store={registry.getStore()}>
+      <Router basename={getBaseName(location.pathname, 2).includes('rbac') ? getBaseName(location.pathname, 2) : getBaseName(location.pathname, 1)}>
+        <App />
+      </Router>
+    </Provider>
+  </RegistryContext.Provider>
 );
 
 export default InsightsRbac;

--- a/src/smart-components/accessRequests/accessRequests.js
+++ b/src/smart-components/accessRequests/accessRequests.js
@@ -40,7 +40,6 @@ const AccessRequests = () => {
             scope="accessRequests"
             fallback={fallback}
             isInternal={false}
-            baseUrl={routes['access-requests']}
             getRegistry={getRegistry}
           />
         )}

--- a/src/smart-components/accessRequests/accessRequests.js
+++ b/src/smart-components/accessRequests/accessRequests.js
@@ -1,24 +1,52 @@
-import React, { lazy, Suspense } from 'react';
-import PropTypes from 'prop-types';
-import { Switch, Route } from 'react-router-dom';
+import React, { useContext, Fragment } from 'react';
+import { Route } from 'react-router-dom';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { routes } from '../../../package.json';
+import { RegistryContext } from '../../utilities/store';
 
-const AccessRequestsPage = lazy(() => import('@redhat-cloud-services/access-requests-frontend/lib/Routes/AccessRequestsPage'));
-const AccessRequestDetailsPage = lazy(() => import('@redhat-cloud-services/access-requests-frontend/lib/Routes/AccessRequestDetailsPage'));
-
-const AccessRequestsPageWrapper = () => <AccessRequestsPage isInternal={false} />;
-const AccessRequestDetailsPageWrapper = ({ match }) => <AccessRequestDetailsPage requestId={match.params.requestId} isInternal={false} />;
-AccessRequestDetailsPageWrapper.propTypes = {
-  match: PropTypes.object,
-};
-
-const AccessRequests = () => (
-  <Suspense fallback={<React.Fragment />}>
-    <Switch>
-      <Route path={routes['access-requests']} exact component={AccessRequestsPageWrapper} />
-      <Route path={routes['access-requests-detail']} exact component={AccessRequestDetailsPageWrapper} />
-    </Switch>
-  </Suspense>
+const fallback = (
+  <Bullseye>
+    <Spinner size="xl" />
+  </Bullseye>
 );
+
+const AccessRequests = () => {
+  const { getRegistry } = useContext(RegistryContext);
+
+  return (
+    <Fragment>
+      <Route
+        path={routes['access-requests']}
+        exact
+        render={() => (
+          <AsyncComponent
+            appName="access-requests"
+            module="./AccessRequestsPage"
+            scope="accessRequests"
+            isInternal={false}
+            fallback={fallback}
+            getRegistry={getRegistry}
+          />
+        )}
+      />
+      <Route
+        path={routes['access-requests-detail']}
+        exact
+        render={() => (
+          <AsyncComponent
+            appName="access-requests"
+            module="./AccessRequestDetailsPage"
+            scope="accessRequests"
+            fallback={fallback}
+            isInternal={false}
+            baseUrl={routes['access-requests']}
+            getRegistry={getRegistry}
+          />
+        )}
+      />
+    </Fragment>
+  );
+};
 
 export default AccessRequests;

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -1,3 +1,4 @@
+import { createContext } from 'react';
 import promiseMiddleware from 'redux-promise-middleware';
 import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -12,6 +13,10 @@ import roleReducer, { rolesInitialState } from '../redux/reducers/role-reducer';
 import accessReducer, { accessInitialState } from '../redux/reducers/access-reducer';
 import permissionReducer, { permissionInitialState } from '../redux/reducers/permission-reducer';
 import costReducer, { costInitialState } from '../redux/reducers/cost-reducer';
+
+export const RegistryContext = createContext({
+  getRegistry: () => {},
+});
 
 const registry = new ReducerRegistry({}, [
   thunk,
@@ -34,4 +39,4 @@ registry.register({
   notifications: notificationsReducer,
 });
 
-export default registry.getStore();
+export default registry;


### PR DESCRIPTION
### Register access request FED modules and use it

Since we can now share modules trough FED modules let's use them in access-requests app https://github.com/RedHatInsights/access-requests-frontend/pull/2, this requires registering such module before first use.

Also since access-request is using redux we have to pass registry to it so it can wrap each route with `Provider`.