### PR TITLE
Display a more specific error in create/update role notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@redhat-cloud-services/access-requests-frontend": "^1.2.11",
         "@redhat-cloud-services/cost-management-client": "^1.0.100",
         "@redhat-cloud-services/frontend-components": "^3.4.14",
-        "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
+        "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.3",
         "@redhat-cloud-services/rbac-client": "^1.0.103",
         "axios-mock-adapter": "^1.19.0",
@@ -3109,9 +3109,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.4.tgz",
-      "integrity": "sha512-8wYFXidJptCfbEXEmi1tM4adHmSVSWEmTjjZ/JD7UCPlmQ3Cr9D+sWyUf4x9iUS5kvSlnUMS1DnwjMjhy10s7g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.5.tgz",
+      "integrity": "sha512-HZKPYiNvBKMP5F3nicdIwPdMBh4o524b+THz0zN4pax0rb6RydR20E5OQ0taHqzUyObyTedM8w4O5ulNpVHduQ==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.2"
@@ -17926,9 +17926,9 @@
       "requires": {}
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.4.tgz",
-      "integrity": "sha512-8wYFXidJptCfbEXEmi1tM4adHmSVSWEmTjjZ/JD7UCPlmQ3Cr9D+sWyUf4x9iUS5kvSlnUMS1DnwjMjhy10s7g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.5.tgz",
+      "integrity": "sha512-HZKPYiNvBKMP5F3nicdIwPdMBh4o524b+THz0zN4pax0rb6RydR20E5OQ0taHqzUyObyTedM8w4O5ulNpVHduQ==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "react-redux": ">=5.0.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@redhat-cloud-services/access-requests-frontend": "^1.2.11",
     "@redhat-cloud-services/cost-management-client": "^1.0.100",
     "@redhat-cloud-services/frontend-components": "^3.4.14",
-    "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
+    "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.3",
     "@redhat-cloud-services/rbac-client": "^1.0.103",
     "axios-mock-adapter": "^1.19.0",

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -7,13 +7,13 @@ export const createRole = (roleData) => ({
   payload: RoleHelper.createRole(roleData),
   meta: {
     notifications: {
-      rejected: {
+      rejected: (payload) => ({
         variant: 'danger',
         title: 'Failed adding role',
         dismissDelay: 8000,
         dismissable: false,
-        description: 'The role was not added successfuly.',
-      },
+        description: payload?.errors?.[0]?.detail || 'The role was not added successfuly.',
+      }),
     },
   },
 });
@@ -90,13 +90,13 @@ export const updateRole = (roleId, data, useCustomAccess) => ({
   payload: RoleHelper.updateRole(roleId, data, useCustomAccess),
   meta: {
     notifications: {
-      rejected: {
+      rejected: (payload) => ({
         variant: 'danger',
         title: 'Failed updating role',
         dismissDelay: 8000,
         dismissable: false,
-        description: 'The role was not updated successfuly.',
-      },
+        description: payload?.errors?.[0]?.detail || 'The role was not updated successfuly.',
+      }),
     },
   },
 });

--- a/src/smart-components/role/add-role-new/add-role-wizard.js
+++ b/src/smart-components/role/add-role-new/add-role-wizard.js
@@ -125,10 +125,16 @@ const AddRoleWizard = ({ pagination, filters }) => {
         []
       ),
     };
-    return dispatch(createRole(roleData)).then(() => {
-      setWizardContextValue((prev) => ({ ...prev, submitting: false, success: true, hideForm: true }));
-      dispatch(fetchRolesWithPolicies({ limit: pagination.limit, inModal: false }));
-    });
+    return dispatch(createRole(roleData))
+      .then(() => {
+        setWizardContextValue((prev) => ({ ...prev, submitting: false, success: true, hideForm: true }));
+        dispatch(fetchRolesWithPolicies({ limit: pagination.limit, inModal: false }));
+      })
+      .catch(() => {
+        setWizardContextValue((prev) => ({ ...prev, submitting: false, success: false, hideForm: true }));
+        dispatch(fetchRolesWithPolicies({ limit: pagination.limit, inModal: false }));
+        onClose();
+      });
   };
 
   if (!schema) {
@@ -146,18 +152,20 @@ const AddRoleWizard = ({ pagination, filters }) => {
         onConfirmCancel={onCancel}
       />
       {wizardContextValue.hideForm ? (
-        <Wizard
-          title="Create role"
-          isOpen
-          onClose={onClose}
-          steps={[
-            {
-              name: 'success',
-              component: <AddRoleSuccess onClose={onClose} />,
-              isFinishedStep: true,
-            },
-          ]}
-        />
+        wizardContextValue.success ? (
+          <Wizard
+            title="Create role"
+            isOpen
+            onClose={onClose}
+            steps={[
+              {
+                name: 'success',
+                component: <AddRoleSuccess onClose={onClose} />,
+                isFinishedStep: true,
+              },
+            ]}
+          />
+        ) : null
       ) : (
         <FormRenderer
           schema={schema}

--- a/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
+++ b/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
@@ -97,9 +97,12 @@ const AddRolePermissionWizard = ({ role }) => {
     };
 
     setWizardContextValue((prev) => ({ ...prev, submitting: true }));
-    dispatch(updateRole(currentRoleID, roleData)).then(() =>
-      setWizardContextValue((prev) => ({ ...prev, submitting: false, success: true, hideForm: true }))
-    );
+    dispatch(updateRole(currentRoleID, roleData))
+      .then(() => setWizardContextValue((prev) => ({ ...prev, submitting: false, success: true, hideForm: true })))
+      .catch(() => {
+        setWizardContextValue((prev) => ({ ...prev, submitting: false, success: false, hideForm: true }));
+        history.push(`/roles/detail/${role.uuid}`);
+      });
   };
 
   return (
@@ -113,17 +116,19 @@ const AddRolePermissionWizard = ({ role }) => {
         onConfirmCancel={handleConfirmCancel}
       />
       {wizardContextValue.hideForm ? (
-        <Wizard
-          title="Add permissions"
-          isOpen
-          steps={[
-            {
-              name: 'success',
-              component: new AddRolePermissionSuccess({ currentRoleID }),
-              isFinishedStep: true,
-            },
-          ]}
-        />
+        wizardContextValue.success ? (
+          <Wizard
+            title="Add permissions"
+            isOpen
+            steps={[
+              {
+                name: 'success',
+                component: new AddRolePermissionSuccess({ currentRoleID }),
+                isFinishedStep: true,
+              },
+            ]}
+          />
+        ) : null
       ) : (
         <FormRenderer
           container={container}


### PR DESCRIPTION
Partially fixes: https://issues.redhat.com/browse/RHCLOUD-16716 and https://issues.redhat.com/browse/RHCLOUD-16875

- Enabled displaying of a more specific error message in create/update role notification.
- Fixed not hiding the add-role and add-permissions wizard when an error occurs during the submit.

Before:
https://user-images.githubusercontent.com/50696716/142600540-5b38dade-53fc-4ca4-b62b-e60eaa3c235d.mp4

Now:
https://user-images.githubusercontent.com/50696716/142600582-0e36794e-a3d5-44bd-9463-fa985d70819a.mp4




