### PR TITLE
Fix errors on editing the group from Groups table

### DIFF
--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -29,7 +29,7 @@ export const syncDefaultPaginationWithUrl = (history, defaultPagination = defaul
   return { ...defaultPagination, limit, offset };
 };
 
-export const isOffsetValid = (offset, count) => offset === 0 || count > offset;
+export const isOffsetValid = (offset = 0, count = 0) => offset === 0 || count > offset;
 
 export const getLastPageOffset = (count, limit) => count - (count % limit);
 

--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -50,7 +50,11 @@ const EditGroupModal = ({
   }, [group]);
 
   const onSubmit = (data) => {
-    const user_data = { description: null, ...data };
+    const user_data = {
+      uuid: data.uuid,
+      description: data.description || null,
+      name: data.name,
+    };
     postMethod
       ? updateGroup(user_data)
           .then(() => postMethod({ limit: pagination?.limit, filters }))


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14831

- fixed error on editing a group from the Group page (caused by extra params passed to the PUT request)
- fixed a `validateOffset` function to handle undefined values

@john-dupuy 