### PR TITLE
Temporarily hide permissions in Group Explorer

### DIFF
--- a/src/smart-components/group/group-table-helpers.js
+++ b/src/smart-components/group/group-table-helpers.js
@@ -130,14 +130,12 @@ export const createRows = (isAdmin, data, selectedRows, expanded = []) => {
                   cells={[
                     { title: intl.formatMessage(messages.roleName) },
                     { title: intl.formatMessage(messages.description) },
-                    { title: intl.formatMessage(messages.permissions) },
                     { title: intl.formatMessage(messages.lastModified) },
                   ]}
                   rows={roles?.map((role) => ({
                     cells: [
                       { title: <AppLink to={pathnames['role-detail'].link.replace(':roleId', role.uuid)}>{role.name}</AppLink> },
                       role.description,
-                      role.accessCount,
                       <Fragment key={`${uuid}-modified`}>
                         <DateFormat date={modified} type={getDateFormat(modified)} />
                       </Fragment>,

--- a/src/test/smart-components/group/__snapshots__/groups.test.js.snap
+++ b/src/test/smart-components/group/__snapshots__/groups.test.js.snap
@@ -503,15 +503,6 @@ exports[`<Groups /> should render group list correctly 1`] = `
                       <th
                         class="pf-v5-c-table__th"
                         data-key="2"
-                        data-label="Permissions"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Permissions
-                      </th>
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="3"
                         data-label="Last modified"
                         scope="col"
                         tabindex="-1"


### PR DESCRIPTION
Temporarily hidden blank permissions column in Group Explorer until API is ready to send necessary data - https://issues.redhat.com/browse/RHCLOUD-29077