### PR TITLE
Fix cost-resources required fields styling

### DIFF
--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -4,6 +4,7 @@ import { Select, SelectOption, SelectVariant, Grid, GridItem, Text, TextVariants
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { getResourceDefinitions, getResource } from '../../../redux/actions/cost-management-actions';
+import './cost-resources.scss';
 
 const selector = ({ costReducer: { resourceTypes, isLoading, loadingResources, resources } }) => ({
   resourceTypes: resourceTypes.data,
@@ -135,12 +136,12 @@ const CostResources = (props) => {
     const options = state[permission].filteredOptions;
     return (
       <React.Fragment>
-        <GridItem md={3} sm={12}>
+        <GridItem md={4} sm={12}>
           <Tooltip content={<div>{permission}</div>}>
             <FormGroup label={permission.replace(/^cost-management:/, '')} isRequired></FormGroup>
           </Tooltip>
         </GridItem>
-        <GridItem md={9} sm={12}>
+        <GridItem md={8} sm={12}>
           <Select
             className="ins-c-rbac-cost-resource-select"
             variant={SelectVariant.checkbox}
@@ -172,12 +173,12 @@ const CostResources = (props) => {
 
   return (
     <Grid hasGutter>
-      <GridItem md={3} className="ins-m-hide-on-sm">
+      <GridItem md={4} className="ins-m-hide-on-sm">
         <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
           Permissions
         </Text>
       </GridItem>
-      <GridItem md={9} className="ins-m-hide-on-sm">
+      <GridItem md={8} className="ins-m-hide-on-sm">
         <Text component={TextVariants.h4} className="ins-c-rbac__bold-text">
           Resource definitions
         </Text>

--- a/src/smart-components/role/add-role-new/cost-resources.scss
+++ b/src/smart-components/role/add-role-new/cost-resources.scss
@@ -1,0 +1,5 @@
+.pf-c-form__label-required {
+    color: var(--pf-global--danger-color--100);
+    margin-left: var(--pf-global--spacer--xs);
+    font-size: var(--pf-global--FontSize--sm);
+}


### PR DESCRIPTION
Made the asterisks for required fields on cost-resources step look the same as in other PF forms and not confuse the user.

**Before:**
![before](https://user-images.githubusercontent.com/50696716/129217173-e61a4c5c-0b6d-41c0-bf57-3df963437645.png)


**Now:**
![now](https://user-images.githubusercontent.com/50696716/129217319-4499f51d-feda-498b-869c-8c2b9819bab6.png)

@mmenestr