### PR TITLE
Fix getLastPageOffset formula

### DIFF
--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -49,7 +49,7 @@ export const isPaginationPresentInUrl = (history) => {
 
 export const isOffsetValid = (offset = 0, count = 0) => offset === 0 || count > offset;
 
-export const getLastPageOffset = (count, limit) => count - (count % limit);
+export const getLastPageOffset = (count, limit) => Math.floor((count % limit === 0 ? count - 1 : count) / limit) * limit;
 
 export const applyPaginationToUrl = (history, limit, offset = 0) => {
   const searchParams = new URLSearchParams(history.location.search);


### PR DESCRIPTION
This fixes https://issues.redhat.com/browse/RHCLOUD-22904

Fixed a wrong getLastPageOffset formula - it returned the wrong result in case of the last page being "full" (number of items === per_page)

