### PR TITLE
Add silent error boundary to fix PF focus trap issues.

### DIFF
--- a/src/smart-components/common/silent-error-boundary.js
+++ b/src/smart-components/common/silent-error-boundary.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class SilentErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    /**
+     * Propagate error if it does not match the configuration
+     */
+    if (!error.message.includes(this.props.silentErrorString)) {
+      this.setState({ hasError: false });
+      throw error;
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // Silently fail
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+SilentErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  silentErrorString: PropTypes.string.isRequired,
+};
+
+export default SilentErrorBoundary;

--- a/src/smart-components/role/add-role-new/add-role-wizard.js
+++ b/src/smart-components/role/add-role-new/add-role-wizard.js
@@ -20,6 +20,7 @@ import { createQueryParams } from '../../../helpers/shared/helpers';
 import paths from '../../../utilities/pathnames';
 
 import './add-role-wizard.scss';
+import SilentErrorBoundary from '../../common/silent-error-boundary';
 
 export const AddRoleWizardContext = createContext({
   success: false,
@@ -150,15 +151,17 @@ const AddRoleWizard = ({ pagination, filters }) => {
   }
   return (
     <AddRoleWizardContext.Provider value={{ ...wizardContextValue, setWizardError, setWizardSuccess, setHideForm }}>
-      <WarningModal
-        type="role"
-        isOpen={cancelWarningVisible}
-        onModalCancel={() => {
-          container.current.hidden = false;
-          setCancelWarningVisible(false);
-        }}
-        onConfirmCancel={onCancel}
-      />
+      <SilentErrorBoundary silentErrorString="focus-trap">
+        <WarningModal
+          type="role"
+          isOpen={cancelWarningVisible}
+          onModalCancel={() => {
+            container.current.hidden = false;
+            setCancelWarningVisible(false);
+          }}
+          onConfirmCancel={onCancel}
+        />
+      </SilentErrorBoundary>
       {wizardContextValue.hideForm ? (
         wizardContextValue.success ? (
           <Wizard


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17120

As we are unable to manually reproduce the issue and the automated tests are still failing, I am adding a silent error boundary that will ignore the `focus-trap` issue as the component is destroyed anyway when the problem is occurring. I will continue investigating the issue and try to come up with a propper fix.