### PR TITLE
fix(basename): basename for workspaces is calculated incorrectly

### DIFF
--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -284,13 +284,16 @@ const Routing = () => {
 
   const routes = getRoutes({ enableServiceAccounts, isITLess, isWorkspacesFlag });
   const renderedRoutes = useMemo(() => renderRoutes(routes as never), [routes]);
+
+  const { getBundle, getApp } = useChrome();
+  const defaultBasename = `/${getBundle()}/${getApp()}`;
   return (
     <Suspense fallback={<AppPlaceholder />}>
       <QuickstartsTestButtons />
       <RouterRoutes>
         {renderedRoutes}
         {/* Catch all unmatched routes */}
-        <RouterRoute path="*" element={<Navigate to={mergeToBasename(pathnames.users.link)} />} />
+        <RouterRoute path="*" element={<Navigate to={mergeToBasename(pathnames.users.link, defaultBasename)} />} />
       </RouterRoutes>
     </Suspense>
   );

--- a/src/presentational-components/shared/AppLink.tsx
+++ b/src/presentational-components/shared/AppLink.tsx
@@ -1,3 +1,4 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import React, { LegacyRef } from 'react';
 import { Link, LinkProps, To } from 'react-router-dom';
 
@@ -17,11 +18,15 @@ export const mergeToBasename = (to: To, basename = '/iam/user-access') => {
   };
 };
 
-const AppLink: React.FC<AppLinkProps> = React.forwardRef((props: AppLinkProps, ref: LegacyRef<HTMLSpanElement>) => (
-  <span ref={ref}>
-    <Link {...props} to={mergeToBasename(props.to, props.linkBasename)} />
-  </span>
-));
+const AppLink: React.FC<AppLinkProps> = React.forwardRef((props: AppLinkProps, ref: LegacyRef<HTMLSpanElement>) => {
+  const { getBundle, getApp } = useChrome();
+  const defaultBasename = `/${getBundle()}/${getApp()}`;
+  return (
+    <span ref={ref}>
+      <Link {...props} to={mergeToBasename(props.to, props.linkBasename || defaultBasename)} />
+    </span>
+  );
+});
 
 AppLink.displayName = 'AppLink';
 

--- a/src/test/__mocks__/@redhat-cloud-services/frontend-components/useChrome/index.js
+++ b/src/test/__mocks__/@redhat-cloud-services/frontend-components/useChrome/index.js
@@ -5,6 +5,8 @@ const useChrome = () => ({
   isProd: () => true,
   getEnvironment: () => undefined,
   auth: { getUser: () => undefined },
+  getBundle: () => 'iam',
+  getApp: () => 'user-access',
 });
 
 module.exports = useChrome;


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Basename calculation for workspaces is incorrect, it uses by default user access instead of access management.

