### PR TITLE
Use replace instead push for mua bundle redirects.

### DIFF
--- a/src/hooks/useBundleApps.js
+++ b/src/hooks/useBundleApps.js
@@ -3,11 +3,11 @@ import { bundleData } from '../presentational-components/myUserAccess/bundles';
 
 const useBundleApps = (bundle) => {
   const {
-    push,
+    replace,
     location: { pathname },
   } = useHistory();
   if (typeof bundle !== 'string' || bundle.length === 0) {
-    push({ to: pathname, search: 'bundle=rhel' });
+    replace({ to: pathname, search: 'bundle=rhel' });
     return [];
   }
 


### PR DESCRIPTION
### Changes
- use `history.replace` instead of `history.push` for MUA bundle redirect

If user goes on `/settings/my-user-access` they will be redirected to `/settings/my-user-access?bundle=rhel`. Before it wsa done using `push` method which causes issues when using the browser back button. The user ends up in an infinite loop because the stack is pushing from `/settings/my-user-access` to the rhel bundle constantly. Using the replace method will not replace the `/settings/my-user-access` with `/settings/my-user-access?bundle=rhel` instead of pushing additional `/settings/my-user-access?bundle=rhel` to the stack so the back button works just fine,