### PR TITLE
remove old "compound expandable table" mobile fix

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -15,14 +15,6 @@
 @media only screen and (max-width: 768px) {
   .rbac-m-hide-on-sm {display: none;}
 
-  // fix for mobile layout: https://github.com/patternfly/patternfly-react/issues/4922
-  .pf-c-table__expandable-row.pf-m-expanded {
-    max-height: none !important;
-    overflow-y: visible;
-    tr:first-of-type {padding-top: 0 !important;}
-    > td::before {display: none;}
-  }
-
   .rbac__user-row .pf-c-label{
     width: max-content;
   }


### PR DESCRIPTION
Local fix is no longer needed. It was fixed in Patternfly-react https://github.com/patternfly/patternfly-react/pull/5017