### PR TITLE
More rows per page for Groups, Roles and Users

### DIFF
--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -4,10 +4,14 @@ export const defaultSettings = {
   itemCount: 0,
 };
 
+export const defaultAdminSettings = {
+  ...defaultSettings,
+  limit: 50,
+};
+
 export const defaultCompactSettings = {
+  ...defaultSettings,
   limit: 10,
-  offset: 0,
-  itemCount: 0,
 };
 
 export const calculatePage = (limit = defaultSettings.limit, offset = 0) => Math.floor(offset / limit) + 1;

--- a/src/presentational-components/shared/toolbar.js
+++ b/src/presentational-components/shared/toolbar.js
@@ -25,6 +25,7 @@ export const paginationBuilder = (pagination = {}, fetchData = () => undefined, 
     { title: '10', value: 10 },
     { title: '20', value: 20 },
     { title: '50', value: 50 },
+    { title: '100', value: 100 },
   ],
   onPerPageSelect: (_event, perPage) => {
     fetchData({

--- a/src/redux/reducers/group-reducer.js
+++ b/src/redux/reducers/group-reducer.js
@@ -16,9 +16,9 @@ import { defaultSettings } from '../../helpers/shared/pagination';
 export const groupsInitialState = {
   groups: {
     data: [],
-    meta: defaultSettings,
+    meta: {},
     filters: {},
-    pagination: { ...defaultSettings, count: 0 },
+    pagination: { count: 0 },
   },
   selectedGroup: { addRoles: {}, members: { meta: defaultSettings }, pagination: defaultSettings },
   isLoading: false,

--- a/src/redux/reducers/role-reducer.js
+++ b/src/redux/reducers/role-reducer.js
@@ -16,7 +16,7 @@ export const rolesInitialState = {
     data: [],
     meta: defaultSettings,
     filters: {},
-    pagination: { ...defaultSettings, count: 0 },
+    pagination: { count: 0 },
   },
   rolesForWizard: {
     data: [],

--- a/src/redux/reducers/user-reducer.js
+++ b/src/redux/reducers/user-reducer.js
@@ -8,7 +8,7 @@ export const usersInitialState = {
   users: {
     meta: defaultSettings,
     filters: {},
-    pagination: { ...defaultSettings, redirected: false },
+    pagination: { redirected: false },
   },
 };
 

--- a/src/smart-components/group/add-group/users-list.js
+++ b/src/smart-components/group/add-group/users-list.js
@@ -1,4 +1,4 @@
-import React, { useEffect, Fragment, useState } from 'react';
+import React, { useEffect, Fragment, useState, useContext } from 'react';
 import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useHistory } from 'react-router-dom';
@@ -12,6 +12,7 @@ import UsersRow from '../../../presentational-components/shared/UsersRow';
 import {
   defaultCompactSettings,
   defaultSettings,
+  defaultAdminSettings,
   syncDefaultPaginationWithUrl,
   applyPaginationToUrl,
   isPaginationPresentInUrl,
@@ -20,6 +21,7 @@ import { syncDefaultFiltersWithUrl, applyFiltersToUrl, areFiltersPresentInUrl } 
 import { CheckIcon, CloseIcon } from '@patternfly/react-icons';
 import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
+import PermissionsContext from '../../../utilities/permissions-context';
 const createRows =
   (userLinks) =>
   (data, _expanded, checkedRows = []) => {
@@ -68,9 +70,10 @@ const createRows =
   };
 
 const UsersList = ({ users, fetchUsers, updateUsersFilters, isLoading, pagination, selectedUsers, setSelectedUsers, userLinks, inModal, props }) => {
+  const { orgAdmin } = useContext(PermissionsContext);
   const defaultPagination = useSelector(({ userReducer: { users } }) => ({
-    limit: inModal ? users.meta.limit : users.pagination.limit || defaultSettings.limit,
-    offset: inModal ? users.meta.offset : users.pagination.offset || defaultSettings.offset,
+    limit: inModal ? users.meta.limit : users.pagination.limit || (orgAdmin ? defaultAdminSettings : defaultSettings).limit,
+    offset: inModal ? users.meta.offset : users.pagination.offset || (orgAdmin ? defaultAdminSettings : defaultSettings).offset,
     count: inModal ? users.meta.count : users.pagination.count,
     redirected: !inModal && users.pagination.redirected,
   }));

--- a/src/smart-components/group/groups.js
+++ b/src/smart-components/group/groups.js
@@ -17,7 +17,13 @@ import GroupRowWrapper from './group-row-wrapper';
 import pathnames from '../../utilities/pathnames';
 import './groups.scss';
 import PageActionRoute from '../common/page-action-route';
-import { applyPaginationToUrl, isPaginationPresentInUrl, syncDefaultPaginationWithUrl } from '../../helpers/shared/pagination';
+import {
+  applyPaginationToUrl,
+  defaultAdminSettings,
+  defaultSettings,
+  isPaginationPresentInUrl,
+  syncDefaultPaginationWithUrl,
+} from '../../helpers/shared/pagination';
 import { applyFiltersToUrl, areFiltersPresentInUrl, syncDefaultFiltersWithUrl } from '../../helpers/shared/filters';
 import { getBackRoute } from '../../helpers/shared/helpers';
 import { useIntl } from 'react-intl';
@@ -54,7 +60,7 @@ const Groups = () => {
     shallowEqual
   );
 
-  const [pagination, setPagination] = useState(meta);
+  const [pagination, setPagination] = useState({ ...(orgAdmin ? defaultAdminSettings : defaultSettings), ...meta });
   const [filterValue, setFilterValue] = useState(filters.name || '');
   const [selectedRows, setSelectedRows] = useState([]);
   const [removeGroupsList, setRemoveGroupsList] = useState([]);

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -17,7 +17,13 @@ import EditRole from './edit-role-modal';
 import PageActionRoute from '../common/page-action-route';
 import ResourceDefinitions from './role-resource-definitions';
 import PermissionsContext from '../../utilities/permissions-context';
-import { syncDefaultPaginationWithUrl, applyPaginationToUrl, isPaginationPresentInUrl } from '../../helpers/shared/pagination';
+import {
+  syncDefaultPaginationWithUrl,
+  applyPaginationToUrl,
+  isPaginationPresentInUrl,
+  defaultAdminSettings,
+  defaultSettings,
+} from '../../helpers/shared/pagination';
 import { syncDefaultFiltersWithUrl, applyFiltersToUrl, areFiltersPresentInUrl } from '../../helpers/shared/filters';
 import { useScreenSize, isSmallScreen } from '@redhat-cloud-services/frontend-components/useScreenSize';
 import messages from '../../Messages';
@@ -35,15 +41,12 @@ const selector = ({ roleReducer: { roles, isLoading } }) => ({
 const Roles = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const { roles, filters, meta, isLoading } = useSelector(selector, shallowEqual);
-  const fetchData = (options) => {
-    return dispatch(fetchRolesWithPolicies({ ...options, inModal: false }));
-  };
   const history = useHistory();
-  const { userAccessAdministrator, orgAdmin } = useContext(PermissionsContext);
-  const [pagination, setPagination] = useState(meta);
-  const [filterValue, setFilterValue] = useState(filters.display_name || '');
   const screenSize = useScreenSize();
+
+  const { roles, filters, meta, isLoading } = useSelector(selector, shallowEqual);
+  const { userAccessAdministrator, orgAdmin } = useContext(PermissionsContext);
+
   const columns = [
     { title: intl.formatMessage(messages.name), key: 'display_name', transforms: [cellWidth(20), sortable] },
     { title: intl.formatMessage(messages.description) },
@@ -51,6 +54,12 @@ const Roles = () => {
     { title: intl.formatMessage(messages.groups), transforms: [nowrap] },
     { title: intl.formatMessage(messages.lastModified), key: 'modified', transforms: [nowrap, sortable] },
   ];
+  const fetchData = (options) => {
+    return dispatch(fetchRolesWithPolicies({ ...options, inModal: false }));
+  };
+
+  const [pagination, setPagination] = useState({ ...(orgAdmin ? defaultAdminSettings : defaultSettings), ...meta });
+  const [filterValue, setFilterValue] = useState(filters.display_name || '');
   const [sortByState, setSortByState] = useState({ index: 0, direction: 'asc' });
   const orderBy = `${sortByState?.direction === 'desc' ? '-' : ''}${columns[sortByState?.index].key}`;
 

--- a/src/test/presentional-components/shared/__snapshots__/toolbar.test.js.snap
+++ b/src/test/presentional-components/shared/__snapshots__/toolbar.test.js.snap
@@ -71,6 +71,10 @@ exports[`<Toolbar> checkedRows is loading - false 1`] = `
           "title": "50",
           "value": 50,
         },
+        Object {
+          "title": "100",
+          "value": 100,
+        },
       ],
     }
   }
@@ -145,6 +149,10 @@ exports[`<Toolbar> checkedRows is loading - false NO DATA 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -308,6 +316,10 @@ exports[`<Toolbar> filters should render with placeholder 1`] = `
           "title": "50",
           "value": 50,
         },
+        Object {
+          "title": "100",
+          "value": 100,
+        },
       ],
     }
   }
@@ -376,6 +388,10 @@ exports[`<Toolbar> filters should render with text filters 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -451,6 +467,10 @@ exports[`<Toolbar> isSelectable is loading - false 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -565,6 +585,10 @@ exports[`<Toolbar> should render buttons 1`] = `
           "title": "50",
           "value": 50,
         },
+        Object {
+          "title": "100",
+          "value": 100,
+        },
       ],
     }
   }
@@ -624,6 +648,10 @@ exports[`<Toolbar> should render correctly - NO DATA 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -685,6 +713,10 @@ exports[`<Toolbar> should render pagination 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -755,6 +787,10 @@ exports[`<Toolbar> should render with filterValue 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }
@@ -852,6 +888,10 @@ exports[`<Toolbar> should render with full data is loading - false 1`] = `
           "title": "50",
           "value": 50,
         },
+        Object {
+          "title": "100",
+          "value": 100,
+        },
       ],
     }
   }
@@ -947,6 +987,10 @@ exports[`<Toolbar> should render with full data is loading - true 1`] = `
         Object {
           "title": "50",
           "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
         },
       ],
     }

--- a/src/test/presentional-components/shared/toolbar.test.js
+++ b/src/test/presentional-components/shared/toolbar.test.js
@@ -17,6 +17,7 @@ const testPagination = {
     { title: '10', value: 10 },
     { title: '20', value: 20 },
     { title: '50', value: 50 },
+    { title: '100', value: 100 },
   ],
 };
 

--- a/src/test/smart-components/myUserAccess/ResourceDefinitionsModal.test.js
+++ b/src/test/smart-components/myUserAccess/ResourceDefinitionsModal.test.js
@@ -51,6 +51,6 @@ describe('<ResourceDefinitionsModal />', () => {
       wrapper.find('InternalDropdownItem').last().prop('onClick')();
     });
     wrapper.update();
-    expect(wrapper.find(TableToolbarViewOld).prop('pagination')).toEqual(expect.objectContaining({ limit: 50 }));
+    expect(wrapper.find(TableToolbarViewOld).prop('pagination')).toEqual(expect.objectContaining({ limit: 100 }));
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-21196

- made 50 rows per page default for org. admins (pages Users, Groups, Roles)
- added 100 rows per page option to the pagination

![image](https://user-images.githubusercontent.com/50696716/196720245-fbf57ef3-3a26-4193-90fd-c97f767bcefc.png)
