### PR TITLE
Fix the Default access group being hidden

### DIFF
--- a/src/redux/actions/group-actions.js
+++ b/src/redux/actions/group-actions.js
@@ -20,7 +20,7 @@ export const fetchSystemGroup = (filterValue) => ({
   type: ActionTypes.FETCH_SYSTEM_GROUP,
   payload: GroupHelper.fetchGroups({
     limit: 1,
-    name: filterValue || 'default',
+    filters: { name: filterValue?.length > 0 ? filterValue : 'default' },
     nameMatch: 'partial',
   }),
 });

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -60,7 +60,7 @@ const Groups = () => {
     setFilterValue(name);
     insights.chrome.appNavClick({ id: 'groups', secondaryNav: true });
     fetchData({ ...syncedPagination, filters: { name } });
-    dispatch(fetchSystemGroup(filterValue));
+    dispatch(fetchSystemGroup(name));
   }, []);
 
   const setCheckedItems = (newSelection) => {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-14049

Fixed "Default access group" missing in the Groups table after adding new filters and pagination persisting