### PR TITLE
[POC] WS data invalidation model

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -14,7 +14,7 @@ const webpackProxy = {
   useProxy: true,
   proxyVerbose: true,
   env: 'stage-beta',
-  // localChrome: '/Users/hq/SoftwareDev/arivepr/insights-chrome/build/',
+  localChrome: '/home/martin/insights/insights-chrome/build/',
   appUrl: process.env.BETA ? ['/beta/settings/my-user-access', '/beta/settings/rbac'] : ['/settings/my-user-access', '/settings/rbac'],
 };
 

--- a/src/redux/experimental/groups-actions.js
+++ b/src/redux/experimental/groups-actions.js
@@ -1,0 +1,42 @@
+import { getAxiosInstance } from '../../helpers/shared/user-login';
+import { EXPERIMENTAL_GROUPS_PAGINATED } from './groups-reducer';
+
+const generateQuery = (base, params) => {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, val]) => {
+    if (typeof val !== 'object' && typeof val !== 'undefined') {
+      search.append(key, val);
+    }
+  });
+  return `${base}?${search.toString()}`;
+};
+
+const createAction = (baseUrl, { filters, ...params }, options) => {
+  const query = generateQuery(baseUrl, params);
+  return {
+    meta: {
+      query,
+    },
+    prefferCache: true,
+    reducer: 'experimentalGroupsReducer',
+    reqType: options.reqType,
+    req: () =>
+      getAxiosInstance()({
+        url: generateQuery(baseUrl, params),
+        ...options,
+      }).then((response) => ({
+        ...response,
+        filters,
+        pagination: {
+          ...response?.meta,
+          offset: params.offset,
+          limit: params.limit,
+        },
+      })),
+  };
+};
+
+export const experimentalFetchGroups = (params = {}, options = {}) => ({
+  type: EXPERIMENTAL_GROUPS_PAGINATED,
+  ...createAction('/api/rbac/v1/groups/', params, { ...options, reqType: 'list' }),
+});

--- a/src/redux/experimental/groups-actions.js
+++ b/src/redux/experimental/groups-actions.js
@@ -1,5 +1,5 @@
 import { getAxiosInstance } from '../../helpers/shared/user-login';
-import { EXPERIMENTAL_GROUPS_PAGINATED } from './groups-reducer';
+import { EXPERIMENTAL_GET_GROUP_ENTITY, EXPERIMENTAL_GROUPS_PAGINATED } from './groups-reducer';
 
 const generateQuery = (base, params) => {
   const search = new URLSearchParams();
@@ -8,14 +8,16 @@ const generateQuery = (base, params) => {
       search.append(key, val);
     }
   });
-  return `${base}?${search.toString()}`;
+  const query = search.toString();
+  return `${base}${query.length > 0 ? `?${search.toString()}` : ''}`;
 };
 
-const createAction = (baseUrl, { filters, ...params }, options) => {
+const createAction = (baseUrl, { filters, entityId, ...params } = {}, options) => {
   const query = generateQuery(baseUrl, params);
   return {
     meta: {
       query,
+      entityId,
     },
     prefferCache: true,
     reducer: 'experimentalGroupsReducer',
@@ -35,6 +37,11 @@ const createAction = (baseUrl, { filters, ...params }, options) => {
       })),
   };
 };
+
+export const experimentalFetchGroup = (uuid) => ({
+  type: EXPERIMENTAL_GET_GROUP_ENTITY,
+  ...createAction(`/api/rbac/v1/groups/${uuid}/`, { entityId: uuid }, { reqType: 'entity' }),
+});
 
 export const experimentalFetchGroups = (params = {}, options = {}) => ({
   type: EXPERIMENTAL_GROUPS_PAGINATED,

--- a/src/redux/experimental/groups-reducer.js
+++ b/src/redux/experimental/groups-reducer.js
@@ -3,8 +3,10 @@ import { defaultSettings } from '../../helpers/shared/pagination';
 const STORAGE_TOMEOUT = 10 * 60 * 1000;
 export const EXPERIMENTAL_GROUPS_PAGINATED = '@@rbac/experimental/groups/paginated';
 export const EXPERIMENTAL_UPDATE_GROUP_ENTITY = '@@rbac/experimental/group/entity/update';
+export const EXPERIMENTAL_GET_GROUP_ENTITY = '@@rbac/experimental/group/entity/get';
 
 export const experimentalGroupsReducerInitialState = {
+  activeEntity: Symbol(''),
   storage: {
     pages: {},
     entities: {},
@@ -15,7 +17,6 @@ export const experimentalGroupsReducerInitialState = {
     filters: {},
     pagination: { ...defaultSettings, count: 0 },
   },
-  selectedGroup: { addRoles: {}, members: { meta: defaultSettings }, pagination: defaultSettings },
   isLoading: false,
   isRecordLoading: false,
 };
@@ -45,7 +46,6 @@ const updateGroup = (state, { payload }) => {
 
 const storePaginatedData = (state, { payload: { data, ...rest }, meta: { query } }) => {
   const expiration = Date.now() + STORAGE_TOMEOUT;
-  console.log({ data, rest, query });
   return {
     ...state,
     isLoading: false,
@@ -78,12 +78,44 @@ const storePaginatedData = (state, { payload: { data, ...rest }, meta: { query }
 };
 
 const setLoadingState = (state) => ({ ...state, error: undefined, isLoading: true });
+const setRecordLoadingState = (state) => ({ ...state, error: undefined, isRecordLoading: true });
+
+const setEntityData = (state, { payload, meta }) => {
+  const expiration = Date.now() + STORAGE_TOMEOUT;
+  return {
+    ...state,
+    isRecordLoading: false,
+    /**
+     * We have to use symbols to ensure immutability of the entity.
+     * 'x' === 'x' but Symbol('x') !== Symbol('x')
+     */
+    activeEntity: Symbol(meta.entityId),
+    storage: {
+      ...state.storage,
+      entities: {
+        ...state.storage.entities,
+        [meta.entityId]: {
+          ...payload,
+          expiration,
+        },
+      },
+    },
+  };
+};
+
+const setGroup = (state, { payload }) => ({
+  ...state,
+  activeEntity: Symbol(payload),
+});
 
 const experimentalGroupsReducer = {
   [`${EXPERIMENTAL_GROUPS_PAGINATED}_PENDING`]: setLoadingState,
   [`${EXPERIMENTAL_GROUPS_PAGINATED}_FULFILLED`]: storePaginatedData,
   [`${EXPERIMENTAL_GROUPS_PAGINATED}_SET`]: setGroups,
   [EXPERIMENTAL_UPDATE_GROUP_ENTITY]: updateGroup,
+  [`${EXPERIMENTAL_GET_GROUP_ENTITY}_PENDING`]: setRecordLoadingState,
+  [`${EXPERIMENTAL_GET_GROUP_ENTITY}_FULFILLED`]: setEntityData,
+  [`${EXPERIMENTAL_GET_GROUP_ENTITY}_SET`]: setGroup,
 };
 
 export default experimentalGroupsReducer;

--- a/src/redux/experimental/groups-reducer.js
+++ b/src/redux/experimental/groups-reducer.js
@@ -1,0 +1,89 @@
+import { defaultSettings } from '../../helpers/shared/pagination';
+
+const STORAGE_TOMEOUT = 10 * 60 * 1000;
+export const EXPERIMENTAL_GROUPS_PAGINATED = '@@rbac/experimental/groups/paginated';
+export const EXPERIMENTAL_UPDATE_GROUP_ENTITY = '@@rbac/experimental/group/entity/update';
+
+export const experimentalGroupsReducerInitialState = {
+  storage: {
+    pages: {},
+    entities: {},
+  },
+  groups: {
+    data: [],
+    meta: defaultSettings,
+    filters: {},
+    pagination: { ...defaultSettings, count: 0 },
+  },
+  selectedGroup: { addRoles: {}, members: { meta: defaultSettings }, pagination: defaultSettings },
+  isLoading: false,
+  isRecordLoading: false,
+};
+
+const setGroups = (state, { payload }) => ({
+  ...state,
+  groups: payload,
+});
+
+const updateGroup = (state, { payload }) => {
+  const newGroup = { ...payload, expiration: Date.now() + STORAGE_TOMEOUT };
+  return {
+    ...state,
+    groups: {
+      ...state.groups,
+      data: state.groups.data.map((group) => (group.uuid === newGroup.uuid ? newGroup : group)),
+    },
+    storage: {
+      ...state.storage,
+      entities: {
+        ...state.storage.entities,
+        [payload.uuid]: newGroup,
+      },
+    },
+  };
+};
+
+const storePaginatedData = (state, { payload: { data, ...rest }, meta: { query } }) => {
+  const expiration = Date.now() + STORAGE_TOMEOUT;
+  console.log({ data, rest, query });
+  return {
+    ...state,
+    isLoading: false,
+    groups: {
+      ...state.groups,
+      ...rest,
+      data,
+    },
+    storage: {
+      pages: {
+        ...state?.storage?.pages,
+        [query]: {
+          entities: data.map(({ uuid }) => uuid),
+          expiration,
+          ...rest,
+        },
+      },
+      entities: data.reduce(
+        (acc, curr) => ({
+          ...acc,
+          [curr.uuid]: {
+            ...curr,
+            expiration,
+          },
+        }),
+        state?.storage?.entities
+      ),
+    },
+  };
+};
+
+const setLoadingState = (state) => ({ ...state, error: undefined, isLoading: true });
+
+const experimentalGroupsReducer = {
+  [`${EXPERIMENTAL_GROUPS_PAGINATED}_PENDING`]: setLoadingState,
+  [`${EXPERIMENTAL_GROUPS_PAGINATED}_FULFILLED`]: storePaginatedData,
+  [`${EXPERIMENTAL_GROUPS_PAGINATED}_SET`]: setGroups,
+  [EXPERIMENTAL_UPDATE_GROUP_ENTITY]: updateGroup,
+};
+
+export default experimentalGroupsReducer;

--- a/src/redux/experimental/groups-reducer.js
+++ b/src/redux/experimental/groups-reducer.js
@@ -7,12 +7,12 @@ export const EXPERIMENTAL_GET_GROUP_ENTITY = '@@rbac/experimental/group/entity/g
 
 export const experimentalGroupsReducerInitialState = {
   activeEntity: Symbol(''),
+  activePage: Symbol(''),
   storage: {
     pages: {},
     entities: {},
   },
-  groups: {
-    data: [],
+  defaultPageMeta: {
     meta: defaultSettings,
     filters: {},
     pagination: { ...defaultSettings, count: 0 },
@@ -23,17 +23,13 @@ export const experimentalGroupsReducerInitialState = {
 
 const setGroups = (state, { payload }) => ({
   ...state,
-  groups: payload,
+  activePage: Symbol(payload),
 });
 
 const updateGroup = (state, { payload }) => {
   const newGroup = { ...payload, expiration: Date.now() + STORAGE_TOMEOUT };
   return {
     ...state,
-    groups: {
-      ...state.groups,
-      data: state.groups.data.map((group) => (group.uuid === newGroup.uuid ? newGroup : group)),
-    },
     storage: {
       ...state.storage,
       entities: {
@@ -46,14 +42,11 @@ const updateGroup = (state, { payload }) => {
 
 const storePaginatedData = (state, { payload: { data, ...rest }, meta: { query } }) => {
   const expiration = Date.now() + STORAGE_TOMEOUT;
+
   return {
     ...state,
+    activePage: Symbol(query),
     isLoading: false,
-    groups: {
-      ...state.groups,
-      ...rest,
-      data,
-    },
     storage: {
       pages: {
         ...state?.storage?.pages,

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,9 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { AppPlaceholder } from './presentational-components/shared/loader-placeholders';
 import pathnames from './utilities/pathnames';
 import QuickstartsTestButtons from './utilities/quickstarts-test-buttons';
+import { useDispatch } from 'react-redux';
+import { fetchGroup } from './helpers/group/group-helper';
+import { EXPERIMENTAL_UPDATE_GROUP_ENTITY } from './redux/experimental/groups-reducer';
 
 const Groups = lazy(() => import('./smart-components/group/groups'));
 const Roles = lazy(() => import('./smart-components/role/roles'));
@@ -14,10 +17,14 @@ const QuickstartsTest = lazy(() => import('./smart-components/quickstarts/quicks
 
 export const Routes = () => {
   const { registerEvent } = useChrome();
+  const dispatch = useDispatch();
   console.log({ registerEvent });
   useEffect(() => {
     if (typeof registerEvent === 'function') {
-      registerEvent('invalidate', 'rbac', 'group', (data) => console.log('RBAC EVENT: ', data));
+      registerEvent('invalidate', 'rbac', 'group', (data) => {
+        console.log('invalidate rbac group', data);
+        fetchGroup(data.uuid).then((resp) => dispatch({ type: EXPERIMENTAL_UPDATE_GROUP_ENTITY, payload: resp }));
+      });
     }
   }, []);
   return (

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,6 @@
 import { Route, Switch, Redirect } from 'react-router-dom';
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { AppPlaceholder } from './presentational-components/shared/loader-placeholders';
 import pathnames from './utilities/pathnames';
 import QuickstartsTestButtons from './utilities/quickstarts-test-buttons';
@@ -12,6 +13,13 @@ const AccessRequests = lazy(() => import('./smart-components/accessRequests/acce
 const QuickstartsTest = lazy(() => import('./smart-components/quickstarts/quickstarts-test'));
 
 export const Routes = () => {
+  const { registerEvent } = useChrome();
+  console.log({ registerEvent });
+  useEffect(() => {
+    if (typeof registerEvent === 'function') {
+      registerEvent('invalidate', 'rbac', 'group', (data) => console.log('RBAC EVENT: ', data));
+    }
+  }, []);
   return (
     <Suspense fallback={<AppPlaceholder />}>
       <QuickstartsTestButtons />

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -8,7 +8,7 @@ import RemoveGroup from './remove-group-modal';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { TableToolbarView } from '../../presentational-components/shared/table-toolbar-view';
 import { createRows } from './group-table-helpers';
-import { fetchAdminGroup, fetchGroups, fetchSystemGroup } from '../../redux/actions/group-actions';
+import { fetchAdminGroup, fetchSystemGroup } from '../../redux/actions/group-actions';
 import Group from './group';
 import { TopToolbar, TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
 import Section from '@redhat-cloud-services/frontend-components/Section';
@@ -21,6 +21,7 @@ import { applyPaginationToUrl, isPaginationPresentInUrl, syncDefaultPaginationWi
 import { applyFiltersToUrl, areFiltersPresentInUrl, syncDefaultFiltersWithUrl } from '../../helpers/shared/filters';
 import { getBackRoute } from '../../helpers/shared/helpers';
 import PermissionsContext from '../../utilities/permissions-context';
+import { experimentalFetchGroups } from '../../redux/experimental/groups-actions';
 
 const columns = [
   { title: 'Name', key: 'name', transforms: [sortable] },
@@ -32,12 +33,12 @@ const columns = [
 const Groups = () => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const fetchData = (options) => dispatch(fetchGroups({ ...options, inModal: false }));
+  const fetchData = (options) => dispatch(experimentalFetchGroups({ ...options, name: options?.filters?.name, inModal: false }));
   const { orgAdmin, userAccessAdministrator } = useContext(PermissionsContext);
   const isAdmin = orgAdmin || userAccessAdministrator;
 
   const { groups, meta, filters, isLoading } = useSelector(
-    ({ groupReducer: { groups, isLoading, adminGroup, systemGroup } }) => ({
+    ({ experimentalGroupsReducer: { groups, isLoading, adminGroup, systemGroup } }) => ({
       groups: [
         ...(adminGroup?.name?.match(new RegExp(groups.filters.name, 'i')) ? [adminGroup] : []),
         ...(systemGroup?.name?.match(new RegExp(groups.filters.name, 'i')) ? [systemGroup] : []),

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -45,13 +45,7 @@ const experimentalInvalidationMiddleware = (store) => (next) => (action) => {
       if (typeof page !== 'undefined' && page.expiration >= ts) {
         const newAction = {
           type: `${action.type}_SET`,
-          payload: {
-            filters: page.filters,
-            links: page.links,
-            meta: page.meta,
-            pagination: page.pagination,
-            data: page.entities.map((uuid) => state.entities[uuid]),
-          },
+          payload: query,
           meta: {
             query,
           },

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -35,7 +35,7 @@ const experimentalInvalidationMiddleware = (store) => (next) => (action) => {
    */
   if (action.prefferCache && action.req) {
     const ts = Date.now();
-    const query = action.meta.query;
+    const query = action?.meta?.query;
     const state = store.getState()[action.reducer]?.storage;
     /**
      * get data list from cache
@@ -64,6 +64,15 @@ const experimentalInvalidationMiddleware = (store) => (next) => (action) => {
       } else if (!page || (state && page.expiration < ts)) {
         return next(constructFetchAction(action));
       }
+    } else if (state && action.reqType === 'entity') {
+      const entity = state.entities[action?.meta?.entityId];
+      const newAction = entity
+        ? {
+            type: `${action.type}_SET`,
+            payload: action?.meta?.entityId,
+          }
+        : constructFetchAction(action);
+      return next(newAction);
     }
     /**
      * Bypass cache


### PR DESCRIPTION
requires: https://github.com/RedHatInsights/insights-chrome/pull/1895

### Description

This POC introduces data invalidation and caching using websockets. Data for RBAC groups is only fetched if the cache is non-existing or stale.

Please do not take the implementation seriously. We would need a proper client library to automate most of the setup. Also, the actual data store could be embedded into chrome. Something to think about. Read more about the WS in the linked chrome POC draft
