### PR TITLE
Enable service accounts on stable only if specific FF is enabled

### DIFF
--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -232,8 +232,9 @@ const renderRoutes = (routes: RouteType[] = []) =>
 
 const Routing = () => {
   const location = useLocation();
-  const { updateDocumentTitle } = useChrome();
-  const enableServiceAccounts = useFlag('platform.rbac.group-service-accounts');
+  const { updateDocumentTitle, isBeta } = useChrome();
+  const enableServiceAccounts =
+    (isBeta() && useFlag('platform.rbac.group-service-accounts')) || (!isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
 
   useEffect(() => {
     const currPath = Object.values(pathnames).find(

--- a/src/smart-components/group/add-group/add-group-wizard.js
+++ b/src/smart-components/group/add-group/add-group-wizard.js
@@ -20,6 +20,8 @@ import AddGroupSuccess from './add-group-success';
 import useAppNavigate from '../../../hooks/useAppNavigate';
 import paths from '../../../utilities/pathnames';
 import messages from '../../../Messages';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag } from '@unleash/proxy-client-react';
 
 export const AddGroupWizardContext = createContext({
   success: false,
@@ -60,7 +62,10 @@ const AddGroupWizard = ({ postMethod, pagination, filters, orderBy }) => {
   const dispatch = useDispatch();
   const intl = useIntl();
   const container = useRef(document.createElement('div'));
-  const schema = useRef(schemaBuilder(container.current));
+  const { isBeta } = useChrome();
+  const enableServiceAccounts =
+    (isBeta() && useFlag('platform.rbac.group-service-accounts')) || (!isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
+  const schema = useRef(schemaBuilder(container.current, enableServiceAccounts));
   const navigate = useAppNavigate();
   const [groupData, setGroupData] = useState({});
   const [wizardContextValue, setWizardContextValue] = useState({

--- a/src/smart-components/group/add-group/schema.js
+++ b/src/smart-components/group/add-group/schema.js
@@ -9,7 +9,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 import messages from '../../../Messages';
 import providerMessages from '../../../locales/data.json';
 
-export const schemaBuilder = (container) => {
+export const schemaBuilder = (container, enableServiceAccounts) => {
   const cache = createIntlCache();
   const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
@@ -64,7 +64,7 @@ export const schemaBuilder = (container) => {
           },
           {
             name: 'add-users',
-            nextStep: 'add-service-accounts',
+            nextStep: enableServiceAccounts ? 'add-service-accounts' : 'review',
             title: intl.formatMessage(messages.addMembers),
             fields: [
               {
@@ -73,17 +73,21 @@ export const schemaBuilder = (container) => {
               },
             ],
           },
-          {
-            name: 'add-service-accounts',
-            nextStep: 'review',
-            title: intl.formatMessage(messages.addServiceAccounts),
-            fields: [
-              {
-                component: 'set-service-accounts',
-                name: 'service-accounts-list',
-              },
-            ],
-          },
+          ...(enableServiceAccounts
+            ? [
+                {
+                  name: 'add-service-accounts',
+                  nextStep: 'review',
+                  title: intl.formatMessage(messages.addServiceAccounts),
+                  fields: [
+                    {
+                      component: 'set-service-accounts',
+                      name: 'service-accounts-list',
+                    },
+                  ],
+                },
+              ]
+            : []),
           {
             name: 'review',
             title: intl.formatMessage(messages.reviewDetails),

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -4,10 +4,13 @@ import { Grid, GridItem, Stack, StackItem, Text, TextVariants } from '@patternfl
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const SummaryContent = () => {
   const intl = useIntl();
   const formOptions = useFormApi();
+  const { isBeta } = useChrome();
   const {
     'group-name': name,
     'group-description': description,
@@ -15,6 +18,8 @@ const SummaryContent = () => {
     'roles-list': selectedRoles,
     'service-accounts-list': selectedServiceAccounts,
   } = formOptions.getState().values;
+  const enableServiceAccounts =
+    (isBeta() && useFlag('platform.rbac.group-service-accounts')) || (!isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
 
   return (
     <div className="rbac">
@@ -76,13 +81,15 @@ const SummaryContent = () => {
                     {intl.formatMessage(messages.serviceAccounts)}
                   </Text>
                 </GridItem>
-                <GridItem md={9}>
-                  {selectedServiceAccounts.map((account, index) => (
-                    <Text className="pf-v5-u-mb-0" key={index}>
-                      {account.name}
-                    </Text>
-                  ))}
-                </GridItem>
+                {enableServiceAccounts && (
+                  <GridItem md={9}>
+                    {selectedServiceAccounts?.map((account, index) => (
+                      <Text className="pf-v5-u-mb-0" key={index}>
+                        {account.name}
+                      </Text>
+                    ))}
+                  </GridItem>
+                )}
               </Grid>
             </StackItem>
           </Stack>

--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -19,7 +19,7 @@ import { BAD_UUID, getBackRoute } from '../../helpers/shared/helpers';
 import { DEFAULT_ACCESS_GROUP_ID } from '../../utilities/constants';
 import messages from '../../Messages';
 import pathnames from '../../utilities/pathnames';
-import { usePreviewFlag } from '../../helpers/shared/use-preview-flag';
+import { useFlag } from '@unleash/proxy-client-react';
 import './group.scss';
 
 const Group = () => {
@@ -30,7 +30,9 @@ const Group = () => {
   const chrome = useChrome();
   const { groupId } = useParams();
   const isPlatformDefault = groupId === DEFAULT_ACCESS_GROUP_ID;
-  const enableServiceAccounts = usePreviewFlag('platform.rbac.group-service-accounts');
+  const enableServiceAccounts =
+    (chrome.isBeta() && useFlag('platform.rbac.group-service-accounts')) ||
+    (!chrome.isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
 
   const tabItems = [
     { eventKey: 0, title: 'Roles', name: pathnames['group-detail-roles'].link.replace(':groupId', groupId), to: 'roles' },

--- a/src/test/smart-components/group/add-group/add-group-wizard.test.js
+++ b/src/test/smart-components/group/add-group/add-group-wizard.test.js
@@ -11,6 +11,20 @@ import { notificationsMiddleware } from '@redhat-cloud-services/frontend-compone
 import AddGroupWizard, { onCancel } from '../../../../smart-components/group/add-group/add-group-wizard';
 import { defaultSettings } from '../../../../helpers/shared/pagination';
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return {
+    __esModule: true,
+    default: () => ({
+      isBeta: () => true,
+    }),
+  };
+});
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  __esModule: true,
+  useFlag: () => true,
+}));
+
 describe('<AddGroupWizard />', () => {
   let initialProps;
   let initialState;


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

SA has GA on 19th, let's prepare for it by hiding it behind extra FF which will be enabled on 19th. This PR also hides adding SA to group by the same feature flag as is the SA tab in group.

[RHCLOUD-32118](https://issues.redhat.com/browse/RHCLOUD-32118)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
