### PR TITLE
Make dates on Users and Roles pages consistent

### DIFF
--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -60,3 +60,8 @@ export const getBackRoute = (pathname, pagination, filters) => ({
     ...filters,
   }),
 });
+
+export const getDateFormat = (date) => {
+  const monthAgo = new Date(Date.now());
+  return Date.parse(date) < monthAgo.setMonth(monthAgo.getMonth() - 1) ? 'onlyDate' : 'relative';
+};

--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -5,6 +5,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { getDateFormat } from '../../helpers/shared/helpers';
 
 const DefaultPlatformPopover = ({ uuid }) => {
   const [isPopoverVisible, setPopoverVisible] = useState(false);
@@ -53,7 +54,7 @@ export const createRows = (data, opened, selectedRows = []) => {
           roleCount,
           principalCount,
           <Fragment key={`${uuid}-modified`}>
-            <DateFormat date={modified} type="relative" />
+            <DateFormat date={modified} type={getDateFormat(modified)} />
           </Fragment>,
         ],
         selected: Boolean(selectedRows && selectedRows.find((row) => row.uuid === uuid)),

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -12,6 +12,7 @@ import { removeRolesFromGroup, addRolesToGroup, fetchRolesForGroup, fetchAddRole
 import AddGroupRoles from './add-group-roles';
 import RemoveRole from './remove-role-modal';
 import paths from '../../../utilities/pathnames';
+import { getDateFormat } from '../../../helpers/shared/helpers';
 import './group-roles.scss';
 
 const columns = [{ title: 'Name', orderBy: 'name' }, { title: 'Description' }, { title: 'Last modified' }];
@@ -30,7 +31,7 @@ const createRows = (groupUuid, data, expanded, checkedRows = []) => {
               </Fragment>,
               description,
               <Fragment key={`${uuid}-modified`}>
-                <DateFormat date={modified} type="relative" />
+                <DateFormat date={modified} type={getDateFormat(modified)} />
               </Fragment>,
             ],
             selected: Boolean(checkedRows && checkedRows.find((row) => row.uuid === uuid)),

--- a/src/smart-components/role/role-permissions-table-helpers.js
+++ b/src/smart-components/role/role-permissions-table-helpers.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import { getDateFormat } from '../../helpers/shared/helpers';
 import { defaultSettings } from '../../helpers/shared/pagination';
 import { Link } from 'react-router-dom';
 import flatten from 'lodash/flatten';
@@ -31,7 +32,7 @@ export const createRows =
                 ]
               : []),
             <Fragment key={`${appName}-modified`}>
-              <DateFormat date={modified} type="relative" />
+              <DateFormat date={modified} type={getDateFormat(modified)} />
             </Fragment>,
           ],
           selected: Boolean(selectedRows?.find(({ uuid }) => uuid === permission)),

--- a/src/smart-components/role/role-table-helpers.js
+++ b/src/smart-components/role/role-table-helpers.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { Link } from 'react-router-dom';
+import { getDateFormat } from '../../helpers/shared/helpers';
 
 export const createRows = (data) =>
   data.reduce(
@@ -19,7 +20,7 @@ export const createRows = (data) =>
           </Fragment>,
           groupsCount,
           <Fragment key={`${uuid}-modified`}>
-            <DateFormat date={modified} type="relative" />
+            <DateFormat date={modified} type={getDateFormat(modified)} />
           </Fragment>,
         ],
       },

--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -17,7 +17,7 @@ import { Table, TableHeader, TableBody, TableVariant, compoundExpand } from '@pa
 import { Fragment } from 'react';
 import EmptyWithAction from '../../presentational-components/shared/empty-state';
 import RbacBreadcrumbs from '../../presentational-components/shared/breadcrubms';
-import { BAD_UUID } from '../../helpers/shared/helpers';
+import { BAD_UUID, getDateFormat } from '../../helpers/shared/helpers';
 import './user.scss';
 
 const columns = [
@@ -31,7 +31,7 @@ const columns = [
     cellTransforms: [compoundExpand],
   },
   {
-    title: 'Last commit',
+    title: 'Last modified',
   },
 ];
 
@@ -78,7 +78,7 @@ const User = ({
                 { title: display_name, props: { component: 'th', isOpen: false } },
                 { title: `${groups_in.length}`, props: { isOpen: expanded[uuid] === 1 } },
                 { title: accessCount, props: { isOpen: expanded[uuid] === 2 } },
-                { title: <DateFormat type="exact" date={modified} /> },
+                { title: <DateFormat type={getDateFormat(modified)} date={modified} /> },
               ],
             },
             {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-15885
- changed the date format to be relative for "last-month" dates and only Date for older ones across all RBAC tables according to the Time/date display guidance (RHCS)
- also unified the column titles to "Last modified"

![Screenshot from 2021-10-08 10-53-08](https://user-images.githubusercontent.com/50696716/136528709-149b2cba-40e5-4a46-8a94-354f3f1dc361.png)

@Hyperkid123 do you think it's ok this way or will we handle the format switch on the FEC DateFormat level?