### PR TITLE
fix(permission): unable to load more than 2 pages in permissions

### DIFF
--- a/src/smart-components/role/add-role/inventory-groups-role.js
+++ b/src/smart-components/role/add-role/inventory-groups-role.js
@@ -303,7 +303,7 @@ const InventoryGroupsRole = (props) => {
                     {...(isLoading && { isLoading: true })}
                     onClick={() => {
                       fetchData([permissionID], { page: state[permissionID].page + 1, name: state[permissionID].filterValue });
-                      dispatchLocally({ type: 'setPage', key: permissionID, page: state[permissionID].page++ });
+                      dispatchLocally({ type: 'setPage', key: permissionID, page: state[permissionID].page + 1 });
                     }}
                     value="loader"
                   >


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Currently users are unable to navigate to more than second page of permissions because it's dispatching only 2nd page in state. This PR fixes it by changing increment to plus.

[RHCLOUD-35972](https://issues.redhat.com/browse/RHCLOUD-35972)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
