### PR TITLE
Revert "Do not send username when creating service account"

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -133,7 +133,7 @@ export async function fetchRolesForGroup(groupId, excluded, { limit, offset, nam
 
 export async function addServiceAccountsToGroup(groupId, serviceAccounts) {
   return await groupApi.addPrincipalToGroup(groupId, {
-    principals: serviceAccounts.map((account) => ({ clientID: account.uuid, type: 'service-account' })),
+    principals: serviceAccounts.map((account) => ({ username: account.name, clientID: account.uuid, type: 'service-account' })),
   });
 }
 


### PR DESCRIPTION
API is not ready yet, let's revert and once they deploy it we'll remove the `username` again.