### PR TITLE
Call real endpoint to receive service accounts for group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.10",
         "@redhat-cloud-services/frontend-components-utilities": "^3.5.0",
         "@redhat-cloud-services/host-inventory-client": "^1.2.3",
-        "@redhat-cloud-services/rbac-client": "^1.2.2",
+        "@redhat-cloud-services/rbac-client": "^1.2.10",
         "@unleash/proxy-client-react": "^3.6.0",
         "axios-mock-adapter": "^1.20.0",
         "babel-loader": "^8.2.3",
@@ -3729,9 +3729,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.2.tgz",
-      "integrity": "sha512-U9wL6k4mJHBLStLXmHpq8WsopRv4tGjtQ39lZo9UUEWmu6g7ul1Sw9lB7D4p0sHLTFBjVzlbyIMKqTJh96iH9w==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.10.tgz",
+      "integrity": "sha512-2DTZrK2BiW68qE2emtr2BbN6n+6h6We9rCO6RBsQXSm5iyt2b9IV3jUCVIeWC94QkFyApooIqqrPhErjJrVEoA==",
       "dependencies": {
         "axios": "^0.27.2"
       }
@@ -22059,9 +22059,9 @@
       }
     },
     "@redhat-cloud-services/rbac-client": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.2.tgz",
-      "integrity": "sha512-U9wL6k4mJHBLStLXmHpq8WsopRv4tGjtQ39lZo9UUEWmu6g7ul1Sw9lB7D4p0sHLTFBjVzlbyIMKqTJh96iH9w==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.10.tgz",
+      "integrity": "sha512-2DTZrK2BiW68qE2emtr2BbN6n+6h6We9rCO6RBsQXSm5iyt2b9IV3jUCVIeWC94QkFyApooIqqrPhErjJrVEoA==",
       "requires": {
         "axios": "^0.27.2"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.10",
     "@redhat-cloud-services/frontend-components-utilities": "^3.5.0",
     "@redhat-cloud-services/host-inventory-client": "^1.2.3",
-    "@redhat-cloud-services/rbac-client": "^1.2.2",
+    "@redhat-cloud-services/rbac-client": "^1.2.10",
     "@unleash/proxy-client-react": "^3.6.0",
     "axios-mock-adapter": "^1.20.0",
     "babel-loader": "^8.2.3",

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -131,14 +131,17 @@ export async function fetchRolesForGroup(groupId, excluded, { limit, offset, nam
   );
 }
 
-export async function fetchAccountsForGroup() {
-  return {
-    data: [
-      { description: 'This is account 1', client_id: 'abra1234-ca56-da789-fg1011', owner: 'rhn-support1', time_created: 123456456 },
-      { description: 'This is account 2', client_id: 'bbra1234-ca56-da789-fg1012', owner: 'rhn-support2', time_created: 123456478 },
-    ],
-    meta: { count: 0 },
-  };
+export async function fetchAccountsForGroup(groupId, usernames, options = {}) {
+  return await groupApi.getPrincipalsFromGroup(
+    groupId,
+    undefined,
+    usernames,
+    options.limit,
+    options.offset,
+    options.orderBy,
+    undefined,
+    'service-account'
+  );
 }
 
 export async function deleteRolesFromGroup(groupId, roles) {
@@ -150,7 +153,7 @@ export async function addRolesToGroup(groupId, roles) {
 }
 
 export async function fetchMembersForGroup(groupId, usernames, options = {}) {
-  return await groupApi.getPrincipalsFromGroup(groupId, usernames, options.limit, options.offset, options.orderBy);
+  return await groupApi.getPrincipalsFromGroup(groupId, undefined, usernames, options.limit, options.offset, options.orderBy);
 }
 
 export async function fetchMemberGroups(username) {

--- a/src/helpers/role/role-helper.js
+++ b/src/helpers/role/role-helper.js
@@ -4,7 +4,7 @@ import { getRoleApi } from '../shared/user-login';
 const roleApi = getRoleApi();
 
 export async function createRole(data) {
-  return await roleApi.createRoles(data);
+  return await roleApi.createRole(data);
 }
 
 export function fetchRoles({


### PR DESCRIPTION
### Description

Since RBAC api supports service accounts now we can call `getPrincipalsFromGroup` with switch `'service-account'` which will return service accounts only.