### PR TITLE
Filter by client ID instead of name

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -149,7 +149,7 @@ export async function fetchAccountsForGroup(groupId, options = {}) {
   return await groupApi.getPrincipalsFromGroup(
     groupId,
     undefined,
-    options.description,
+    options.clientID,
     options.limit,
     options.offset,
     undefined,

--- a/src/smart-components/group/service-account/group-service-accounts.js
+++ b/src/smart-components/group/service-account/group-service-accounts.js
@@ -55,7 +55,7 @@ const GroupServiceAccounts = () => {
   const dispatch = useDispatch();
   const navigate = useAppNavigate();
   const { groupId } = useParams();
-  const [descriptionValue, setDescriptionValue] = useState('');
+  const [clientIDValue, setClientIDValue] = useState('');
   const [selectedAccounts, setSelectedAccounts] = useState([]);
   const { userAccessAdministrator, orgAdmin } = useContext(PermissionsContext);
   const hasPermissions = useRef(orgAdmin || userAccessAdministrator);
@@ -162,11 +162,11 @@ const GroupServiceAccounts = () => {
               isSelectable
               rows={createRows(serviceAccounts, selectedAccounts)}
               data={serviceAccounts}
-              filterValue={descriptionValue}
+              filterValue={clientIDValue}
               fetchData={(config) => fetchGroupAccounts(groupId, config)}
               emptyFilters={{ description: '' }}
-              setFilterValue={({ description }) => {
-                typeof description !== 'undefined' && setDescriptionValue(description);
+              setFilterValue={({ clientID }) => {
+                typeof clientID !== 'undefined' && setClientIDValue(clientID);
               }}
               isLoading={isLoading}
               pagination={pagination}
@@ -180,7 +180,7 @@ const GroupServiceAccounts = () => {
                 title: intl.formatMessage(messages.noGroupAccounts),
                 description: [intl.formatMessage(isAdminDefault ? messages.contactServiceTeamForAccounts : messages.addAccountsToThisGroup), ''],
               }}
-              filters={[{ key: 'description', value: descriptionValue }]}
+              filters={[{ key: 'clientID', value: clientIDValue }]}
               tableId="group-accounts"
               ouiaId="group-accounts"
             />


### PR DESCRIPTION
### Description

Current filter does not properly work because it's trying to filter by name, however service accounts filter doesn't allow filtering by it. This PR fixes this by filtering by clientID.