### PR TITLE
Wait for cost permissions to be loaded

### DIFF
--- a/src/smart-components/role/add-role-new/add-permissions.js
+++ b/src/smart-components/role/add-role-new/add-permissions.js
@@ -146,7 +146,6 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
       dispatch(fetchRole(baseRoleUuid));
     }
 
-    hasAccess && dispatch(getResourceDefinitions());
     formOptions.change('has-cost-resources', false);
     fetchData(pagination);
     fetchOptions({ field: 'application', limit: 50 });
@@ -155,6 +154,10 @@ const AddPermissionsTable = ({ selectedPermissions, setSelectedPermissions, ...p
 
     return () => dispatch(resetExpandSplats());
   }, []);
+
+  useEffect(() => {
+    hasAccess && dispatch(getResourceDefinitions());
+  }, [hasAccess]);
 
   useEffect(() => {
     debouncedGetResourceOptions(filters);


### PR DESCRIPTION
This should fix https://issues.redhat.com/browse/RHCLOUD-22696

Moved resource definitions fetching after checking the cost permissions