### PR TITLE
Fix error when loading user list post-inviting users inboundary

### DIFF
--- a/src/smart-components/group/add-group/users-list-itless.js
+++ b/src/smart-components/group/add-group/users-list-itless.js
@@ -518,7 +518,7 @@ const UsersListItless = ({ selectedUsers, setSelectedUsers, userLinks, usesMetaI
         <Outlet
           context={{
             [paths['invite-users'].path]: {
-              fetchData,
+              fetchData: () => fetchData({ ...pagination, filters, usesMetaInURL }),
             },
           }}
         />


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Follow up to: https://github.com/RedHatInsights/insights-rbac-ui/pull/1643. After inviting a user - there is an error where `limit` is undefined when executing fetchdata.

---

### Screenshots

NA

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
