### PR TITLE
Avoid reset filters on navigation click

### DIFF
--- a/src/helpers/shared/filters.js
+++ b/src/helpers/shared/filters.js
@@ -32,6 +32,11 @@ export const syncDefaultFiltersWithUrl = (history, keys, defaults = {}) => {
   return filters;
 };
 
+export const areFiltersPresentInUrl = (history, keys) => {
+  const searchParams = new URLSearchParams(history.location.search);
+  return keys.some((key) => searchParams.get(key));
+};
+
 export const applyFiltersToUrl = (history, newValues) => {
   const searchParams = new URLSearchParams(history.location.search);
   Object.keys(newValues).forEach((key) => searchParams.delete(key));

--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -55,8 +55,8 @@ export const createQueryParams = (params) => {
 export const getBackRoute = (pathname, pagination, filters) => ({
   pathname,
   search: createQueryParams({
-    page: calculatePage(pagination.limit, pagination.offset),
     per_page: pagination.limit,
+    page: calculatePage(pagination.limit, pagination.offset),
     ...filters,
   }),
 });

--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -15,15 +15,15 @@ export const calculatePage = (limit = defaultSettings.limit, offset = 0) => Math
 export const calculateOffset = (page = 1, limit = defaultSettings.limit) => (page - 1) * limit;
 
 export const syncDefaultPaginationWithUrl = (history, defaultPagination = defaultSettings) => {
-  const searchParams = new URLSearchParams(history.location.search);
+  let searchParams = new URLSearchParams();
 
   let limit = parseInt(searchParams.get('per_page'));
+  let page = parseInt(searchParams.get('page'));
+
   if (isNaN(limit) || limit <= 0) {
     limit = defaultPagination.limit;
     searchParams.set('per_page', limit);
   }
-
-  let page = parseInt(searchParams.get('page'));
   if (isNaN(page) || page <= 0) {
     page = 1;
     searchParams.set('page', page);
@@ -36,6 +36,11 @@ export const syncDefaultPaginationWithUrl = (history, defaultPagination = defaul
     search: searchParams.toString(),
   });
   return { ...defaultPagination, limit, offset };
+};
+
+export const isPaginationPresentInUrl = (history) => {
+  const searchParams = new URLSearchParams(history.location.search);
+  return searchParams.get('per_page') && searchParams.get('per_page');
 };
 
 export const isOffsetValid = (offset = 0, count = 0) => offset === 0 || count > offset;

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -9,8 +9,14 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { Label } from '@patternfly/react-core';
 import { sortable, nowrap } from '@patternfly/react-table';
 import UsersRow from '../../../presentational-components/shared/UsersRow';
-import { defaultCompactSettings, defaultSettings, syncDefaultPaginationWithUrl, applyPaginationToUrl } from '../../../helpers/shared/pagination';
-import { syncDefaultFiltersWithUrl, applyFiltersToUrl } from '../../../helpers/shared/filters';
+import {
+  defaultCompactSettings,
+  defaultSettings,
+  syncDefaultPaginationWithUrl,
+  applyPaginationToUrl,
+  isPaginationPresentInUrl,
+} from '../../../helpers/shared/pagination';
+import { syncDefaultFiltersWithUrl, applyFiltersToUrl, areFiltersPresentInUrl } from '../../../helpers/shared/filters';
 import { CheckIcon, CloseIcon } from '@patternfly/react-icons';
 
 const columns = [
@@ -104,6 +110,15 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
     setFilters(newFilters);
     fetchUsers({ ...mappedProps({ ...pagination, filters: newFilters }), inModal });
   }, []);
+
+  useEffect(() => {
+    if (!inModal) {
+      isPaginationPresentInUrl(history) || applyPaginationToUrl(history, pagination.limit, pagination.offset);
+      Object.values(filters).some((filter) => filter?.length > 0) &&
+        !areFiltersPresentInUrl(history, Object.keys(filters)) &&
+        syncDefaultFiltersWithUrl(history, Object.keys(filters), filters);
+    }
+  });
 
   const setCheckedItems = (newSelection) => {
     setSelectedUsers((users) => {

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -17,8 +17,8 @@ import GroupRowWrapper from './group-row-wrapper';
 import { routes as paths } from '../../../package.json';
 import './groups.scss';
 import PageActionRoute from '../common/page-action-route';
-import { applyPaginationToUrl, syncDefaultPaginationWithUrl } from '../../helpers/shared/pagination';
-import { applyFiltersToUrl, syncDefaultFiltersWithUrl } from '../../helpers/shared/filters';
+import { applyPaginationToUrl, isPaginationPresentInUrl, syncDefaultPaginationWithUrl } from '../../helpers/shared/pagination';
+import { applyFiltersToUrl, areFiltersPresentInUrl, syncDefaultFiltersWithUrl } from '../../helpers/shared/filters';
 import { getBackRoute } from '../../helpers/shared/helpers';
 
 const columns = [
@@ -62,6 +62,11 @@ const Groups = () => {
     fetchData({ ...syncedPagination, filters: { name } });
     dispatch(fetchSystemGroup(name));
   }, []);
+
+  useEffect(() => {
+    isPaginationPresentInUrl(history) || applyPaginationToUrl(history, pagination.limit, pagination.offset);
+    filterValue?.length > 0 && !areFiltersPresentInUrl(history, ['name']) && syncDefaultFiltersWithUrl(history, ['name'], { name: filterValue });
+  });
 
   const setCheckedItems = (newSelection) => {
     setSelectedRows((rows) =>

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -15,8 +15,8 @@ import { routes as paths } from '../../../package.json';
 import EditRole from './edit-role-modal';
 import PageActionRoute from '../common/page-action-route';
 import ResourceDefinitions from './role-resource-definitions';
-import { syncDefaultPaginationWithUrl, applyPaginationToUrl } from '../../helpers/shared/pagination';
-import { syncDefaultFiltersWithUrl, applyFiltersToUrl } from '../../helpers/shared/filters';
+import { syncDefaultPaginationWithUrl, applyPaginationToUrl, isPaginationPresentInUrl } from '../../helpers/shared/pagination';
+import { syncDefaultFiltersWithUrl, applyFiltersToUrl, areFiltersPresentInUrl } from '../../helpers/shared/filters';
 import './roles.scss';
 
 const AddRoleWizard = lazy(() => import(/* webpackChunkname: "AddRoleWizard" */ './add-role-new/add-role-wizard'));
@@ -64,6 +64,13 @@ const Roles = () => {
   useEffect(() => {
     meta.redirected && applyPaginationToUrl(history, meta.limit, meta.offset);
   }, [meta.redirected]);
+
+  useEffect(() => {
+    isPaginationPresentInUrl(history) || applyPaginationToUrl(history, pagination.limit, pagination.offset);
+    filterValue?.length > 0 &&
+      !areFiltersPresentInUrl(history, ['display_name']) &&
+      syncDefaultFiltersWithUrl(history, ['display_name'], { display_name: filterValue });
+  });
 
   const routes = () => (
     <Suspense fallback={<Fragment />}>

--- a/src/test/role/__snapshots__/role.test.js.snap
+++ b/src/test/role/__snapshots__/role.test.js.snap
@@ -36,7 +36,7 @@ exports[`role should render top toolbar 1`] = `
         "title": "Roles",
         "to": Object {
           "pathname": "/roles",
-          "search": "page=1&per_page=20",
+          "search": "per_page=20&page=1",
         },
       },
       Object {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-15764

Prevented URL in Users, Roles and Groups page from being reset on double navigation click.

@john-dupuy 