### PR TITLE
Filter non-function middlewares.

### DIFF
--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -19,7 +19,7 @@ export const RegistryContext = createContext({
   getRegistry: () => {},
 });
 
-const registry = new ReducerRegistry({}, [
+const middlewares = [
   thunk,
   promiseMiddleware,
   notificationsMiddleware({
@@ -27,7 +27,9 @@ const registry = new ReducerRegistry({}, [
     errorDescriptionKey: ['errors[0].detail', 'errors', 'stack'],
   }),
   reduxLogger,
-]);
+].filter((middleware) => typeof middleware === 'function');
+
+const registry = new ReducerRegistry({}, middlewares);
 
 registry.register({
   userReducer: applyReducerHash(userReducer, usersInitialState),


### PR DESCRIPTION
Unblocks prod releaes.

Not sure yet why the logger middleware is an object. I suspect the transformation to an empty module causes the issue during the build.

You can replicate the bug locally if you remove the filter and run `NODE_ENV=production npm run start`