### PR TITLE
Make Default Access Group visible again

### DIFF
--- a/src/redux/actions/group-actions.js
+++ b/src/redux/actions/group-actions.js
@@ -31,10 +31,8 @@ export const fetchSystemGroup = (filterValue) => ({
   type: ActionTypes.FETCH_SYSTEM_GROUP,
   payload: GroupHelper.fetchGroups({
     limit: 1,
-    filters: { name: filterValue },
-    nameMatch: 'partial',
+    ...(filterValue?.length > 0 ? { filters: { name: filterValue }, nameMatch: 'partial' } : {}),
     platformDefault: true,
-    system: false,
   }),
 });
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHCLOUD-20903

Fixed fetching default access group - `system=false` made it being fetched only as a "Custom default"