### PR TITLE
Filter roles using display_name, not name

### DIFF
--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -56,7 +56,7 @@ export async function fetchRolesWithPolicies({
     offset,
     filters.name,
     undefined,
-    undefined,
+    filters.display_name,
     nameMatch,
     scope,
     orderBy,

--- a/src/smart-components/group/add-group/roles-list.js
+++ b/src/smart-components/group/add-group/roles-list.js
@@ -52,7 +52,7 @@ const RolesList = ({ roles, fetchRoles, isLoading, pagination, selectedRoles, ca
       data={roles}
       filterValue={filterValue}
       filterPlaceholder="role name"
-      fetchData={(config) => fetchRoles(mappedProps({ ...config, filters: { name: config.name } }))}
+      fetchData={(config) => fetchRoles(mappedProps({ ...config, filters: { display_name: config.name } }))}
       setFilterValue={({ name }) => setFilterValue(name)}
       isLoading={isLoading}
       ouiaId="roles-table"


### PR DESCRIPTION
Roles ist is now filterable by `display_name` not name

@john-dupuy 