### PR TITLE
Get rid of window.history.back

### DIFF
--- a/src/smart-components/group/group.js
+++ b/src/smart-components/group/group.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { useLocation, useParams, Outlet } from 'react-router-dom';
+import { useLocation, useParams, Outlet, useNavigationType } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -27,6 +27,7 @@ const Group = () => {
   const dispatch = useDispatch();
   const navigate = useAppNavigate();
   const location = useLocation();
+  const navigationType = useNavigationType();
   const chrome = useChrome();
   const { groupId } = useParams();
   const isPlatformDefault = groupId === DEFAULT_ACCESS_GROUP_ID;
@@ -263,7 +264,7 @@ const Group = () => {
                 ouiaId="back-button"
                 variant="primary"
                 aria-label="Back to previous page"
-                onClick={() => window.history.back()}
+                onClick={() => navigate(navigationType !== 'POP' ? -1 : pathnames.groups.link)}
               >
                 {intl.formatMessage(messages.backToPreviousPage)}
               </Button>,

--- a/src/smart-components/role/role.js
+++ b/src/smart-components/role/role.js
@@ -1,7 +1,7 @@
 import React, { Fragment, Suspense, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useNavigationType, useParams } from 'react-router-dom';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { Button, Level, LevelItem, Text, TextContent } from '@patternfly/react-core';
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core/deprecated';
@@ -13,6 +13,7 @@ import { fetchGroup, fetchRolesForGroup, fetchSystemGroup } from '../../redux/ac
 import { ToolbarTitlePlaceholder } from '../../presentational-components/shared/loader-placeholders';
 import { DEFAULT_ACCESS_GROUP_ID } from '../../utilities/constants';
 import { BAD_UUID, getBackRoute } from '../../helpers/shared/helpers';
+import useAppNavigate from '../../hooks/useAppNavigate';
 import { defaultSettings } from '../../helpers/shared/pagination';
 import Permissions from './role-permissions';
 import EmptyWithAction from '../../presentational-components/shared/empty-state';
@@ -25,6 +26,8 @@ import './role.scss';
 const Role = ({ onDelete }) => {
   const intl = useIntl();
   const chrome = useChrome();
+  const navigate = useAppNavigate();
+  const navigationType = useNavigationType();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [isNonPermissionAddingRole, setIsNonPermissionAddingRole] = useState(false);
   const { roleId, groupId } = useParams();
@@ -211,7 +214,7 @@ const Role = ({ onDelete }) => {
                 ouiaId="back-button"
                 variant="primary"
                 aria-label="Back to previous page"
-                onClick={() => window.history.back()}
+                onClick={() => navigate(navigationType !== 'POP' ? -1 : pathnames.roles.link)}
               >
                 {intl.formatMessage(messages.backToPreviousPage)}
               </Button>,

--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext, Fragment, Suspense } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useNavigationType, useParams } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { Button, Label, Stack, StackItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { TableVariant, compoundExpand } from '@patternfly/react-table';
@@ -33,6 +33,7 @@ let debouncedFetch;
 const User = () => {
   const intl = useIntl();
   const navigate = useAppNavigate();
+  const navigationType = useNavigationType();
   const dispatch = useDispatch();
   const { username } = useParams();
   const [filter, setFilter] = useState('');
@@ -319,7 +320,7 @@ const User = () => {
                 ouiaId="back-button"
                 variant="primary"
                 aria-label="Back to previous page"
-                onClick={() => window.history.back()}
+                onClick={() => navigate(navigationType !== 'POP' ? -1 : pathnames.users.link)}
               >
                 {intl.formatMessage(messages.backToPreviousPage)}
               </Button>,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Replaced `window.history.back` with a react router way of navigating to a previous page correctly

par of [RHCLOUD-27116](https://issues.redhat.com/browse/RHCLOUD-27116)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
_N/A_


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
