### PR TITLE
Update warning modal close event.

### DIFF
--- a/src/smart-components/role/add-role-new/add-role-wizard.js
+++ b/src/smart-components/role/add-role-new/add-role-wizard.js
@@ -18,6 +18,7 @@ import TypeSelector from './type-selector';
 import { useHistory } from 'react-router-dom';
 import { createQueryParams } from '../../../helpers/shared/helpers';
 import paths from '../../../utilities/pathnames';
+
 import './add-role-wizard.scss';
 
 export const AddRoleWizardContext = createContext({
@@ -77,9 +78,16 @@ const AddRoleWizard = ({ pagination, filters }) => {
       );
     }
 
-    push({
-      pathname: paths.roles,
-      search: createQueryParams({ page: 1, per_page: pagination.limit, ...filters }),
+    setCancelWarningVisible(false);
+    /**
+     * This timeout should force React to wait for the modal close and push to history afterwards.
+     * That should fix the runtime error we are seeing in the production version of the code.
+     */
+    setTimeout(() => {
+      push({
+        pathname: paths.roles,
+        search: createQueryParams({ page: 1, per_page: pagination.limit, ...filters }),
+      });
     });
   };
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17120

@john-dupuy I was unable to reproduce this issue when running the code locally. But I've added changes around the warning modal close event because I have the following theory:

The cancel modal cancel action is pushed into the browser history. That history change forces the parent component (wizard modal) to close. That will destroy the parent focus trap of the cancel modal which will lead to the error we are seeing due to the nature of async rendering and React portals. However I can't confirm the theory because we can't reproduce the issue locally, only once the code was deployed.

I've added additional logic and pushed the history event to the end of the event loop, so the modal should properly close before the history change actually happens.

If this won't help, I will add a silent error boundary which will ignore errors with the `focus-trap` string and render nothing.

Unfortunately, we have to deploy the code to check if this change helped.
