### PR TITLE
Fix editingGroupTitle translation ID

### DIFF
--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -69,7 +69,7 @@ const EditGroupModal = ({
     addNotification({
       variant: 'warning',
       dismissDelay: 8000,
-      title: intl.formatMessage(selectedGroup ? messages.editingGroup : messages.addingGroupTitle),
+      title: intl.formatMessage(selectedGroup ? messages.editingGroupTitle : messages.addingGroupTitle),
       description: intl.formatMessage(selectedGroup ? messages.editGroupCanceledDescription : messages.addingGroupCanceledDescription),
     });
     onClose();


### PR DESCRIPTION
Fix editingGroupTitle translation ID making the user unable to close the edit modal