### PR TITLE
Fix group name validation & description change

### DIFF
--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -50,7 +50,7 @@ const EditGroupModal = ({
   }, [group]);
 
   const onSubmit = (data) => {
-    const user_data = { ...data };
+    const user_data = { description: null, ...data };
     postMethod
       ? updateGroup(user_data)
           .then(() => postMethod({ limit: pagination?.limit, filters }))
@@ -78,7 +78,7 @@ const EditGroupModal = ({
         component: selectedGroup ? componentTypes.TEXT_FIELD : 'skeleton',
         ...(selectedGroup ? { validateOnMount: true } : {}),
         validate: [
-          { type: 'validate-group-name', id: match ? match.params.id : group.id, idKey: 'uuid' },
+          { type: 'validate-group-name', id: match ? match.params.id : group.uuid, idKey: 'uuid' },
           {
             type: validatorTypes.REQUIRED,
           },

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -91,6 +91,7 @@ const Group = ({
     <DropdownItem
       component={
         <Link
+          onClick={() => setDropdownOpen(false)}
           to={(location.pathname.includes('members') ? routes['group-detail-members-edit'] : routes['group-detail-roles-edit']).replace(
             ':uuid',
             uuid

--- a/src/smart-components/role/role.js
+++ b/src/smart-components/role/role.js
@@ -100,7 +100,14 @@ const Role = ({ onDelete }) => {
   const title = !isRecordLoading && role ? role.display_name || role.name : undefined;
   const description = !isRecordLoading && role ? role.description : undefined;
   const dropdownItems = [
-    <DropdownItem component={<Link to={routes['role-detail-edit'].replace(':id', uuid)}>Edit</Link>} key="edit-role" />,
+    <DropdownItem
+      component={
+        <Link onClick={() => setDropdownOpen(false)} to={routes['role-detail-edit'].replace(':id', uuid)}>
+          Edit
+        </Link>
+      }
+      key="edit-role"
+    />,
     <DropdownItem
       component={
         <Link onClick={onDelete} to={routes['role-detail-remove'].replace(':id', uuid)}>

--- a/src/test/smart-components/group/remove-group-modal.test.js
+++ b/src/test/smart-components/group/remove-group-modal.test.js
@@ -77,6 +77,7 @@ describe('<RemoveGroupModal />', () => {
   it('should call cancel action', () => {
     const store = mockStore(initialState);
     fetchGroupSpy.mockImplementationOnce(() => ({ type: FETCH_GROUP, payload: Promise.resolve({}) }));
+    fetchGroupSpy.mockImplementationOnce(() => ({ type: FETCH_GROUP, payload: Promise.resolve({}) }));
     const wrapper = mount(<GroupWrapper store={store} />);
 
     wrapper.find(Button).last().simulate('click');


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHCLOUD-13081

- fixed group name validation to not block editing the description of a group while keeping the name the same
(validator was using `group.id`, which is undefined instead of `group.uuid` to make an exception for name collision with the group itself)
- also found and fixed a bug which disallowed to remove description from the group - when setting group description for example from "test description" to undefined, the description was not cleared

@john-dupuy 