### PR TITLE
Display MUA bundle according to URL

### DIFF
--- a/src/hooks/useBundleApps.js
+++ b/src/hooks/useBundleApps.js
@@ -6,8 +6,9 @@ const useBundleApps = (bundle) => {
     replace,
     location: { pathname },
   } = useHistory();
-  if (typeof bundle !== 'string' || bundle.length === 0) {
-    replace({ to: pathname, search: 'bundle=rhel' });
+  if (typeof bundle !== 'string' || bundle.length === 0 || !['application_services', 'openshift', 'rhel', 'ansible'].includes(bundle)) {
+    bundle = 'rhel';
+    replace({ to: pathname, search: `bundle=${bundle}` });
     return [];
   }
 

--- a/src/test/hooks/useBundleApps.test.js
+++ b/src/test/hooks/useBundleApps.test.js
@@ -28,7 +28,7 @@ describe('useBundleApps', () => {
     expect(wrapper.find(SpyComponent).prop('result')).toEqual([]);
   });
 
-  it('should redirect to rhelfirst app if no bundle id is passed', async () => {
+  it('should redirect to rhel first app if no bundle id is passed', async () => {
     const wrapper = mount(<DummyComponent initialEntries={['/foo']} bundle="" />);
     expect(wrapper.find(SpyComponent).prop('result')).toEqual([]);
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14545

Added displaying MUA according to bundle passed in URL query params.
If none of  `'application_services', 'openshift', 'rhel', 'ansible'` bundles is passed, RHEL is displayed.