### PR TITLE
Make WarningModal button labels consistent

### DIFF
--- a/locales/translation-template.json
+++ b/locales/translation-template.json
@@ -447,6 +447,10 @@
     "defaultMessage": "Description",
     "description": "Description column label"
   },
+  "discard": {
+    "defaultMessage": "Discard",
+    "description": "Discard label"
+  },
   "discardedInputsWarning": {
     "defaultMessage": "All inputs will be discarded",
     "description": "Warning saying that all inputs will be discarded"

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1781,4 +1781,9 @@ export default defineMessages({
     description: 'Copy to all label',
     defaultMessage: 'Copy to all',
   },
+  discard: {
+    id: 'discard',
+    description: 'Discard label',
+    defaultMessage: 'Discard',
+  },
 });

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -112,6 +112,7 @@
     "deletingGroupRemovesRoles": "Deleting the <b>{name}</b> group removes all roles from the members inside the group.",
     "deletingGroupsRemovesRoles": "Deleting these <b>{count}</b> groups removes all roles from the members inside the groups.",
     "description": "Description",
+    "discard": "Discard",
     "discardedInputsWarning": "All inputs will be discarded",
     "edit": "Edit",
     "editGroupCanceledDescription": "Edit group was canceled by the user.",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -111,6 +111,7 @@
   "deletingGroupRemovesRoles": "Deleting the <b>{name}</b> group removes all roles from the members inside the group.",
   "deletingGroupsRemovesRoles": "Deleting these <b>{count}</b> groups removes all roles from the members inside the groups.",
   "description": "Description",
+  "discard": "Discard",
   "discardedInputsWarning": "All inputs will be discarded",
   "edit": "Edit",
   "editGroupCanceledDescription": "Edit group was canceled by the user.",

--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -119,8 +119,7 @@ const AddGroupWizard = ({ postMethod, pagination, filters, orderBy }) => {
           container.current.hidden = false;
           setWizardCanceled(false);
         }}
-        confirmButtonLabel={intl.formatMessage(messages.exit)}
-        cancelButtonLabel={intl.formatMessage(messages.stay)}
+        confirmButtonLabel={intl.formatMessage(messages.discard)}
         onConfirm={redirectToGroups}
       >
         {intl.formatMessage(messages.discardedInputsWarning)}

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -170,7 +170,6 @@ const Group = () => {
           isOpen={isResetWarningVisible}
           title={intl.formatMessage(messages.restoreDefaultAccessQuestion)}
           confirmButtonLabel={intl.formatMessage(messages.continue)}
-          cancelButtonLabel={intl.formatMessage(messages.cancel)}
           onClose={() => setResetWarningVisible(false)}
           onConfirm={() => {
             dispatch(removeGroups([systemGroupUuid])).then(() =>

--- a/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
+++ b/src/smart-components/role/add-role-permissions/add-role-permission-wizard.js
@@ -131,9 +131,10 @@ const AddRolePermissionWizard = ({ role }) => {
         title={intl.formatMessage(messages.exitItemAdding, { item: intl.formatMessage(messages.permissions).toLocaleLowerCase() })}
         isOpen={cancelWarningVisible}
         onClose={() => setCancelWarningVisible(false)}
+        confirmButtonLabel={intl.formatMessage(messages.discard)}
         onConfirm={handleConfirmCancel}
       >
-        {intl.formatMessage(messages.changesWillBeLost)}
+        {intl.formatMessage(messages.discardedInputsWarning)}
       </WarningModal>
       {wizardContextValue.hideForm ? (
         wizardContextValue.success ? (

--- a/src/smart-components/role/add-role/add-role-wizard.js
+++ b/src/smart-components/role/add-role/add-role-wizard.js
@@ -170,6 +170,7 @@ const AddRoleWizard = ({ pagination, filters, orderBy }) => {
       <SilentErrorBoundary silentErrorString="focus-trap">
         <WarningModal
           title={intl.formatMessage(messages.exitItemCreation, { item: intl.formatMessage(messages.role).toLocaleLowerCase() })}
+          confirmButtonLabel={intl.formatMessage(messages.discard)}
           isOpen={cancelWarningVisible}
           onClose={() => {
             container.current.hidden = false;

--- a/src/smart-components/role/edit-resource-definitions-modal.js
+++ b/src/smart-components/role/edit-resource-definitions-modal.js
@@ -206,8 +206,7 @@ const EditResourceDefinitionsModal = ({ cancelRoute }) => {
         onClose={() => dispatchLocally({ type: 'update', payload: { cancelWarningVisible: false } })}
         onConfirm={onCancel}
         data-testid="warning-modal"
-        confirmButtonLabel={intl.formatMessage(messages.exit)}
-        cancelButtonLabel={intl.formatMessage(messages.stay)}
+        confirmButtonLabel={intl.formatMessage(messages.discard)}
       >
         {intl.formatMessage(messages.changesWillBeLost)}
       </WarningModal>

--- a/src/smart-components/user/add-user-to-group/add-user-to-group.js
+++ b/src/smart-components/user/add-user-to-group/add-user-to-group.js
@@ -96,6 +96,7 @@ const AddUserToGroup = ({ username }) => {
         title={intl.formatMessage(messages.exitItemAdding, { item: intl.formatMessage(messages.users).toLocaleLowerCase() })}
         isOpen={cancelWarningVisible}
         onClose={() => setCancelWarningVisible(false)}
+        confirmButtonLabel={intl.formatMessage(messages.discard)}
         onConfirm={redirectToUserDetail}
       >
         {intl.formatMessage(messages.changesWillBeLost)}

--- a/src/test/role/edit-resource-definitions-modal.test.js
+++ b/src/test/role/edit-resource-definitions-modal.test.js
@@ -125,7 +125,7 @@ describe('EditResourceDefinitionsModal - Cost management', () => {
     expect(screen.getByTestId('warning-modal')).toBeInTheDocument();
 
     await act(async () => {
-      screen.getByText('Exit').click();
+      screen.getByText('Discard').click();
     });
 
     expect(() => screen.getByTestId('warning-modal')).toThrow('');


### PR DESCRIPTION
Fixes [RHCLOUD-30780](https://issues.redhat.com/browse/RHCLOUD-30780)

- made wording and button labels consistent across warning modals
- fixed add user to group warning modal to appear properly
- updated tests

<img width="660" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/dcdabc47-29ba-457b-a7ef-0e9721e71280">
<img width="660" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/e56c04f5-5395-4473-bee8-552964828cfe">
<img width="660" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/c54c3e7b-c387-4057-af86-acacca0fe4c3">
<img width="660" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/bab8041d-5e91-4bdc-80ee-5f58a67e9b9c">
<img width="660" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/bef69131-dfe0-47df-9de9-f6b0c09aa2f1">

