### PR TITLE
Make onSort use the right sortByIndex

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -166,6 +166,7 @@ export const TableToolbarView = ({
             sortBy={sortByState}
             ouiaId={ouiaId}
             onSort={(e, index, direction) => {
+              const sortByIndex = Math.min((index || selectColumnOffset) - selectColumnOffset, columns?.length - 1);
               setSortByState({ index, direction });
               filters && filters.length > 0
                 ? fetchData({


### PR DESCRIPTION
This fixes: https://issues.redhat.com/browse/RHCLOUD-15796

`onSort` function has not been using a proper index

@john-dupuy 