### PR TITLE
Update error notification if group does not exist

### DIFF
--- a/src/redux/actions/group-actions.js
+++ b/src/redux/actions/group-actions.js
@@ -199,12 +199,15 @@ export const addServiceAccountsToGroup = (groupId, serviceAccounts) => {
           dismissDelay: 8000,
           description: intl.formatMessage(messages.addGroupServiceAccountsSuccessDescription, { count: serviceAccounts.length }),
         },
-        rejected: {
+        rejected: (payload) => ({
           variant: 'danger',
           title: intl.formatMessage(messages.addGroupServiceAccountsErrorTitle, { count: serviceAccounts.length }),
           dismissDelay: 8000,
-          description: intl.formatMessage(messages.addGroupServiceAccountsErrorDescription, { count: serviceAccounts.length }),
-        },
+          description: intl.formatMessage(
+            Number(payload?.errors?.[0]?.status) === 404 ? messages.groupDoesNotExist : messages.addGroupServiceAccountsErrorDescription,
+            { count: serviceAccounts.length, id: groupId }
+          ),
+        }),
       },
     },
   };


### PR DESCRIPTION
[RHCLOUD-29493](https://issues.redhat.com/browse/RHCLOUD-29493)

Updated error notification description when removing SA from not-existing group.

New message: "Group with ID {id} does not exist."