### PR TITLE
Remove service-account- prefix from delete API call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
         "@redhat-cloud-services/host-inventory-client": "^1.4.0",
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
-        "@redhat-cloud-services/rbac-client": "^2.2.0",
+        "@redhat-cloud-services/rbac-client": "^2.2.1",
         "@unleash/proxy-client-react": "^4.0.3",
         "axios-mock-adapter": "^1.22.0",
         "babel-loader": "^9.1.3",
@@ -4476,9 +4476,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.2.0.tgz",
-      "integrity": "sha512-crytQeif+qr5yWwIpP5baMA4slk7SGmV9CC/1HiyyM91OoC9Iculqp2kYjWY3FtEEw0iJRaOyjV2RRfR+Cmzyw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.2.1.tgz",
+      "integrity": "sha512-3Z8yQK9XUGBrRwif+oeCXkGL0LQGdg/oOdeohvfhICnv97UKfd19XelL3VNettatSMshwZMsDkVxr5//uKrM7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
     "@redhat-cloud-services/host-inventory-client": "^1.4.0",
     "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
-    "@redhat-cloud-services/rbac-client": "^2.2.0",
+    "@redhat-cloud-services/rbac-client": "^2.2.1",
     "@unleash/proxy-client-react": "^4.0.3",
     "axios-mock-adapter": "^1.22.0",
     "babel-loader": "^9.1.3",

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -138,7 +138,7 @@ export async function addServiceAccountsToGroup(groupId, serviceAccounts) {
 }
 
 export async function removeServiceAccountsFromGroup(groupId, serviceAccountsIds) {
-  return await groupApi.deletePrincipalFromGroup(groupId, undefined, serviceAccountsIds.map((clientId) => `service-account-${clientId}`).join(','));
+  return await groupApi.deletePrincipalFromGroup(groupId, undefined, serviceAccountsIds.join(','));
 }
 
 export async function fetchAccountsForGroup(groupId, options = {}) {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Removed service-account- prefix from delete API call

[RHCLOUD-32035](https://issues.redhat.com/browse/RHCLOUD-32035)

---

### Screenshots
_N/A_


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
