### PR TITLE
RHCLOUD-31826: quick fix for sentry errors when switching between roles and groups

### DIFF
--- a/src/smart-components/role/role-table-helpers.js
+++ b/src/smart-components/role/role-table-helpers.js
@@ -51,7 +51,7 @@ export const createRows = (data, selectedRows, intl, expanded, adminGroup) =>
                       group.description,
                       {
                         title:
-                          adminGroup.uuid === group.uuid ? null : (
+                          adminGroup?.uuid === group.uuid ? null : (
                             <AppLink
                               to={pathnames['roles-add-group-roles'].link.replace(':roleId', uuid).replace(':groupId', group.uuid)}
                               state={{ name: group.name }}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
We have an issue where setting filters in the groups UI then switching to the roles UI is causing sentry errors. See attached RHCLOUD ticket and slack discussion here: https://redhat-internal.slack.com/archives/C05M0SNTLM8/p1712174912636909. This is causing several issues in our test suites. The issue is not reproducible every time in my observations, but if you set the filter and click back and forth enough it will eventually error.

I suspect this may have been introduced in https://github.com/RedHatInsights/insights-rbac-ui/pull/1601. After that change, while we load the roles UI - we make a request to load the adminGroup here: https://github.com/RedHatInsights/insights-rbac-ui/blob/master/src/smart-components/role/roles.js#L96. The adminGroup is then passed into our `createRows` helpers here: https://github.com/RedHatInsights/insights-rbac-ui/blob/master/src/smart-components/role/roles.js#L182 (which is throwing errors).

AFAIK there is no guarantee the adminGroup request will have loaded by the time the UI finishes loading and calls the `createRows` helper (hence adminGroup will be undefined until the request finishes and it makes its way into redux).

For now I've simply added an optional chaining check to the line that was throwing the sentry error. I think long term we need a few changes:
1. Do we really need to make the same admin group request every time we load the page? Or can it be cached?
2. If the admin group must be loaded before we do any table evaluation, we need to move the call to request it sooner in the page loading and stop the UI from rendering any further
3. Do we really need to use redux for this?
4. We _really_ should convert this to typescript - which likely would have alerted us to the fact that adminGroup can either be `undefined | Object`

https://issues.redhat.com/browse/RHCLOUD-31826

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2024-04-11 at 6 11 13 PM](https://github.com/RedHatInsights/insights-rbac-ui/assets/21317056/66122fd9-d5db-4214-969e-310c73f836a0)



#### After:
![Screenshot 2024-04-11 at 6 10 39 PM](https://github.com/RedHatInsights/insights-rbac-ui/assets/21317056/ebaa5ce6-c698-4385-a195-d32398ad0b5e)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
