### PR TITLE
Fix Clear all filters

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -25,6 +25,7 @@ export const TableToolbarView = ({
   pagination,
   filterValue,
   isLoading,
+  emptyFilters,
   setFilterValue,
   checkedRows,
   isSelectable,
@@ -85,15 +86,11 @@ export const TableToolbarView = ({
                     variant="link"
                     ouiaId="clear-filters-button"
                     onClick={() => {
-                      setFilterValue({
-                        ...pagination,
-                        offset: 0,
-                        name: '',
-                      });
+                      setFilterValue(emptyFilters);
                       fetchData({
                         ...pagination,
                         offset: 0,
-                        name: '',
+                        ...(emptyFilters ? emptyFilters : { name: '' }),
                       });
                     }}
                   >
@@ -233,6 +230,7 @@ TableToolbarView.propTypes = {
   rowWrapper: propTypes.any,
   isCompact: propTypes.bool,
   borders: propTypes.bool,
+  emptyFilters: propTypes.object,
   checkedRows: propTypes.array,
   createRows: propTypes.func.isRequired,
   columns: propTypes.array.isRequired,
@@ -254,6 +252,7 @@ TableToolbarView.propTypes = {
 
 TableToolbarView.defaultProps = {
   ...Toolbar.defaultProps,
+  emptyFilters: {},
   isCompact: false,
   borders: true,
   routes: () => null,

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -149,6 +149,7 @@ const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, paginatio
         inModal || applyPaginationToUrl(history, limit, offset);
         inModal || applyFiltersToUrl(history, { username, email, status });
       }}
+      emptyFilters={{ username: '', email: '', status: '' }}
       setFilterValue={({ username, email, status }) => {
         updateFilters({
           username: typeof username === 'undefined' ? filters.username : username,

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -218,7 +218,7 @@ const Groups = () => {
               applyFiltersToUrl(history, { name });
               return fetchData({ count, limit, offset, orderBy, filters: { name } });
             }}
-            setFilterValue={({ name }) => setFilterValue(name)}
+            setFilterValue={({ name = '' }) => setFilterValue(name)}
             toolbarButtons={toolbarButtons}
             isLoading={!isLoading && groups?.length === 0 && filterValue?.length === 0 ? true : isLoading}
             filterPlaceholder="name"

--- a/src/smart-components/myUserAccess/MUARolesTable.js
+++ b/src/smart-components/myUserAccess/MUARolesTable.js
@@ -140,6 +140,7 @@ const MUARolesTable = ({
           debouncedFetch(limit, offset, name, application, permission, orderBy);
         }}
         sortBy={{ index: 0, direction: 'asc' }}
+        emptyFilters={{ name: '', application: [] }}
         setFilterValue={setFilters}
         isLoading={isLoading}
         pagination={roles.meta}

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -161,7 +161,7 @@ const Roles = () => {
               applyFiltersToUrl(history, { display_name: name });
               return fetchData(mappedProps({ count, limit, offset, orderBy, filters: { display_name: name } }));
             }}
-            setFilterValue={({ name }) => setFilterValue(name)}
+            setFilterValue={({ name = '' }) => setFilterValue(name)}
             isLoading={!isLoading && roles?.length === 0 && filterValue?.length === 0 ? true : isLoading}
             pagination={pagination}
             routes={routes}

--- a/src/test/role/__snapshots__/roles.test.js.snap
+++ b/src/test/role/__snapshots__/roles.test.js.snap
@@ -54,6 +54,7 @@ exports[`<Roles /> should render correctly 1`] = `
       },
     ]
   }
+  emptyFilters={Object {}}
   fetchData={[Function]}
   filterItems={Array []}
   filterPlaceholder="name"
@@ -150,6 +151,7 @@ exports[`<Roles /> should render correctly in org admin 1`] = `
       },
     ]
   }
+  emptyFilters={Object {}}
   fetchData={[Function]}
   filterItems={Array []}
   filterPlaceholder="name"

--- a/src/test/smart-components/group/principal/__snapshots__/principals.test.js.snap
+++ b/src/test/smart-components/group/principal/__snapshots__/principals.test.js.snap
@@ -50,6 +50,7 @@ exports[`<GroupPrincipals /> should render correctly with data 1`] = `
       },
     ]
   }
+  emptyFilters={Object {}}
   emptyProps={
     Object {
       "description": Array [
@@ -257,6 +258,7 @@ exports[`<GroupPrincipals /> should render correctly with org admin rights 1`] =
       },
     ]
   }
+  emptyFilters={Object {}}
   emptyProps={
     Object {
       "description": Array [

--- a/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
+++ b/src/test/smart-components/group/role/__snapshots__/group-roles.test.js.snap
@@ -21,6 +21,7 @@ exports[`<GroupPrincipals /> should render empty correctly 1`] = `
   }
   createRows={[Function]}
   data={Array []}
+  emptyFilters={Object {}}
   emptyProps={
     Object {
       "description": Array [


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-19135

In settings/rbac/users (groups, roles or MUA) Button "Clear all filters" cleared filters, but left text in search input and filter chips visible. This should be fixed now.