### PR TITLE
Fix filter persisting after leaving User detail

### DIFF
--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -60,7 +60,7 @@ const User = ({
   });
 
   useEffect(() => {
-    fetchUsers({ ...defaultSettings, limit: 0, filters: { username } });
+    fetchUsers({ ...defaultSettings, limit: 0, filters: { username }, inModal: true });
     insights.chrome.appObjectId(username);
     return () => insights.chrome.appObjectId(undefined);
   }, []);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-15849

Prevented User detail from the unwanted setting filter for the Users page with the displayed user value.