### PR TITLE
Update of node-fetch module to version 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,12 +3107,12 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.4.tgz",
-      "integrity": "sha512-fariIRhk4D3Bvpz02cvmbxhPRLWADecLeYpR6xpnIQH64JSzJDoffKgiYoBgqFmoZTpsK+TseySBjtpmpcXjKA==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.7.tgz",
+      "integrity": "sha512-NtHktrBArEA1eFkCWxVes1UsufyPKEdiCYCaGE5dTRYKdNfUVKKfV2Hq1efADINO6SpYvKDy3YXDbSk8I6WGnQ==",
       "dev": true,
       "dependencies": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.11",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
         "babel-loader": "^8.2.2",
@@ -14296,9 +14296,9 @@
       }
     },
     "node_modules/showdown/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "engines": {
         "node": ">=4"
       }
@@ -18850,12 +18850,12 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.4.tgz",
-      "integrity": "sha512-fariIRhk4D3Bvpz02cvmbxhPRLWADecLeYpR6xpnIQH64JSzJDoffKgiYoBgqFmoZTpsK+TseySBjtpmpcXjKA==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.7.tgz",
+      "integrity": "sha512-NtHktrBArEA1eFkCWxVes1UsufyPKEdiCYCaGE5dTRYKdNfUVKKfV2Hq1efADINO6SpYvKDy3YXDbSk8I6WGnQ==",
       "dev": true,
       "requires": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.11",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
         "babel-loader": "^8.2.2",
@@ -27415,9 +27415,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
         },
         "camelcase": {
           "version": "4.1.0",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-18051

**Version before:**
insights-rbac-frontend@1.1.0 /Users/rkaluzik/rh/insights-rbac-ui
└─┬ cross-fetch@3.1.4 invalid: "^3.1.5" from the root project
  └── node-fetch@2.6.1

**Version after:**
insights-rbac-frontend@1.1.0 /Users/rkaluzik/rh/insights-rbac-ui
└─┬ cross-fetch@3.1.5
  └── node-fetch@2.6.7