### PR TITLE
Fix cutoff of resources with long names

### DIFF
--- a/src/smart-components/role/add-role-new/add-role-wizard.scss
+++ b/src/smart-components/role/add-role-new/add-role-wizard.scss
@@ -121,6 +121,7 @@
     .pf-c-select__menu {
         max-height: 300px;
         overflow: auto;
+        width: inherit;
         .pf-c-select__menu-item:nth-child(3) {
             .pf-c-check__input {
                 display: none;
@@ -129,6 +130,12 @@
                 color: var(--pf-global--link--Color);
             }
         }
+    }
+    .pf-c-check.pf-c-select__menu-item {
+         width: inherit;
+    }
+    .pf-c-check__label {
+        white-space: pre-wrap;
     }
 }
 

--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer } from 'react';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
-import { Select, SelectOption, SelectVariant, Grid, GridItem, Text, TextVariants, FormGroup } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Grid, GridItem, Text, TextVariants, FormGroup, Tooltip } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { getResourceDefinitions, getResource } from '../../../redux/actions/cost-management-actions';
@@ -135,10 +135,12 @@ const CostResources = (props) => {
     const options = state[permission].filteredOptions;
     return (
       <React.Fragment>
-        <GridItem md={4} sm={12}>
-          <FormGroup label={permission} isRequired></FormGroup>
+        <GridItem md={3} sm={12}>
+          <Tooltip content={<div>{permission}</div>}>
+            <FormGroup label={permission.replace(/^cost-management:/, '')} isRequired></FormGroup>
+          </Tooltip>
         </GridItem>
-        <GridItem md={8} sm={12}>
+        <GridItem md={9} sm={12}>
           <Select
             className="ins-c-rbac-cost-resource-select"
             variant={SelectVariant.checkbox}
@@ -170,12 +172,12 @@ const CostResources = (props) => {
 
   return (
     <Grid hasGutter>
-      <GridItem md={4} className="ins-m-hide-on-sm">
+      <GridItem md={3} className="ins-m-hide-on-sm">
         <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
-          Cost management permissions
+          Permissions
         </Text>
       </GridItem>
-      <GridItem md={8} className="ins-m-hide-on-sm">
+      <GridItem md={9} className="ins-m-hide-on-sm">
         <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
           Resource definitions
         </Text>

--- a/src/smart-components/role/add-role-new/schema.js
+++ b/src/smart-components/role/add-role-new/schema.js
@@ -174,7 +174,11 @@ export default (container) => ({
             {
               component: 'plain-text',
               name: 'text-description',
-              label: <p>Specify where you would like to apply each cost permission selected in the previous step, using the dropdown below.</p>,
+              label: (
+                <p className="pf-u-mb-md">
+                  Specify where you would like to apply each cost permission selected in the previous step, using the dropdown below.
+                </p>
+              ),
             },
             {
               component: 'cost-resources',


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-14260

- reworded permisions header
- made the resource definitions column wider (9 columns instead of 8)
- added resource names word breaking
- removed "cost-management:" prefix from the permissions labels - full text is now visible in a tooltip on hover

**Before:**
![before](https://user-images.githubusercontent.com/50696716/129010738-50490ddf-3028-48f4-bbc6-f29cda4386b6.png)

**After:**
![fixed01](https://user-images.githubusercontent.com/50696716/129010567-1cbc56bb-ad6a-42df-8bfc-57b7d683a432.png)
![fixed02](https://user-images.githubusercontent.com/50696716/129010559-2dcb9dd3-d6d6-4901-9e20-656da7fc1c26.png)
![fixed03](https://user-images.githubusercontent.com/50696716/129010556-ce68a2ec-7562-4f21-a5dd-27ae61728ba9.png)
![fixed04](https://user-images.githubusercontent.com/50696716/129010549-43328453-f99f-4491-bd2d-b543f65bfbe4.png)

@mmenestr

