### PR TITLE
Fix "exit" link for Add role permissions success

### DIFF
--- a/src/smart-components/role/add-role-permissions/add-role-permission-success.js
+++ b/src/smart-components/role/add-role-permissions/add-role-permission-success.js
@@ -19,8 +19,8 @@ const AddRolePermissionSuccess = ({ currentRoleID }) => {
         <Title headingLevel="h4" size="lg">
           {intl.formatMessage(messages.permissionsAddedSuccessfully)}
         </Title>
-        <EmptyStateBody></EmptyStateBody>
-        <AppLink to={pathnames['role-detail'].link.replace(':groupId', currentRoleID)}>
+        <EmptyStateBody />
+        <AppLink to={pathnames['role-detail'].link.replace(':roleId', currentRoleID)}>
           <Button onClick={() => dispatch(fetchRole(currentRoleID))}>{intl.formatMessage(messages.exit)}</Button>
         </AppLink>
       </EmptyState>


### PR DESCRIPTION
This should fix [RHCLOUD-26430](https://issues.redhat.com/browse/RHCLOUD-26430)

Fixed "Exit" link for the add permissions success state