### PR TITLE
Fix default group ID in requests

### DIFF
--- a/locales/translation-template.json
+++ b/locales/translation-template.json
@@ -827,6 +827,10 @@
     "defaultMessage": "Success removing role",
     "description": "Remove role success notification title"
   },
+  "removeRoles": {
+    "defaultMessage": "Remove roles",
+    "description": "Remove roles label"
+  },
   "removeRolesModalText": {
     "defaultMessage": "Members in the <b>{name}</b> group will lose the permissions in these <b>{roles}</b> roles",
     "description": "Remove role message warning about losing permissions"

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -793,6 +793,11 @@ export default defineMessages({
     description: 'Remove role label',
     defaultMessage: 'Remove role',
   },
+  removeRoles: {
+    id: 'removeRoles',
+    description: 'Remove roles label',
+    defaultMessage: 'Remove roles',
+  },
   removeRoleQuestion: {
     id: 'removeRoleQuestion',
     description: 'Remove role question label',

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -207,6 +207,7 @@
     "removeRoleQuestion": "Remove role?",
     "removeRoleSuccessDescription": "The role was removed successfully.",
     "removeRoleSuccessTitle": "Success removing role",
+    "removeRoles": "Remove roles",
     "removeRolesModalText": "Members in the <b>{name}</b> group will lose the permissions in these <b>{roles}</b> roles",
     "removeRolesQuestion": "Remove roles?",
     "required": "Required",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -206,6 +206,7 @@
   "removeRoleQuestion": "Remove role?",
   "removeRoleSuccessDescription": "The role was removed successfully.",
   "removeRoleSuccessTitle": "Success removing role",
+  "removeRoles": "Remove roles",
   "removeRolesModalText": "Members in the <b>{name}</b> group will lose the permissions in these <b>{roles}</b> roles",
   "removeRolesQuestion": "Remove roles?",
   "required": "Required",

--- a/src/redux/actions/group-actions.js
+++ b/src/redux/actions/group-actions.js
@@ -1,8 +1,10 @@
 import * as ActionTypes from '../action-types';
 import * as GroupHelper from '../../helpers/group/group-helper';
-import { useIntl } from 'react-intl';
+import { createIntl, createIntlCache } from 'react-intl';
 import { BAD_UUID } from '../../helpers/shared/helpers';
 import messages from '../../Messages';
+import providerMessages from '../../locales/data.json';
+import { locale } from '../../AppEntry';
 
 const handleUuidError = (err) => {
   const error = err?.errors?.[0] || {};
@@ -63,7 +65,8 @@ export const addGroup = (groupData) => ({
 });
 
 export const updateGroup = (groupData) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.UPDATE_GROUP,
     payload: GroupHelper.updateGroup(groupData),
@@ -89,7 +92,8 @@ export const updateGroup = (groupData) => {
 };
 
 export const removeGroups = (uuids) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.REMOVE_GROUPS,
     payload: GroupHelper.removeGroups(uuids),
@@ -115,7 +119,8 @@ export const resetSelectedGroup = () => ({
 });
 
 export const addMembersToGroup = (groupId, members) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.ADD_MEMBERS_TO_GROUP,
     payload: GroupHelper.addPrincipalsToGroup(groupId, members),
@@ -139,7 +144,8 @@ export const addMembersToGroup = (groupId, members) => {
 };
 
 export const removeMembersFromGroup = (groupId, members) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.REMOVE_MEMBERS_FROM_GROUP,
     payload: GroupHelper.deletePrincipalsFromGroup(groupId, members),
@@ -178,7 +184,8 @@ export const fetchAddRolesForGroup = (groupId, pagination, options) => ({
 });
 
 export const addRolesToGroup = (groupId, roles) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.ADD_ROLES_TO_GROUP,
     payload: GroupHelper.addRolesToGroup(groupId, roles),
@@ -202,7 +209,8 @@ export const addRolesToGroup = (groupId, roles) => {
 };
 
 export const removeRolesFromGroup = (groupId, roles) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.REMOVE_ROLES_FROM_GROUP,
     payload: GroupHelper.deleteRolesFromGroup(groupId, roles),

--- a/src/redux/actions/policy-actions.js
+++ b/src/redux/actions/policy-actions.js
@@ -1,7 +1,9 @@
 import * as ActionTypes from '../action-types';
 import * as PolicyHelper from '../../helpers/policy/policy-helper';
-import { useIntl } from 'react-intl';
+import { createIntl, createIntlCache } from 'react-intl';
 import messages from '../../Messages';
+import providerMessages from '../../locales/data.json';
+import { locale } from '../../AppEntry';
 
 export const fetchGroupPolicies = (options = {}) => ({
   type: ActionTypes.FETCH_GROUP_POLICIES,
@@ -14,7 +16,8 @@ export const fetchPolicy = (apiProps) => ({
 });
 
 export const createPolicy = (policyData) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.ADD_POLICY,
     payload: PolicyHelper.createPolicy(policyData),
@@ -38,7 +41,8 @@ export const createPolicy = (policyData) => {
 };
 
 export const removePolicy = (policy) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.REMOVE_POLICY,
     payload: PolicyHelper.removePolicy(policy),
@@ -56,7 +60,8 @@ export const removePolicy = (policy) => {
 };
 
 export const updatePolicy = (uuid, policyData) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.UPDATE_POLICY,
     payload: PolicyHelper.updatePolicy(uuid, policyData),

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -1,11 +1,14 @@
 import * as ActionTypes from '../action-types';
 import * as RoleHelper from '../../helpers/role/role-helper';
 import { BAD_UUID } from '../../helpers/shared/helpers';
-import { useIntl } from 'react-intl';
+import { createIntl, createIntlCache } from 'react-intl';
 import messages from '../../Messages';
+import providerMessages from '../../locales/data.json';
+import { locale } from '../../AppEntry';
 
 export const createRole = (roleData) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.ADD_ROLE,
     payload: RoleHelper.createRole(roleData),
@@ -52,7 +55,8 @@ export const fetchRolesWithPolicies = (options = {}) => ({
 });
 
 export const removeRole = (role) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.REMOVE_ROLE,
     payload: RoleHelper.removeRole(role),
@@ -91,7 +95,8 @@ export const fetchRolesForWizard = (options = {}) => ({
 });
 
 export const updateRole = (roleId, data, useCustomAccess) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.UPDATE_ROLE,
     payload: RoleHelper.updateRole(roleId, data, useCustomAccess),
@@ -109,7 +114,8 @@ export const updateRole = (roleId, data, useCustomAccess) => {
 };
 
 export const patchRole = (roleId, data) => {
-  const intl = useIntl();
+  const cache = createIntlCache();
+  const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
     type: ActionTypes.PATCH_ROLE,
     payload: RoleHelper.patchRole(roleId, data),

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -71,9 +71,9 @@ const Group = ({
 
   useEffect(() => {
     fetchSystemGroup();
-    const currUuid = uuid !== 'default-access' ? uuid : systemGroupUuid;
-    fetchData(currUuid);
+    const currUuid = !isPlatformDefault ? uuid : systemGroupUuid;
     if (currUuid) {
+      fetchData(systemGroupUuid);
       insights.chrome.appObjectId(currUuid);
       return () => insights.chrome.appObjectId(undefined);
     }

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -152,7 +152,7 @@ const GroupRoles = ({
         values={{
           b: (text) => <b>{text}</b>,
           name,
-          role,
+          ...(plural ? { roles: role } : { role }),
         }}
       />
     </p>

--- a/src/smart-components/group/role/group-roles.js
+++ b/src/smart-components/group/role/group-roles.js
@@ -158,13 +158,15 @@ const GroupRoles = ({
     </p>
   );
 
+  const fetchUuid = uuid !== 'default-access' ? uuid : systemGroupUuid;
+
   const actionResolver = () => [
     ...(hasPermissions.current && !isAdminDefault
       ? [
           {
             title: intl.formatMessage(messages.remove),
             onClick: (_event, _rowId, role) => {
-              setConfirmDelete(() => () => removeRoles(uuid, [role.uuid], () => fetchRolesForGroup({ ...pagination, offset: 0 })(uuid)));
+              setConfirmDelete(() => () => removeRoles(fetchUuid, [role.uuid], () => fetchRolesForGroup({ ...pagination, offset: 0 })(fetchUuid)));
               setDeleteInfo({
                 title: intl.formatMessage(messages.removeRoleQuestion),
                 confirmButtonLabel: intl.formatMessage(messages.removeRole),
@@ -176,8 +178,6 @@ const GroupRoles = ({
         ]
       : []),
   ];
-
-  const fetchUuid = uuid !== 'default-access' ? uuid : systemGroupUuid;
 
   const routes = () => (
     <Fragment>
@@ -211,7 +211,7 @@ const GroupRoles = ({
       ? [
           <Link
             className={`rbac-m-hide-on-sm rbac-c-button__add-role${disableAddRoles && '-disabled'}`}
-            to={`/groups/detail/${uuid}/roles/add_roles`}
+            to={`/groups/detail/${fetchUuid}/roles/add_roles`}
             key="add-to-group"
           >
             {addRoleButton(disableAddRoles, generateOuiaID(name || ''), isAdminDefault && intl.formatMessage(messages.defaultGroupNotManually))}
@@ -237,9 +237,9 @@ const GroupRoles = ({
               setConfirmDelete(
                 () => () =>
                   removeRoles(
-                    uuid,
+                    fetchUuid,
                     selectedRoles.map((role) => role.uuid),
-                    () => fetchRolesForGroup({ ...pagination, offset: 0 })(uuid)
+                    () => fetchRolesForGroup({ ...pagination, offset: 0 })(fetchUuid)
                   )
               );
               setDeleteInfo({


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHCLOUD-20961

- fixed passing a real default group uuid in the API requests to avoid errors
- also added missing translations
- removed unwanted usage of the `useIntl` hook 