### PR TITLE
Do not send username when creating service account

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -133,7 +133,7 @@ export async function fetchRolesForGroup(groupId, excluded, { limit, offset, nam
 
 export async function addServiceAccountsToGroup(groupId, serviceAccounts) {
   return await groupApi.addPrincipalToGroup(groupId, {
-    principals: serviceAccounts.map((account) => ({ username: account.name, clientID: account.uuid, type: 'service-account' })),
+    principals: serviceAccounts.map((account) => ({ clientID: account.uuid, type: 'service-account' })),
   });
 }
 


### PR DESCRIPTION
### Description

API no longer requires name for service accounts.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-29429