### PR TITLE
Wiat for action to fulfill before re-fetching service account data

### DIFF
--- a/src/smart-components/group/service-account/add-group-service-accounts.tsx
+++ b/src/smart-components/group/service-account/add-group-service-accounts.tsx
@@ -18,7 +18,7 @@ import messages from '../../../Messages';
 import './group-service-accounts.scss';
 
 interface AddGroupServiceAccountsProps {
-  postMethod: () => void;
+  postMethod: (promise?: Promise<unknown>) => void;
 }
 
 export interface PaginationProps {
@@ -89,8 +89,9 @@ const AddGroupServiceAccounts: React.FunctionComponent<AddGroupServiceAccountsPr
   };
 
   const onSubmit = () => {
-    dispatch(addServiceAccountsToGroup(groupId === DEFAULT_ACCESS_GROUP_ID ? systemGroupUuid : groupId, selectedAccounts));
-    postMethod();
+    const action = addServiceAccountsToGroup(groupId === DEFAULT_ACCESS_GROUP_ID ? systemGroupUuid : groupId, selectedAccounts);
+    dispatch(action);
+    postMethod(action.payload);
   };
 
   const columns = [

--- a/src/smart-components/group/service-account/group-service-accounts.js
+++ b/src/smart-components/group/service-account/group-service-accounts.js
@@ -187,15 +187,19 @@ const GroupServiceAccounts = () => {
         <Outlet
           context={{
             [pathnames['group-service-accounts-remove-group'].path]: {
-              postMethod: () => {
+              postMethod: (promise) => {
                 navigate(pathnames['group-detail-service-accounts'].link.replace(':groupId', groupId));
-                fetchData();
+                if (promise) {
+                  promise.then(fetchData);
+                }
               },
             },
             [pathnames['group-add-service-account'].path]: {
-              postMethod: () => {
+              postMethod: (promise) => {
                 navigate(pathnames['group-detail-service-accounts'].link.replace(':groupId', groupId));
-                fetchData();
+                if (promise) {
+                  promise.then(fetchData);
+                }
               },
             },
           }}

--- a/src/smart-components/group/service-account/remove-group-service-accounts.tsx
+++ b/src/smart-components/group/service-account/remove-group-service-accounts.tsx
@@ -9,7 +9,7 @@ import { removeServiceAccountFromGroup } from '../../../redux/actions/group-acti
 type AddGroupServiceAccountsProps = {
   cancelRoute: string;
   submitRoute: string;
-  postMethod: () => void;
+  postMethod: (promise?: Promise<unknown>) => void;
 };
 
 type RBACStore = {
@@ -49,8 +49,9 @@ const RemoveServiceAccountFromGroup: React.FunctionComponent<AddGroupServiceAcco
       withCheckbox
       onClose={() => postMethod()}
       onSubmit={() => {
-        dispatch(removeServiceAccountFromGroup(group.uuid, selectedServiceAccounts));
-        postMethod();
+        const action = removeServiceAccountFromGroup(group.uuid, selectedServiceAccounts);
+        dispatch(action);
+        postMethod(action.payload);
       }}
       isOpen={true}
     />


### PR DESCRIPTION
### Description

Adding service account takes longer time and we refresh right after the modal is closed. We will have to waif for the action to finish before refreshing the page.