### PR TITLE
Check cost-management access in add permissions

### DIFF
--- a/locales/translation-template.json
+++ b/locales/translation-template.json
@@ -583,6 +583,10 @@
     "defaultMessage": "No",
     "description": "No label"
   },
+  "noCostManagementPermissions": {
+    "defaultMessage": "You are not entitled to add cost-management permissions to your role.",
+    "description": "No Cost management permissions message"
+  },
   "noGroupMembers": {
     "defaultMessage": "There are no members in this group",
     "description": "No members in a given group title"

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1111,6 +1111,11 @@ export default defineMessages({
     description: 'Configure resources for permission message',
     defaultMessage: 'To add this permission to your role and define specific resources for it, at least one data source must be connected.',
   },
+  noCostManagementPermissions: {
+    id: 'noCostManagementPermissions',
+    description: 'No Cost management permissions message',
+    defaultMessage: 'You are not entitled to add cost-management permissions to your role.',
+  },
   configureCostSources: {
     id: 'configureCostSources',
     description: 'Configure resources for Cost management message',

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -146,6 +146,7 @@
     "nameAlreadyTaken": "Name has already been taken.",
     "nameAndDescription": "Name and description",
     "no": "No",
+    "noCostManagementPermissions": "You are not entitled to add cost-management permissions to your role.",
     "noGroupMembers": "There are no members in this group",
     "noGroupRoles": "There are no roles in this group",
     "noMatchingItemsFound": "No matching {items} found",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -145,6 +145,7 @@
   "nameAlreadyTaken": "Name has already been taken.",
   "nameAndDescription": "Name and description",
   "no": "No",
+  "noCostManagementPermissions": "You are not entitled to add cost-management permissions to your role.",
   "noGroupMembers": "There are no members in this group",
   "noGroupRoles": "There are no roles in this group",
   "noMatchingItemsFound": "No matching {items} found",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-19880

![image](https://user-images.githubusercontent.com/50696716/191250804-90cb2293-d268-4204-85bd-197695aa71eb.png)

Added disabling the cost-permissions for the user without cost-management permissions and a helper tooltip. Also, disabled fetching of resource definitions when the user is lacking those cost permissions so 403 should not occur.