### PR TITLE
Add ocp-advisor to the openshift bundle

### DIFF
--- a/src/presentational-components/myUserAccess/bundles.js
+++ b/src/presentational-components/myUserAccess/bundles.js
@@ -13,10 +13,11 @@ export const bundleData = [
     title: 'OpenShift',
     apps: {
       clusters: '/',
+      advisor: '/insights/advisor',
       subscriptions: '/subscriptions',
       'cost management': '/cost-management',
     },
-    appsIds: ['cost-management', 'subscriptions'],
+    appsIds: ['cost-management', 'subscriptions', 'ocp-advisor'],
   },
   {
     entitlement: 'rhel',


### PR DESCRIPTION
This adds OCP Advisor entry to the OpenShift bundle in RBAC UI.

OCP Advisor app config is defined here: https://github.com/RedHatInsights/cloud-services-config/blob/prod-stable/main.yml#L583.
The OCP Advisor roles: https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/roles/ocp-advisor.json.

![Screenshot 2022-04-12 at 10-35-21 rbac console redhat com](https://user-images.githubusercontent.com/31385370/162917950-672ddb78-b952-4751-bc12-ee121b108376.png)
