### PR TITLE
Use default filter settings only when no URL query

### DIFF
--- a/src/redux/reducers/user-reducer.js
+++ b/src/redux/reducers/user-reducer.js
@@ -7,7 +7,7 @@ export const usersInitialState = {
   isUserDataLoading: false,
   users: {
     meta: defaultSettings,
-    filters: { status: ['Active'] },
+    filters: {},
     pagination: { ...defaultSettings, redirected: false },
   },
 };

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -89,7 +89,7 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
       userReducer: {
         users: { filters },
       },
-    }) => filters
+    }) => (history.location.search.length > 0 ? filters : { status: ['Active'] })
   );
 
   const [filters, setFilters] = useState(


### PR DESCRIPTION
Before in Users, the default "Active" filter was added every time when the URL query params for filtering were not defined. Now it is being added only for a URL with no query params at all expecting that if URL contains any query params, user wants exactly this view and no automatically added options.

https://issues.redhat.com/browse/RHCLOUD-18748