### PR TITLE
Replace deprecated PF Select in inventory groups

### DIFF
--- a/src/smart-components/role/add-role/add-role-wizard.scss
+++ b/src/smart-components/role/add-role/add-role-wizard.scss
@@ -117,24 +117,13 @@
     }
 }
 
-.rbac-m-resource-type-select {
-    .pf-v5-c-select__menu {
+.rbac-c-resource-type-select {
+    .pf-v5-c-menu__content {
         max-height: 300px;
         overflow: auto;
         width: inherit;
-        .pf-v5-c-select__menu-item:nth-child(3) {
-            .pf-v5-c-check__input {
-                display: none;
-            }
-            .pf-v5-c-check__label {
-                color: var(--pf-v5-global--link--Color);
-            }
-        }
     }
-    .pf-v5-c-check.pf-v5-c-select__menu-item {
-         width: inherit;
-    }
-    .pf-v5-c-check__label {
+    .pf-v5-c-menu__item-text {
         white-space: pre-wrap;
     }
 }

--- a/src/smart-components/role/add-role/inventory-groups-role.js
+++ b/src/smart-components/role/add-role/inventory-groups-role.js
@@ -207,6 +207,7 @@ const InventoryGroupsRole = (props) => {
             {state[permissionID].selected.length > 0 ? (
               <ChipGroup aria-label="Current selections">
                 <Chip
+                  closeBtnAriaLabel="Clear all"
                   badge={<Badge isRead>{state[permissionID].selected.length}</Badge>}
                   onClick={(ev) => {
                     ev.stopPropagation();

--- a/src/smart-components/role/add-role/inventory-groups-role.js
+++ b/src/smart-components/role/add-role/inventory-groups-role.js
@@ -1,6 +1,26 @@
 import React, { useEffect, useReducer } from 'react';
-import { Button, Grid, GridItem, Text, TextVariants, FormGroup, Tooltip, Divider } from '@patternfly/react-core';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Grid,
+  GridItem,
+  Text,
+  TextVariants,
+  FormGroup,
+  Tooltip,
+  Divider,
+  MenuToggle,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  SelectList,
+  SelectOption,
+  Select,
+  Spinner,
+  Badge,
+  Chip,
+  ChipGroup,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
@@ -105,6 +125,7 @@ const InventoryGroupsRole = (props) => {
   const dispatch = useDispatch();
   const { input } = useFieldApi(props);
   const formOptions = useFormApi();
+  const isHosts = (permissionID) => permissionID.includes('hosts:');
 
   const { resourceTypes, totalCount, isLoading } = useSelector(selector, shallowEqual);
   const permissions =
@@ -115,11 +136,15 @@ const InventoryGroupsRole = (props) => {
 
   const fetchData = (permissions, apiProps) => dispatch(fetchInventoryGroups(permissions, apiProps));
 
-  // eslint-disable-next-line
-  const onSelect = (event, selection, selectAll, key) => {
+  const onSelect = (_event, selection, selectAll, key) => {
     const ungroupedSystems = { id: null, name: 'null' };
     return (
-      (selectAll && dispatchLocally({ type: 'selectAll', selectionArray: [ungroupedSystems, ...Object.values(resourceTypes[key])], key })) ||
+      (selectAll &&
+        dispatchLocally({
+          type: 'selectAll',
+          selectionArray: isHosts(key) ? [ungroupedSystems, ...Object.values(resourceTypes[key])] : Object.values(resourceTypes[key]),
+          key,
+        })) ||
       dispatchLocally({ type: 'select', processedSelection: selection === 'null' ? ungroupedSystems : resourceTypes[key][selection], key })
     );
   };
@@ -152,87 +177,140 @@ const InventoryGroupsRole = (props) => {
     formOptions.change('inventory-group-permissions', groupsPermissionsDefinition);
   }, [state]);
 
+  const onToggleClick = (permissionID) => dispatchLocally({ type: 'toggle', key: permissionID, isOpen: !state[permissionID].isOpen });
+
+  const onTextInputChange = (_event, value, permissionID) => {
+    dispatchLocally({ type: 'setFilter', key: permissionID, filterValue: value });
+    debouncedFetch(() => fetchData([permissionID], { name: value }), 2000);
+  };
+
+  const toggle = (toggleRef, permissionID) => (
+    <Tooltip content={<div>{intl.formatMessage(messages.inventoryGroupsTooltip)}</div>}>
+      <MenuToggle
+        variant="typeahead"
+        aria-label={intl.formatMessage(messages.inventoryGroupsTypeAheadLabel)}
+        onClick={() => onToggleClick(permissionID)}
+        innerRef={toggleRef}
+        isExpanded={state[permissionID].isOpen}
+        isFullWidth
+      >
+        <TextInputGroup isPlain>
+          <TextInputGroupMain
+            value={state[permissionID].filterValue}
+            onClick={() => state[permissionID].isOpen || onToggleClick(permissionID)}
+            onChange={(e, value) => onTextInputChange(e, value, permissionID)}
+            autoComplete="off"
+            placeholder={intl.formatMessage(messages.selectGroups)}
+            role="combobox"
+            isExpanded={state[permissionID].isOpen}
+          >
+            {state[permissionID].selected.length > 0 ? (
+              <ChipGroup aria-label="Current selections">
+                <Chip
+                  badge={<Badge isRead>{state[permissionID].selected.length}</Badge>}
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    clearSelection(permissionID);
+                  }}
+                >
+                  selected
+                </Chip>
+              </ChipGroup>
+            ) : null}
+          </TextInputGroupMain>
+
+          <TextInputGroupUtilities>
+            {state[permissionID].filterValue.length > 0 && (
+              <Button
+                variant="plain"
+                aria-label="Clear input value"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  onTextInputChange(e, '', permissionID);
+                }}
+              >
+                <TimesIcon aria-hidden />
+              </Button>
+            )}
+          </TextInputGroupUtilities>
+        </TextInputGroup>
+      </MenuToggle>
+    </Tooltip>
+  );
+
   const makeRow = (permissionID, index) => {
-    const ungroupedSystems = intl
-      .formatMessage(messages.ungroupedSystems)
-      .toLocaleLowerCase()
-      .includes(state[permissionID].filterValue.toLocaleLowerCase())
-      ? [
-          <SelectOption key={`${permissionID}-ungrouped`} value="null">
-            <FormattedMessage {...messages.ungroupedSystems} />
-          </SelectOption>,
-          <Divider component="li" key={`${permissionID}-divider`} />,
-        ]
-      : [];
     const options = Object.values(resourceTypes?.[permissionID] ?? {});
 
     return (
       <React.Fragment key={permissionID}>
         <Grid>
-          <GridItem lg={3} md={3} sm={4}>
+          <GridItem md={3}>
             <FormGroup label={permissionID?.replace('inventory:', '')} isRequired />
           </GridItem>
-          <GridItem lg={7} md={6} sm={5}>
-            <Tooltip content={<div>{intl.formatMessage(messages.inventoryGroupsTooltip)}</div>}>
-              <Select
-                className="rbac-m-resource-type-select"
-                variant={SelectVariant.checkbox}
-                typeAheadAriaLabel={intl.formatMessage(messages.inventoryGroupsTypeAheadLabel)}
-                aria-labelledby={permissionID}
-                selections={state[permissionID].selected.map(({ name }) => name)}
-                placeholderText={intl.formatMessage(messages.selectGroups)}
-                onSelect={(event, selection) => onSelect(event, selection, selection === 'select-all', permissionID)}
-                onToggle={(_event, isOpen) => {
-                  // TODO: persist filter state when https://github.com/patternfly/patternfly-react/issues/9490 is resolved
-                  !isOpen && state[permissionID].filterValue?.length > 0 && fetchData([permissionID]);
-                  dispatchLocally({ type: 'toggle', key: permissionID, filterValue: '', page: 1, isOpen });
-                }}
-                onClear={() => clearSelection(permissionID)}
-                onFilter={(event) => {
-                  if (event) {
-                    dispatchLocally({ type: 'setFilter', key: permissionID, filterValue: event.target.value });
-                    debouncedFetch(() => fetchData([permissionID], { name: event.target.value }), 2000);
-                  }
-                }}
-                isOpen={state[permissionID].isOpen}
-                hasInlineFilter
-                {...(!isLoading &&
-                  resourceTypes[permissionID] &&
-                  Object.values(resourceTypes[permissionID]).length < totalCount && {
-                    loadingVariant: {
-                      text: intl.formatMessage(messages.seeMore),
-                      onClick: () => {
-                        fetchData([permissionID], { page: state[permissionID].page + 1, name: state[permissionID].filterValue });
-                        dispatchLocally({ type: 'setPage', key: permissionID, page: state[permissionID].page++ });
-                      },
-                    },
-                  })}
-                {...(isLoading && { loadingVariant: 'spinner' })}
-              >
-                {[
-                  ...(options?.length > 0
-                    ? [
-                        <SelectOption key={`${permissionID}-all`} value="select-all">
-                          <FormattedMessage
-                            {...messages.selectAll}
-                            values={{
-                              length: options?.length,
-                            }}
-                          />
-                        </SelectOption>,
-                      ]
-                    : []),
-                  ...(permissionID.includes('hosts:') ? ungroupedSystems : []),
-                  ...(options?.map((option, index) => (
-                    <SelectOption key={`${permissionID}-${index + 1}`} value={option?.name}>
-                      {option.children}
+          <GridItem md={7}>
+            <Select
+              role="menu"
+              aria-labelledby={permissionID}
+              className="rbac-c-resource-type-select"
+              isOpen={state[permissionID].isOpen}
+              selected={state[permissionID].selected}
+              onSelect={(event, selection) => onSelect(event, selection, selection === 'select-all', permissionID)}
+              onOpenChange={(isOpen) => dispatchLocally({ type: 'toggle', key: permissionID, isOpen })}
+              toggle={(toggleRef) => toggle(toggleRef, permissionID)}
+            >
+              <SelectList>
+                {options?.length > 0 ? (
+                  <SelectOption className="pf-v5-u-link-color" key={`${permissionID}-all`} value="select-all">
+                    <FormattedMessage
+                      {...messages.selectAll}
+                      values={{
+                        length: options?.length + Number(isHosts(permissionID)),
+                      }}
+                    />
+                  </SelectOption>
+                ) : null}
+                {isHosts(permissionID) ? (
+                  <>
+                    <SelectOption
+                      key={`${permissionID}-ungrouped`}
+                      value="null"
+                      hasCheckbox
+                      isSelected={state[permissionID].selected.some((item) => item.name === 'null')}
+                    >
+                      <FormattedMessage {...messages.ungroupedSystems} />
                     </SelectOption>
-                  )) || []),
-                ]}
-              </Select>
-            </Tooltip>
+                    {options.length > 0 ? <Divider component="li" key={`${permissionID}-divider`} /> : null}
+                  </>
+                ) : null}
+                {options.map((option) => (
+                  <SelectOption
+                    hasCheckbox
+                    key={option.id}
+                    isSelected={state[permissionID].selected.some((item) => item.name === option.name)}
+                    className={option.className}
+                    value={option.name}
+                  >
+                    {option.name}
+                  </SelectOption>
+                ))}
+                {isLoading || (resourceTypes[permissionID] && Object.values(resourceTypes[permissionID]).length < totalCount) ? (
+                  <SelectOption
+                    {...(!isLoading && { isLoadButton: true })}
+                    {...(isLoading && { isLoading: true })}
+                    onClick={() => {
+                      fetchData([permissionID], { page: state[permissionID].page + 1, name: state[permissionID].filterValue });
+                      dispatchLocally({ type: 'setPage', key: permissionID, page: state[permissionID].page++ });
+                    }}
+                    value="loader"
+                  >
+                    {isLoading ? <Spinner size="lg" /> : intl.formatMessage(messages.seeMore)}
+                  </SelectOption>
+                ) : null}
+              </SelectList>
+            </Select>
           </GridItem>
-          <GridItem lg={2} md={4} sm={2}>
+          <GridItem md={2}>
             {index <= 0 && permissions.length > 1 && (
               <Button key={`${permissionID}-copy`} variant="link" isInLink onClick={() => dispatchLocally({ type: 'copyToAll', permissions })}>
                 {intl.formatMessage(messages.copyToAll)}
@@ -246,7 +324,7 @@ const InventoryGroupsRole = (props) => {
 
   return (
     <Grid hasGutter>
-      <GridItem lg={3} md={6} className="rbac-m-hide-on-sm">
+      <GridItem md={3} className="rbac-m-hide-on-sm">
         <Text component={TextVariants.h4} className="rbac-bold-text pf-v5-u-mt-sm">
           {intl.formatMessage(messages.permissions)}
         </Text>

--- a/src/test/smart-components/addRoleWizard/__snapshots__/inventory-groups-role.test.js.snap
+++ b/src/test/smart-components/addRoleWizard/__snapshots__/inventory-groups-role.test.js.snap
@@ -6,7 +6,7 @@ exports[`Inventory groups role Add permissions to group renders without failing 
     class="pf-v5-l-grid pf-m-gutter"
   >
     <div
-      class="pf-v5-l-grid__item pf-m-6-col-on-md pf-m-3-col-on-lg rbac-m-hide-on-sm"
+      class="pf-v5-l-grid__item pf-m-3-col-on-md rbac-m-hide-on-sm"
     >
       <h4
         class="rbac-bold-text pf-v5-u-mt-sm"
@@ -35,7 +35,7 @@ exports[`Inventory groups role Add permissions to group renders without failing 
       class="pf-v5-l-grid"
     >
       <div
-        class="pf-v5-l-grid__item pf-m-4-col-on-sm pf-m-3-col-on-md pf-m-3-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-3-col-on-md"
       >
         <div
           class="pf-v5-c-form__group"
@@ -66,57 +66,72 @@ exports[`Inventory groups role Add permissions to group renders without failing 
         </div>
       </div>
       <div
-        class="pf-v5-l-grid__item pf-m-5-col-on-sm pf-m-6-col-on-md pf-m-7-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-7-col-on-md"
       >
         <div
           style="display: contents;"
         >
           <div
-            class="pf-v5-c-select rbac-m-resource-type-select"
-            data-ouia-component-id="OUIA-Generated-Select-checkbox-1"
-            data-ouia-component-type="PF5/Select"
-            data-ouia-safe="true"
+            class="pf-v5-c-menu-toggle pf-m-full-width pf-m-typeahead"
           >
             <div
-              class="pf-v5-c-select__toggle pf-m-typeahead"
+              class="pf-v5-c-text-input-group pf-m-plain"
             >
               <div
-                class="pf-v5-c-select__toggle-wrapper"
+                autocomplete="off"
+                class="pf-v5-c-text-input-group__main"
               >
                 <span
-                  class="pf-v5-c-select__toggle-text"
+                  class="pf-v5-c-text-input-group__text"
                 >
-                  Select groups
+                  <input
+                    aria-expanded="false"
+                    aria-label="Type to filter"
+                    class="pf-v5-c-text-input-group__text-input"
+                    placeholder="Select groups"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
                 </span>
               </div>
-              <button
-                aria-expanded="false"
-                aria-label="Options menu"
-                aria-labelledby="inventory:hosts:read pf-select-toggle-id-0"
-                class="pf-v5-c-button pf-v5-c-select__toggle-button pf-m-plain"
-                id="pf-select-toggle-id-0"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v5-svg pf-v5-c-select__toggle-arrow"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </button>
+              <div
+                class="pf-v5-c-text-input-group__utilities"
+              />
             </div>
+            <button
+              aria-expanded="false"
+              aria-label="Menu toggle"
+              class="pf-v5-c-menu-toggle__button"
+              type="button"
+            >
+              <span
+                class="pf-v5-c-menu-toggle__controls"
+              >
+                <span
+                  class="pf-v5-c-menu-toggle__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
           </div>
         </div>
       </div>
       <div
-        class="pf-v5-l-grid__item pf-m-2-col-on-sm pf-m-4-col-on-md pf-m-2-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-2-col-on-md"
       >
         <button
           aria-disabled="false"
@@ -134,7 +149,7 @@ exports[`Inventory groups role Add permissions to group renders without failing 
       class="pf-v5-l-grid"
     >
       <div
-        class="pf-v5-l-grid__item pf-m-4-col-on-sm pf-m-3-col-on-md pf-m-3-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-3-col-on-md"
       >
         <div
           class="pf-v5-c-form__group"
@@ -165,57 +180,72 @@ exports[`Inventory groups role Add permissions to group renders without failing 
         </div>
       </div>
       <div
-        class="pf-v5-l-grid__item pf-m-5-col-on-sm pf-m-6-col-on-md pf-m-7-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-7-col-on-md"
       >
         <div
           style="display: contents;"
         >
           <div
-            class="pf-v5-c-select rbac-m-resource-type-select"
-            data-ouia-component-id="OUIA-Generated-Select-checkbox-2"
-            data-ouia-component-type="PF5/Select"
-            data-ouia-safe="true"
+            class="pf-v5-c-menu-toggle pf-m-full-width pf-m-typeahead"
           >
             <div
-              class="pf-v5-c-select__toggle pf-m-typeahead"
+              class="pf-v5-c-text-input-group pf-m-plain"
             >
               <div
-                class="pf-v5-c-select__toggle-wrapper"
+                autocomplete="off"
+                class="pf-v5-c-text-input-group__main"
               >
                 <span
-                  class="pf-v5-c-select__toggle-text"
+                  class="pf-v5-c-text-input-group__text"
                 >
-                  Select groups
+                  <input
+                    aria-expanded="false"
+                    aria-label="Type to filter"
+                    class="pf-v5-c-text-input-group__text-input"
+                    placeholder="Select groups"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
                 </span>
               </div>
-              <button
-                aria-expanded="false"
-                aria-label="Options menu"
-                aria-labelledby="inventory:groups:write pf-select-toggle-id-1"
-                class="pf-v5-c-button pf-v5-c-select__toggle-button pf-m-plain"
-                id="pf-select-toggle-id-1"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v5-svg pf-v5-c-select__toggle-arrow"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </button>
+              <div
+                class="pf-v5-c-text-input-group__utilities"
+              />
             </div>
+            <button
+              aria-expanded="false"
+              aria-label="Menu toggle"
+              class="pf-v5-c-menu-toggle__button"
+              type="button"
+            >
+              <span
+                class="pf-v5-c-menu-toggle__controls"
+              >
+                <span
+                  class="pf-v5-c-menu-toggle__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
           </div>
         </div>
       </div>
       <div
-        class="pf-v5-l-grid__item pf-m-2-col-on-sm pf-m-4-col-on-md pf-m-2-col-on-lg"
+        class="pf-v5-l-grid__item pf-m-2-col-on-md"
       />
     </div>
   </div>

--- a/src/test/smart-components/addRoleWizard/inventory-groups-role.test.js
+++ b/src/test/smart-components/addRoleWizard/inventory-groups-role.test.js
@@ -109,7 +109,7 @@ describe('Inventory groups role', () => {
     const store = mockStore(initialStateWithPermissions);
     renderComponent(store);
 
-    fireEvent.click(screen.getAllByLabelText('Options menu')[0]);
+    fireEvent.click(screen.getAllByLabelText('Menu toggle')[0]);
 
     expect(screen.getByText('fooBar')).toBeInTheDocument();
   });
@@ -123,7 +123,7 @@ describe('Inventory groups role', () => {
     const store = mockStore(initialStateWithPermissions);
     const renderedResults = renderComponent(store);
 
-    fireEvent.click(screen.getAllByLabelText('Options menu')[0]);
+    fireEvent.click(screen.getAllByLabelText('Menu toggle')[0]);
     expect(screen.getByText('fooBar')).toBeInTheDocument();
     fireEvent.click(screen.getByText('fooBar'));
 
@@ -132,8 +132,8 @@ describe('Inventory groups role', () => {
 
     // Opening the second groups selection
     fireEvent.click(renderedResults.getByText('Copy to all'));
-    expect(screen.getAllByLabelText('Options menu')[1]);
-    fireEvent.click(screen.getAllByLabelText('Options menu')[1]);
+    expect(screen.getAllByLabelText('Menu toggle')[1]);
+    fireEvent.click(screen.getAllByLabelText('Menu toggle')[1]);
 
     const badgesAfterCopyAll = screen.getAllByText('1', { selector: '.pf-v5-c-badge' });
     expect(badgesAfterCopyAll).toHaveLength(2);
@@ -148,7 +148,7 @@ describe('Inventory groups role', () => {
     const store = mockStore(initialStateWithPermissions);
     const renderedResults = renderComponent(store);
 
-    fireEvent.click(screen.getAllByLabelText('Options menu')[0]);
+    fireEvent.click(screen.getAllByLabelText('Menu toggle')[0]);
     expect(renderedResults.getByText('fooBar')).toBeInTheDocument();
     fireEvent.click(screen.getByText('fooBar'));
 


### PR DESCRIPTION
[RHCLOUD-27776](https://issues.redhat.com/browse/RHCLOUD-27776)

Replaced deprecated PF Select in inventory groups

Before:
<img width="1120" alt="image" src="https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/0ca05b5f-74d9-4788-9a19-b985dba75256">

Now:
![chrome-capture-2024-3-4](https://github.com/RedHatInsights/insights-rbac-ui/assets/50696716/9ea31090-32c1-4f7d-bc59-6f0af97e02c2)
