### PR TITLE
Fix AddRolePermissionWizard reappearing after submit

### DIFF
--- a/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
+++ b/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
@@ -143,7 +143,7 @@ const AddRolePermissionWizard = ({ role }) => {
             steps={[
               {
                 name: 'success',
-                component: new AddRolePermissionSuccess({ currentRoleID }),
+                component: <AddRolePermissionSuccess currentRoleID={currentRoleID} />,
                 isFinishedStep: true,
               },
             ]}


### PR DESCRIPTION
Fixes [RHCLOUD-30701](https://issues.redhat.com/browse/RHCLOUD-30701)

Fix AddRolePermissionWizard reappearing after submission - a success state is now shown properly