### PR TITLE
feat: show WS enable alert only if user can perform this action

### DIFF
--- a/cypress/e2e/enable-workspaces-alert.cy.ts
+++ b/cypress/e2e/enable-workspaces-alert.cy.ts
@@ -1,6 +1,6 @@
 describe('Enable Workspaces Alert', () => {
   beforeEach(() => {
-    cy.login(true);
+    cy.login(false);
     cy.visit('/iam/user-access/overview');
     cy.intercept('GET', '**/api/rbac/v1/access/?application=rbac&limit=1000').as('overviewPage');
     cy.wait('@overviewPage', { timeout: 8000 }).its('response.statusCode').should('eq', 200);

--- a/src/smart-components/overview/overview.js
+++ b/src/smart-components/overview/overview.js
@@ -41,10 +41,11 @@ const Overview = () => {
   const intl = useIntl();
   const [expanded, setExpanded] = useState(true);
   const isWorkspacesFlag = useFlag('platform.rbac.workspaces');
+  const isWorkspacesEligible = useFlag('platform.rbac.workspaces-eligible');
 
   return (
     <React.Fragment>
-      {isWorkspacesFlag && <EnableWorkspacesAlert />}
+      {isWorkspacesEligible && !isWorkspacesFlag && <EnableWorkspacesAlert />}
       <ContentHeader
         title={intl.formatMessage(messages.overview)}
         subtitle={intl.formatMessage(messages.overviewSubtitle)}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
The enable workspaces should be visible only to customers if they can enable it. Once they are on workspaces they can't go back.

[RHCLOUD-35833](https://issues.redhat.com/browse/RHCLOUD-35833)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

![Screenshot 2024-10-22 at 11 18 30](https://github.com/user-attachments/assets/abc1b64c-92e9-4fbe-be6b-57dbc1b292e2)

#### After:
![Screenshot 2024-10-22 at 11 17 18](https://github.com/user-attachments/assets/ec8eb39d-7f93-4337-85a2-6eea5ed88d95)



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
