### PR TITLE
Persist resources selection in add role wizard

### DIFF
--- a/src/smart-components/role/add-role-new/cost-resources.js
+++ b/src/smart-components/role/add-role-new/cost-resources.js
@@ -104,7 +104,10 @@ const CostResources = (props) => {
 
   useEffect(() => {
     (formOptions.getState().values['resource-definitions'] || []).map(({ permission, resources }) =>
-      resources.map((resource) => permissions.includes(permission) && dispatchLocaly({ type: 'select', selection: resource, key: permission }))
+      resources.map(
+        (resource) =>
+          permissions.find((item) => item?.uuid === permission) && dispatchLocaly({ type: 'select', selection: resource, key: permission })
+      )
     );
     fetchData();
     formOptions.change('has-cost-resources', true);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-15719

Fixed selection of cost-resources not persistent after going back in the add role wizard - wrong param used in the comparison method.

@john-dupuy please for verification