### PR TITLE
Fixing quickstarts trigger always being acitve

### DIFF
--- a/src/utilities/quickstarts-test-buttons.js
+++ b/src/utilities/quickstarts-test-buttons.js
@@ -27,8 +27,14 @@ const QuickstartsTestButtons = () => {
     }
   }, []);
 
+  useEffect(() => {
+    setOpenQuickstart(quickstartsContext.activeQuickStartID === '' ? false : true);
+  }, [quickstartsContext]);
+
   const handleActivateQuickstart = () => {
-    openQuickstart & (quickstartsContext.activeQuickStartID !== '') ? quickStarts.toggle() : quickStarts.toggle('monitor-sampleapp', {});
+    openQuickstart & (quickstartsContext.activeQuickStartID !== '' && typeof quickstartsContext.activeQuickStartID !== 'undefined')
+      ? quickStarts.toggle()
+      : quickStarts.toggle('monitor-sampleapp', {});
     setOpenQuickstart(!openQuickstart);
   };
 
@@ -44,7 +50,7 @@ const QuickstartsTestButtons = () => {
     <>
       {isQuickstartEnabled && (
         <>
-          <Button onClick={handleActivateQuickstart} variant={'primary'} style={btnStyle}>
+          <Button onClick={handleActivateQuickstart} variant={'primary'} style={btnStyle} isDisabled={openQuickstart}>
             Trigger my quickstart
           </Button>
           <Button onClick={handleOpenCatalog} variant={'primary'} style={btnStyle}>

--- a/src/utilities/quickstarts-test-buttons.js
+++ b/src/utilities/quickstarts-test-buttons.js
@@ -32,9 +32,7 @@ const QuickstartsTestButtons = () => {
   }, [quickstartsContext]);
 
   const handleActivateQuickstart = () => {
-    openQuickstart & (quickstartsContext.activeQuickStartID !== '' && typeof quickstartsContext.activeQuickStartID !== 'undefined')
-      ? quickStarts.toggle()
-      : quickStarts.toggle('monitor-sampleapp', {});
+    openQuickstart & !!quickstartsContext.activeQuickStartID ? quickStarts.toggle() : quickStarts.toggle('monitor-sampleapp', {});
     setOpenQuickstart(!openQuickstart);
   };
 


### PR DESCRIPTION
Making sure the user can't reactivate the pendo badge referenced [in this card](https://github.com/RedHatInsights/insights-chrome/pull/1780) by leaving the `Trigger my quickstart` button always active.

![Screen Shot 2022-02-21 at 1 16 55 PM](https://user-images.githubusercontent.com/56621323/155008801-54ed5ec2-ef96-4f3a-a440-052e2bb26eb7.png)
