### PR TITLE
Fix description input naming in edit group

### DIFF
--- a/src/smart-components/group/edit-group-modal.js
+++ b/src/smart-components/group/edit-group-modal.js
@@ -87,8 +87,8 @@ const EditGroupModal = ({ postMethod, pagination, cancelRoute, submitRoute = can
         ],
       },
       {
-        name: 'name',
-        label: intl.formatMessage(messages.name),
+        name: 'description',
+        label: intl.formatMessage(messages.description),
         component: selectedGroup ? componentTypes.TEXTAREA : 'skeleton',
         validate: [
           {


### PR DESCRIPTION
Fixes [RHCLOUD-30329](https://issues.redhat.com/browse/RHCLOUD-30329)