### PR TITLE
Workspaces - navigation and header

### DIFF
--- a/cypress/e2e/workspaces.cy.ts
+++ b/cypress/e2e/workspaces.cy.ts
@@ -1,0 +1,11 @@
+describe('Workspaces page', () => {
+  it('Visit Workspaces page', () => {
+    cy.login();
+
+    cy.visit('/iam/access-management/workspaces');
+    cy.wait(4000);
+
+    // check if Workspaces heading exists on the page
+    cy.contains('Workspaces').should('exist');
+  });
+});

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -937,6 +937,22 @@ export default defineMessages({
     description: 'Overview Hero third list item',
     defaultMessage: `Assign users to these groups, allowing them to inherit the permissions associated with their group's roles`,
   },
+  workspaces: {
+    id: 'workspaces',
+    description: 'Workspaces heading',
+    defaultMessage: 'Workspaces',
+  },
+  workspacesSubtitle: {
+    id: 'workspacesSubtitle',
+    description: 'Workspaces subtitle',
+    defaultMessage:
+      'Workspaces provide a flexible, hierarchical, approach to organizing your assets and streamlining access management. Configure workspaces to fit your organizational structure.',
+  },
+  workspacesLearnMore: {
+    id: 'workspacesLearnMore',
+    description: 'learn more link',
+    defaultMessage: 'Learn more about workspaces',
+  },
   viewGroupsBtn: {
     id: 'viewGroupsBtn',
     description: 'View groups button',

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -10,6 +10,7 @@ import { useFlag } from '@unleash/proxy-client-react';
 
 const Overview = lazy(() => import('./smart-components/overview/overview'));
 
+const Workspaces = lazy(() => import('./smart-components/workspaces/workspaces'));
 const Users = lazy(() => import('./smart-components/user/users'));
 const UserDetail = lazy(() => import('./smart-components/user/user'));
 const AddUserToGroup = lazy(() => import('./smart-components/user/add-user-to-group/add-user-to-group'));
@@ -42,6 +43,10 @@ const getRoutes = ({ enableServiceAccounts, isITLess }: Record<string, boolean>)
   {
     path: pathnames.overview.path,
     element: Overview,
+  },
+  {
+    path: pathnames.workspaces.path,
+    element: Workspaces,
   },
   {
     path: pathnames['user-detail'].path,

--- a/src/smart-components/workspaces/workspaces.tsx
+++ b/src/smart-components/workspaces/workspaces.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import messages from '../../Messages';
+import { ContentHeader } from '@patternfly/react-component-groups';
+import { Card, PageSection } from '@patternfly/react-core';
+
+const Workspaces = () => {
+  const intl = useIntl();
+
+  return (
+    <React.Fragment>
+      <ContentHeader
+        title={intl.formatMessage(messages.workspaces)}
+        subtitle={intl.formatMessage(messages.workspacesSubtitle)}
+        linkProps={{
+          label: intl.formatMessage(messages.workspacesLearnMore),
+          isExternal: true,
+          // TODO: URL to be provided by UX later on
+          href: '#',
+        }}
+      />
+      <PageSection>
+        <Card aria-label="Get started card" className="pf-u-mb-lg" data-ouia-component-id="get-started-card">
+          Table to be added
+        </Card>
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default Workspaces;

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -8,6 +8,11 @@ const pathnames = {
     path: '/overview/*',
     title: 'Overview',
   },
+  workspaces: {
+    link: '/workspaces',
+    path: '/workspaces/*',
+    title: 'Workspaces',
+  },
   groups: {
     link: '/groups',
     path: '/groups/*',


### PR DESCRIPTION
### Description
This PR implements first part of RHCLOUD-31947 - sets up routing and adds header for Workspaces. TableView will follow.

[RHCLOUD-31947](https://issues.redhat.com/browse/RHCLOUD-31947)

---

### Screenshots
![image](https://github.com/user-attachments/assets/d35e1f38-1bc4-4bda-9aaa-ffaa7fa7b888)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
