### PR TITLE
Fix "Group not found"error in Role detail

### DIFF
--- a/src/smart-components/role/role.js
+++ b/src/smart-components/role/role.js
@@ -83,11 +83,11 @@ const Role = ({ onDelete }) => {
             },
           ]
         : [undefined]
-      : groupExists
+      : groupExists || !groupUuid
       ? []
       : [{ title: 'Invalid group', isActive: true }]),
 
-    ...(groupExists
+    ...(groupExists || !groupUuid
       ? [
           {
             title: isRecordLoading ? undefined : roleExists ? role?.display_name || role?.name : 'Invalid role',
@@ -121,7 +121,7 @@ const Role = ({ onDelete }) => {
 
   return (
     <Fragment>
-      {groupExists && roleExists ? (
+      {(groupExists || !groupUuid) && roleExists ? (
         <Fragment>
           <TopToolbar breadcrumbs={breadcrumbsList()}>
             <Level>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-14401

The reason for this bug was an incomplete condition handling displaying the empty state.

@john-dupuy please verify with me, thanks for reporting!