### PR TITLE
Use display_name for User detail

### DIFF
--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -67,15 +67,15 @@ const User = ({
 
   const history = useHistory();
 
-  const createRows = (data) => {
-    return data
+  const createRows = (data) =>
+    data
       ? data.reduce(
-          (acc, { uuid, name, groups_in = [], modified, accessCount }, i) => [
+          (acc, { uuid, display_name, groups_in = [], modified, accessCount }, i) => [
             ...acc,
             {
               uuid,
               cells: [
-                { title: name, props: { component: 'th', isOpen: false } },
+                { title: display_name, props: { component: 'th', isOpen: false } },
                 { title: `${groups_in.length}`, props: { isOpen: expanded[uuid] === 1 } },
                 { title: accessCount, props: { isOpen: expanded[uuid] === 2 } },
                 { title: <DateFormat type="exact" date={modified} /> },
@@ -132,7 +132,6 @@ const User = ({
           []
         )
       : [];
-  };
 
   useEffect(() => {
     fetchRoles({ limit: 20, offset: 0, addFields: ['groups_in'], username });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-15797

User detail is now displaying `display_name` for roles, not `name`