### PR TITLE
Conditionally reset groups/roles filters

### DIFF
--- a/src/smart-components/role/remove-role-modal.js
+++ b/src/smart-components/role/remove-role-modal.js
@@ -12,7 +12,7 @@ import { roleNameSelector } from './role-selectors';
 import useAppNavigate from '../../hooks/useAppNavigate';
 import messages from '../../Messages';
 
-const RemoveRoleModal = ({ cancelRoute, submitRoute = cancelRoute, afterSubmit, setFilterValue, isLoading }) => {
+const RemoveRoleModal = ({ cancelRoute, submitRoute = cancelRoute, afterSubmit, isLoading }) => {
   const intl = useIntl();
   const { roleId } = useParams();
   const roles = roleId.split(',');
@@ -39,7 +39,6 @@ const RemoveRoleModal = ({ cancelRoute, submitRoute = cancelRoute, afterSubmit, 
   }, [roleName, roles]);
 
   const onSubmit = () => {
-    setFilterValue && setFilterValue('');
     Promise.all(roles.map((id) => dispatch(removeRole(id)))).then(() => afterSubmit());
     navigate(submitRoute);
   };
@@ -117,7 +116,6 @@ RemoveRoleModal.propTypes = {
     }),
   ]),
   afterSubmit: PropTypes.func.isRequired,
-  setFilterValue: PropTypes.func,
   isLoading: PropTypes.bool.isRequired,
 };
 

--- a/src/test/smart-components/group/remove-group-modal.test.js
+++ b/src/test/smart-components/group/remove-group-modal.test.js
@@ -41,19 +41,11 @@ describe('<RemoveGroupModal />', () => {
 
   const GroupWrapper = ({ store }) => (
     <Provider store={store}>
-      <MemoryRouter initialEntries={['/groups/', '/groups/remove-group']} initialIndex={2}>
+      <MemoryRouter initialEntries={['/groups/', '/groups/remove-group/123']} initialIndex={2}>
         <Routes>
           <Route
-            path="/groups/remove-group"
-            element={
-              <RemoveGroupModal
-                {...initialProps}
-                groupsToRemove={[{ uuid: '123' }]}
-                pagination={{ limit: 0 }}
-                filters={{}}
-                cancelRoute={pathnames.groups.link}
-              />
-            }
+            path="/groups/remove-group/:groupId"
+            element={<RemoveGroupModal {...initialProps} pagination={{ limit: 0 }} filters={{}} cancelRoute={pathnames.groups.link} />}
           />
         </Routes>
       </MemoryRouter>
@@ -117,5 +109,6 @@ describe('<RemoveGroupModal />', () => {
     });
     expect(initialProps.postMethod).toHaveBeenCalled();
     expect(removeGroupsSpy).toHaveBeenCalledWith(['123']);
+    expect(mockedNavigate).toHaveBeenCalledWith('/iam/user-access/groups', undefined);
   });
 });

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -14,8 +14,8 @@ const pathnames = {
     title: 'Create group',
   },
   'remove-group': {
-    link: '/groups/remove-group',
-    path: 'remove-group',
+    link: '/groups/remove-group/:groupId',
+    path: 'remove-group/:groupId',
     title: 'Delete group',
   },
   'edit-group': {


### PR DESCRIPTION
[RHCLOUD-27443](https://issues.redhat.com/browse/RHCLOUD-27443)
When submitting remove the group/role modal from the Groups/Roles page:

if no more items are applicable to the filter after deletion -> reset the filters & redirect to Groups/Roles page
if some other items are still applicable after deletion -> just redirect to Groups/Roles and keep the filters applied