### PR TITLE
Reduce requests for the Roles expandable table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@redhat-cloud-services/frontend-components": "^3.9.29",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.10",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
-        "@redhat-cloud-services/rbac-client": "^1.0.110",
+        "@redhat-cloud-services/rbac-client": "^1.2.1",
         "axios-mock-adapter": "^1.20.0",
         "babel-loader": "^8.2.3",
         "classnames": "^2.3.1",
@@ -3577,19 +3577,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "1.0.110",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.110.tgz",
-      "integrity": "sha512-t9XMNDqu1UwO/YMYD8vxMbOcyJDc6z/sEgnNb9h7oqEIQOMzEk8k+qoXYiGSCSfcgVBuRkPXUd6tpM95LfOXgA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.1.tgz",
+      "integrity": "sha512-c2GMVFYjZ0f8lYVR4vq8SwYOGXaoqJK52Ck9m/ytwLz9Cq4HnSwqfPrMaii+ehT2yqcEX2c5FBH41ZcZmKah5Q==",
       "dependencies": {
-        "axios": "^0.21.1"
-      }
-    },
-    "node_modules/@redhat-cloud-services/rbac-client/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "axios": "^0.27.2"
       }
     },
     "node_modules/@scalprum/core": {
@@ -20907,21 +20899,11 @@
       }
     },
     "@redhat-cloud-services/rbac-client": {
-      "version": "1.0.110",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.110.tgz",
-      "integrity": "sha512-t9XMNDqu1UwO/YMYD8vxMbOcyJDc6z/sEgnNb9h7oqEIQOMzEk8k+qoXYiGSCSfcgVBuRkPXUd6tpM95LfOXgA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.1.tgz",
+      "integrity": "sha512-c2GMVFYjZ0f8lYVR4vq8SwYOGXaoqJK52Ck9m/ytwLz9Cq4HnSwqfPrMaii+ehT2yqcEX2c5FBH41ZcZmKah5Q==",
       "requires": {
-        "axios": "^0.21.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
+        "axios": "^0.27.2"
       }
     },
     "@scalprum/core": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@redhat-cloud-services/frontend-components": "^3.9.29",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.10",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
-    "@redhat-cloud-services/rbac-client": "^1.0.110",
+    "@redhat-cloud-services/rbac-client": "^1.2.1",
     "axios-mock-adapter": "^1.20.0",
     "babel-loader": "^8.2.3",
     "classnames": "^2.3.1",

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -45,7 +45,7 @@ export async function fetchRolesWithPolicies({
   nameMatch,
   scope = 'account',
   orderBy = 'display_name',
-  addFields = ['groups_in_count', 'groups_in'],
+  addFields = ['groups_in_count', 'groups_in', 'access'],
   username,
   options,
   permission,

--- a/src/redux/action-types.js
+++ b/src/redux/action-types.js
@@ -13,7 +13,6 @@ export const UPDATE_USERS_FILTERS = 'UPDATE_USERS_FILTERS';
 
 export const ADD_ROLE = 'ADD_ROLE';
 export const FETCH_ROLE = 'FETCH_ROLE';
-export const FETCH_ROLE_DETAILS = 'FETCH_ROLE_DETAILS';
 export const FETCH_ROLES = 'FETCH_ROLES';
 export const REMOVE_ROLE = 'REMOVE_ROLE';
 export const RESET_SELECTED_ROLE = 'RESET_SELECTED_ROLE';

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -37,19 +37,6 @@ export const fetchRole = (apiProps) => ({
   }),
 });
 
-export const fetchRoleDetails = (uuid) => ({
-  type: ActionTypes.FETCH_ROLE_DETAILS,
-  meta: { uuid },
-  payload: RoleHelper.fetchRole(uuid).catch((err) => {
-    const error = err?.errors?.[0] || {};
-    if (error.status === '400' && error.source === 'role uuid validation') {
-      return { error: BAD_UUID };
-    }
-
-    throw err;
-  }),
-});
-
 export const fetchRoles = (options = {}) => ({
   type: ActionTypes.FETCH_ROLES,
   payload: RoleHelper.fetchRoles(options).catch((err) => {

--- a/src/redux/reducers/role-reducer.js
+++ b/src/redux/reducers/role-reducer.js
@@ -1,6 +1,5 @@
 import {
   FETCH_ROLE,
-  FETCH_ROLE_DETAILS,
   FETCH_ROLES,
   FETCH_ROLE_FOR_USER,
   FETCH_ROLE_FOR_PRINCIPAL,
@@ -38,22 +37,6 @@ const setRoles = (state, { payload }) => ({
   ...(!payload.error ? { roles: { ...state.roles, ...payload } } : payload),
   isLoading: false,
 });
-const setRoleDetailLoading = (state, { meta }) => ({
-  ...state,
-  roles: {
-    ...state.roles,
-    data: (state?.roles?.data || []).map((role) => (role.uuid === meta.uuid ? { ...role, isLoading: true } : role)),
-  },
-});
-const setRoleDetails = (state, { payload }) => ({
-  ...state,
-  roles: {
-    ...state.roles,
-    data: !payload.error
-      ? (state?.roles?.data || []).map((role) => (role.uuid === payload.uuid ? { ...role, ...payload, isLoading: false } : role))
-      : state?.roles?.data || [],
-  },
-});
 const setRolesWithAccess = (state, { payload }) => ({
   ...state,
   rolesWithAccess: { ...state.rolesWithAccess, [payload.uuid]: payload },
@@ -69,8 +52,6 @@ export default {
   [`${FETCH_ROLE}_FULFILLED`]: setRole,
   [`${FETCH_ROLE}_PENDING`]: setRecordLoadingState,
   [`${FETCH_ROLE}_FULFILLED`]: setRole,
-  [`${FETCH_ROLE_DETAILS}_PENDING`]: setRoleDetailLoading,
-  [`${FETCH_ROLE_DETAILS}_FULFILLED`]: setRoleDetails,
   [`${FETCH_ROLES}_FULFILLED`]: setRoles,
   [`${FETCH_ROLES}_PENDING`]: setLoadingState,
   [`${FETCH_ROLE_FOR_USER}_FULFILLED`]: setRolesWithAccess,

--- a/src/smart-components/role/role-table-helpers.js
+++ b/src/smart-components/role/role-table-helpers.js
@@ -4,26 +4,13 @@ import { Link } from 'react-router-dom';
 import { getDateFormat } from '../../helpers/shared/helpers';
 import { Text } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { ListLoader } from '../../presentational-components/shared/loader-placeholders';
 import messages from '../../Messages';
 
 export const createRows = (data, selectedRows, intl, expanded) =>
   data.reduce(
     (
       acc,
-      {
-        uuid,
-        access = [],
-        display_name,
-        name,
-        description,
-        system,
-        accessCount,
-        groups_in_count: groupsCount,
-        groups_in: groups,
-        isLoading,
-        modified,
-      },
+      { uuid, access = [], display_name, name, description, system, accessCount, groups_in_count: groupsCount, groups_in: groups, modified },
       i
     ) => [
       ...acc,
@@ -78,8 +65,6 @@ export const createRows = (data, selectedRows, intl, expanded) =>
                   <TableHeader />
                   <TableBody />
                 </Table>
-              ) : isLoading ? (
-                <ListLoader items={3} isCompact />
               ) : (
                 <Text className="pf-u-mx-lg pf-u-my-sm">{intl.formatMessage(messages.noPermissions)}</Text>
               ),

--- a/src/smart-components/role/roles.js
+++ b/src/smart-components/role/roles.js
@@ -6,7 +6,7 @@ import { cellWidth, compoundExpand, nowrap, sortable } from '@patternfly/react-t
 import { Button, Stack, StackItem } from '@patternfly/react-core';
 import { createRows } from './role-table-helpers';
 import { getBackRoute, mappedProps } from '../../helpers/shared/helpers';
-import { fetchRoleDetails, fetchRolesWithPolicies } from '../../redux/actions/role-actions';
+import { fetchRolesWithPolicies } from '../../redux/actions/role-actions';
 import { TopToolbar, TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
 import { TableToolbarView } from '../../presentational-components/shared/table-toolbar-view';
 import RemoveRole from './remove-role-modal';
@@ -92,8 +92,6 @@ const Roles = () => {
       !areFiltersPresentInUrl(history, ['display_name']) &&
       syncDefaultFiltersWithUrl(history, ['display_name'], { display_name: filterValue });
   });
-
-  const fetchPermissionsForRole = (uuid) => dispatch(fetchRoleDetails(uuid));
 
   const routes = () => (
     <Suspense fallback={<Fragment />}>
@@ -191,14 +189,8 @@ const Roles = () => {
     );
   };
 
-  const onExpand = (_event, _rowIndex, colIndex, isOpen, rowData) => {
-    if (!isOpen) {
-      setExpanded({ ...expanded, [rowData.uuid]: colIndex + Number(!isSelectable) });
-      colIndex + Number(!isSelectable) === 3 && fetchPermissionsForRole(rowData.uuid);
-    } else {
-      setExpanded({ ...expanded, [rowData.uuid]: -1 });
-    }
-  };
+  const onExpand = (_event, _rowIndex, colIndex, isOpen, rowData) =>
+    setExpanded({ ...expanded, [rowData.uuid]: isOpen ? -1 : colIndex + Number(!isSelectable) });
 
   const rows = createRows(roles, selectedRows, intl, expanded);
   const renderRolesList = () => (

--- a/src/test/redux/actions/role-actions.test.js
+++ b/src/test/redux/actions/role-actions.test.js
@@ -1,26 +1,23 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import promiseMiddleware from 'redux-promise-middleware';
-import { fetchRoleDetails, fetchRoles } from '../../../redux/actions/role-actions';
-import { FETCH_ROLES, FETCH_ROLE_DETAILS } from '../../../redux/action-types';
+import { fetchRoles } from '../../../redux/actions/role-actions';
+import { FETCH_ROLES } from '../../../redux/action-types';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
 
 import * as RoleHelper from '../../../helpers/role/role-helper';
-import { BAD_UUID } from '../../../helpers/shared/helpers';
 
 describe('role actions', () => {
   const middlewares = [thunk, promiseMiddleware, notificationsMiddleware()];
   let mockStore;
 
   const fetchRolesSpy = jest.spyOn(RoleHelper, 'fetchRoles');
-  const fetchRoleDetailsSpy = jest.spyOn(RoleHelper, 'fetchRole');
   beforeEach(() => {
     mockStore = configureStore(middlewares);
   });
 
   afterEach(() => {
     fetchRolesSpy.mockReset();
-    fetchRoleDetailsSpy.mockReset();
   });
 
   it('should dispatch correct actions after fetching roles', async () => {
@@ -39,46 +36,6 @@ describe('role actions', () => {
     ];
 
     await store.dispatch(fetchRoles());
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it('should dispatch correct actions after fetching role details', async () => {
-    const store = mockStore({});
-    fetchRoleDetailsSpy.mockResolvedValueOnce({
-      data: [{ name: 'roleName', uuid: '1234', access: [] }],
-    });
-    const expectedActions = [
-      {
-        type: `${FETCH_ROLE_DETAILS}_PENDING`,
-        meta: { uuid: '1234' },
-      },
-      {
-        meta: { uuid: '1234' },
-        payload: { data: [{ name: 'roleName', uuid: '1234', access: [] }] },
-        type: `${FETCH_ROLE_DETAILS}_FULFILLED`,
-      },
-    ];
-
-    await store.dispatch(fetchRoleDetails('1234'));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it('should dispatch correct actions after fetching role fails', async () => {
-    const store = mockStore({});
-    fetchRoleDetailsSpy.mockRejectedValueOnce({ errors: [{ status: '400', source: 'role uuid validation' }] });
-    const expectedActions = [
-      {
-        type: `${FETCH_ROLE_DETAILS}_PENDING`,
-        meta: { uuid: '1234' },
-      },
-      {
-        meta: { uuid: '1234' },
-        payload: { error: BAD_UUID },
-        type: `${FETCH_ROLE_DETAILS}_FULFILLED`,
-      },
-    ];
-
-    await store.dispatch(fetchRoleDetails('1234'));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/test/redux/reducers/role-reducer.test.js
+++ b/src/test/redux/reducers/role-reducer.test.js
@@ -1,7 +1,7 @@
 import roleReducer, { rolesInitialState } from '../../../redux/reducers/role-reducer';
 import { callReducer } from '../redux-helpers';
 
-import { FETCH_ROLES, FETCH_ROLE, FETCH_ROLE_FOR_USER, FETCH_ROLES_FOR_WIZARD, FETCH_ROLE_DETAILS } from '../../../redux/action-types';
+import { FETCH_ROLES, FETCH_ROLE, FETCH_ROLE_FOR_USER, FETCH_ROLES_FOR_WIZARD } from '../../../redux/action-types';
 
 describe('Role reducer', () => {
   let initialState;
@@ -56,18 +56,5 @@ describe('Role reducer', () => {
     const payload = { data: 'Foo' };
     const expectedState = { ...initialState, isWizardLoading: false, rolesForWizard: payload };
     expect(reducer(initialState, { type: `${FETCH_ROLES_FOR_WIZARD}_FULFILLED`, payload })).toEqual(expectedState);
-  });
-
-  it('should set loading state when loading role details', () => {
-    const initialModified = { ...initialState, roles: { ...initialState.roles, data: [{ uuid: '123', isLoading: true }] } };
-    const expectedState = { ...initialState, roles: { ...initialState.roles, data: [{ uuid: '123', isLoading: true }] } };
-    expect(reducer(initialModified, { type: `${FETCH_ROLE_DETAILS}_PENDING`, meta: { uuid: '123' } })).toEqual(expectedState);
-  });
-
-  it('should set role details data and set loading state to false', () => {
-    const initialModified = { ...initialState, roles: { ...initialState.roles, data: [{ uuid: '123' }] } };
-    const payload = { uuid: '123', access: [] };
-    const expectedState = { ...initialState, roles: { ...initialState.roles, data: [{ uuid: '123', isLoading: false, access: [] }] } };
-    expect(reducer(initialModified, { type: `${FETCH_ROLE_DETAILS}_FULFILLED`, payload })).toEqual(expectedState);
   });
 });

--- a/src/test/role/roles.test.js
+++ b/src/test/role/roles.test.js
@@ -11,7 +11,7 @@ import notificationsMiddleware from '@redhat-cloud-services/frontend-components-
 import { rolesInitialState } from '../../redux/reducers/role-reducer';
 
 import * as RoleActions from '../../redux/actions/role-actions';
-import { FETCH_ROLES, FETCH_ROLE_DETAILS } from '../../redux/action-types';
+import { FETCH_ROLES } from '../../redux/action-types';
 import { defaultSettings } from '../../helpers/shared/pagination';
 
 describe('<Roles />', () => {
@@ -20,7 +20,6 @@ describe('<Roles />', () => {
   let initialState;
 
   const fetchRolesWithPoliciesSpy = jest.spyOn(RoleActions, 'fetchRolesWithPolicies');
-  const fetchRoleDetailsSpy = jest.spyOn(RoleActions, 'fetchRoleDetails');
   beforeEach(() => {
     mockStore = configureStore(middlewares);
     initialState = {
@@ -64,7 +63,6 @@ describe('<Roles />', () => {
   });
 
   afterEach(() => {
-    fetchRoleDetailsSpy.mockReset();
     fetchRolesWithPoliciesSpy.mockReset();
   });
 
@@ -172,7 +170,6 @@ describe('<Roles />', () => {
   it('should render correctly expanded', async () => {
     const store = mockStore(initialState);
     fetchRolesWithPoliciesSpy.mockImplementationOnce(() => ({ type: FETCH_ROLES, payload: Promise.resolve({}) }));
-    fetchRoleDetailsSpy.mockImplementationOnce(() => ({ type: FETCH_ROLE_DETAILS, payload: Promise.resolve({}) }));
     let wrapper;
     await act(async () => {
       wrapper = mount(
@@ -184,11 +181,8 @@ describe('<Roles />', () => {
       );
     });
 
-    expect(fetchRoleDetailsSpy).not.toHaveBeenCalled();
     wrapper.find('#expandable-toggle-0-3').simulate('click');
-    expect(fetchRoleDetailsSpy).not.toHaveBeenCalled();
     wrapper.find('#expandable-toggle-0-2').simulate('click');
-    expect(fetchRoleDetailsSpy).toHaveBeenCalledTimes(1);
     expect(toJson(wrapper.find('TableToolbarView'), { mode: 'shallow' })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
[RHCLOUD-24244](https://issues.redhat.com/browse/RHCLOUD-24244)

Follow-up on https://github.com/RedHatInsights/insights-rbac-ui/pull/1351
reduces the number of API calls and makes permissions expandable table in Roles available immediately