### PR TITLE
Fix remove service account by properly sending correct data to server

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -140,7 +140,7 @@ export async function addServiceAccountsToGroup(groupId, serviceAccounts) {
 export async function removeServiceAccountsFromGroup(groupId, serviceAccounts) {
   return await groupApi.deletePrincipalFromGroup(groupId, '', {
     query: {
-      'service-accounts': serviceAccounts.map(({ name }) => name).join(','),
+      'service-accounts': serviceAccounts.map(({ clientID }) => `service-account-${clientID}`).join(','),
     },
   });
 }


### PR DESCRIPTION
### Description

When user is removing service accounts from a group they have to send specific format `service-account` followed by client ID instead of name. This PR fixes such issue by following this format.

https://issues.redhat.com/browse/RHCLOUD-29666