### PR TITLE
Fix unwanted empty state on searchBar clearing

### DIFF
--- a/src/presentational-components/shared/empty-state.js
+++ b/src/presentational-components/shared/empty-state.js
@@ -9,7 +9,7 @@ const EmptyWithAction = ({ title, icon, description, actions, ...props }) => (
     <Title headingLevel="h4" size="lg">
       {title}
     </Title>
-    <EmptyStateBody>
+    <EmptyStateBody className="pf-u-mb-md">
       {description.map((text, key) => (
         <React.Fragment key={key}>
           {text} <br />

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -209,7 +209,7 @@ const Groups = () => {
             }}
             setFilterValue={({ name }) => setFilterValue(name)}
             toolbarButtons={toolbarButtons}
-            isLoading={isLoading}
+            isLoading={!isLoading && groups?.length === 0 && filterValue?.length === 0 ? true : isLoading}
             filterPlaceholder="name"
             rowWrapper={GroupRowWrapper}
             tableId="groups"

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -151,7 +151,7 @@ const Roles = () => {
               return fetchData(mappedProps({ count, limit, offset, orderBy, filters: { name } }));
             }}
             setFilterValue={({ name }) => setFilterValue(name)}
-            isLoading={isLoading}
+            isLoading={!isLoading && roles?.length === 0 && filterValue?.length === 0 ? true : isLoading}
             pagination={pagination}
             routes={routes}
             ouiaId="roles-table"


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-11313

Removed unwanted page “flickering” - briefly displaying a button to create groups, then reverting to the page with all the groups when the search bar was cleared. 

@john-dupuy 