### PR TITLE
feat(invite-users): add invite users modal via data driven forms

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -28,6 +28,67 @@ export default defineMessages({
     defaultMessage:
       'The organization administrator role is the highest permission level with full access to content and features. This is the only role that can manage users.',
   },
+  inviteUsersFormManageSupportCasesFieldTitle: {
+    id: 'inviteUsersFormManageSupportCasesFieldTitle',
+    description: 'Invite users form manage support cases field title',
+    defaultMessage: 'Organization administrators',
+  },
+  inviteUsersFormManageSupportCasesFieldDescription: {
+    id: 'inviteUsersFormManageSupportCasesFieldDescription',
+    description: 'Invite users form manage support cases field description',
+    defaultMessage:
+      'The organization administrator role is the highest permission level with full access to content and features. This is the only role that can manage users.',
+  },
+  inviteUsersFormDownloadSoftwareUpdatesFieldTitle: {
+    id: 'inviteUsersFormDownloadSoftwareUpdatesFieldTitle',
+    description: 'Invite users form download software and updates field title',
+    defaultMessage: 'Download software and updates',
+  },
+  inviteUsersFormDownloadSoftwareUpdatesFieldDescription: {
+    id: 'inviteUsersFormDownloadSoftwareUpdatesFieldDescription',
+    description: 'Invite users form download software and updates field description',
+    defaultMessage: 'User can download software and updates from the Red Hat Customer Portal.',
+  },
+  inviteUsersFormManageSubscriptionsFieldTitle: {
+    id: 'inviteUsersFormManageSubscriptionsFieldTitle',
+    description: 'Invite users form manage subscriptions field title',
+    defaultMessage: 'Manage your subscriptions',
+  },
+  inviteUsersFormManageSubscriptionsFieldDescription: {
+    id: 'inviteUsersFormManageSubscriptionsFieldDescription',
+    description: 'Invite users form manage subscriptions field description',
+    defaultMessage: 'Grants user access to subscription management via Red Hat Subscription Management in the Red Hat Customer Portal.',
+  },
+  inviteUsersFormManageSubscriptionsViewEditUsersOnlyTitle: {
+    id: 'inviteUsersFormManageSubscriptionsViewEditUsersOnlyTitle',
+    description: 'Invite users form manage subscriptions field View edit Users only title',
+    defaultMessage: 'View/Edit users only',
+  },
+  inviteUsersFormManageSubscriptionsViewEditUsersOnlyDescription: {
+    id: 'inviteUsersFormManageSubscriptionsViewEditUsersOnlyDescription',
+    description: 'Invite users form manage subscriptions field View edit Users only description',
+    defaultMessage: 'User can view and edit only the systems that they have registered in the account.',
+  },
+  inviteUsersFormManageSubscriptionsViewAllTitle: {
+    id: 'inviteUsersFormManageSubscriptionsViewAllTitle',
+    description: 'Invite users form manage subscriptions field view all option title',
+    defaultMessage: 'User can view and edit only the systems that they have registered in the account.',
+  },
+  inviteUsersFormManageSubscriptionsViewAllDescription: {
+    id: 'inviteUsersFormManageSubscriptionsViewAllDescription',
+    description: 'Invite users form manage subscriptions field view all option description',
+    defaultMessage: 'User can view (but not edit) all systems and Subscription Management Applications in the account.',
+  },
+  inviteUsersFormManageSubscriptionsViewEditAllTitle: {
+    id: 'inviteUsersFormManageSubscriptionsViewEditAllTitle',
+    description: 'Invite users form manage subscriptions field View/Edit all option title',
+    defaultMessage: 'View/Edit all',
+  },
+  inviteUsersFormManageSubscriptionsViewEditAllDescription: {
+    id: 'inviteUsersFormManageSubscriptionsViewEditAllDescription',
+    description: 'Invite users form manage subscriptions field View/Edit all option description',
+    defaultMessage: 'User can view and edit all systems and Subscription Management Applications in the account.',
+  },
   inviteUsersFormEmailsFieldTitle: {
     id: 'inviteUsersFormEmailsFieldTitle',
     description: 'Invite users form emails field title',
@@ -36,7 +97,22 @@ export default defineMessages({
   inviteUsersFormEmailsFieldDescription: {
     id: 'inviteUsersFormEmailsFieldDescription',
     description: 'Invite users form emails field description',
-    defaultMessage: 'Enter up to 50 e-mail addresses separated by commas or returns.',
+    defaultMessage: 'Enter up to 50 email addresses separated by commas or returns.',
+  },
+  inviteUsersFormEmailsFieldError: {
+    id: 'inviteUsersFormEmailsFieldError',
+    description: 'Invite users form emails field error message is one email address is not valid.',
+    defaultMessage: 'Some of the email addresses you provided are not valid',
+  },
+  inviteUsersMessageTitle: {
+    id: 'inviteUsersMessageTitle',
+    description: 'Message to be sent to each email',
+    defaultMessage: 'Send a message with the invite',
+  },
+  inviteUsersCustomerPortalPermissions: {
+    id: 'inviteUsersCustomerPortalPermissions',
+    description: 'Customer portal permissions title',
+    defaultMessage: 'Customer Portal access permissions',
   },
   inviteUsersCancelled: {
     id: 'inviteUsersCancelled',

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -17,6 +17,7 @@ const Users = lazy(() => import('./smart-components/user/users'));
 const UserDetail = lazy(() => import('./smart-components/user/user'));
 const AddUserToGroup = lazy(() => import('./smart-components/user/add-user-to-group/add-user-to-group'));
 const InviteUsersModal = lazy(() => import('./smart-components/user/invite-users/invite-users-modal'));
+const InviteUsersModalCommonAuth = lazy(() => import('./smart-components/user/invite-users/invite-users-modal-common-auth'));
 
 const Roles = lazy(() => import('./smart-components/role/roles'));
 const Role = lazy(() => import('./smart-components/role/role'));
@@ -44,10 +45,16 @@ const QuickstartsTest = lazy(() => import('./smart-components/quickstarts/quicks
 
 const UsersAndUserGroups = lazy(() => import('./smart-components/access-management/users-and-user-groups'));
 
-const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag }: Record<string, boolean>) => [
+const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel }: Record<string, boolean>) => [
   {
     path: pathnames['users-and-user-groups'].path,
     element: UsersAndUserGroups,
+    childRoutes: [
+      isCommonAuthModel && {
+        path: pathnames['invite-group-users'].path,
+        element: InviteUsersModalCommonAuth,
+      },
+    ],
   },
   {
     path: pathnames.overview.path,
@@ -79,9 +86,9 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag }: Record
     path: pathnames.users.path,
     element: Users,
     childRoutes: [
-      isITLess && {
+      (isITLess || isCommonAuthModel) && {
         path: pathnames['invite-users'].path,
-        element: InviteUsersModal,
+        element: isCommonAuthModel ? InviteUsersModalCommonAuth : InviteUsersModal,
       },
     ],
   },
@@ -267,6 +274,7 @@ const Routing = () => {
   const location = useLocation();
   const { updateDocumentTitle, isBeta } = useChrome();
   const isITLess = useFlag('platform.rbac.itless');
+  const isCommonAuthModel = useFlag('platform.rbac.common-auth-model');
   const enableServiceAccounts =
     (isBeta() && useFlag('platform.rbac.group-service-accounts')) || (!isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
   const isWorkspacesFlag = useFlag('platform.rbac.workspaces');
@@ -287,7 +295,7 @@ const Routing = () => {
     }
   }, [location.pathname, updateDocumentTitle]);
 
-  const routes = getRoutes({ enableServiceAccounts, isITLess, isWorkspacesFlag });
+  const routes = getRoutes({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel });
   const renderedRoutes = useMemo(() => renderRoutes(routes as never), [routes]);
 
   const { getBundle, getApp } = useChrome();

--- a/src/helpers/user/user-helper.js
+++ b/src/helpers/user/user-helper.js
@@ -2,6 +2,10 @@ import { getLastPageOffset, isOffsetValid } from '../shared/pagination';
 import { getPrincipalApi } from '../shared/user-login';
 import { isInt, isStage, isITLessProd } from '../../itLessConfig';
 
+export const MANAGE_SUBSCRIPTIONS_VIEW_EDIT_USER = 'view-edit-user';
+export const MANAGE_SUBSCRIPTIONS_VIEW_ALL = 'view-all';
+export const MANAGE_SUBSCRIPTIONS_VIEW_EDIT_ALL = 'view-edit-all';
+
 const principalApi = getPrincipalApi();
 
 const principalStatusApiMap = {

--- a/src/presentational-components/shared/AppLink.tsx
+++ b/src/presentational-components/shared/AppLink.tsx
@@ -4,6 +4,7 @@ import { Link, LinkProps, To } from 'react-router-dom';
 
 interface AppLinkProps extends LinkProps {
   linkBasename?: string;
+  to: To;
 }
 
 export const mergeToBasename = (to: To, basename = '/iam/user-access') => {
@@ -18,15 +19,17 @@ export const mergeToBasename = (to: To, basename = '/iam/user-access') => {
   };
 };
 
-const AppLink: React.FC<AppLinkProps> = React.forwardRef((props: AppLinkProps, ref: LegacyRef<HTMLSpanElement>) => {
-  const { getBundle, getApp } = useChrome();
-  const defaultBasename = `/${getBundle()}/${getApp()}`;
-  return (
-    <span ref={ref}>
-      <Link {...props} to={mergeToBasename(props.to, props.linkBasename || defaultBasename)} />
-    </span>
-  );
-});
+const AppLink: React.FC<React.PropsWithChildren<AppLinkProps & { className?: string }>> = React.forwardRef(
+  (props: React.PropsWithChildren<AppLinkProps>, ref: LegacyRef<HTMLSpanElement>) => {
+    const { getBundle, getApp } = useChrome();
+    const defaultBasename = `/${getBundle()}/${getApp()}`;
+    return (
+      <span ref={ref}>
+        <Link {...props} to={mergeToBasename(props.to, props.linkBasename || defaultBasename)} />
+      </span>
+    );
+  }
+);
 
 AppLink.displayName = 'AppLink';
 

--- a/src/presentational-components/shared/table-composable-toolbar-view.tsx
+++ b/src/presentational-components/shared/table-composable-toolbar-view.tsx
@@ -54,7 +54,7 @@ interface MainTableProps {
   setFilterValue: (value: FilterProps) => void;
   pagination: { limit?: number; offset?: number; count?: number; noBottom?: boolean };
   fetchData: (config: FetchDataProps) => void;
-  toolbarButtons?: () => React.ReactNode[];
+  toolbarButtons?: () => (React.JSX.Element | React.ReactNode)[];
   filterPlaceholder?: string;
   filters: Array<{
     value: string | number | Array<unknown>;

--- a/src/smart-components/common/expandable-checkbox.tsx
+++ b/src/smart-components/common/expandable-checkbox.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import useFieldApi, { UseFieldApiConfig } from '@data-driven-forms/react-form-renderer/use-field-api';
+import { ExpandableSection, Checkbox, FormGroup, Radio, Tooltip } from '@patternfly/react-core';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/outlined-question-circle-icon';
+
+export type ExpandableCheckboxItemType = {
+  title: string;
+  description: string;
+  name: string;
+  options?: { title: string; description: string; name: string }[];
+};
+
+const ExpandableCheckbox: React.FC<UseFieldApiConfig> = (props) => {
+  const formOptions = useFormApi();
+  const { items, input } = useFieldApi(props);
+  const values = formOptions.getState().values;
+  return (
+    <FormGroup>
+      {items?.map((item: ExpandableCheckboxItemType, key: number) => (
+        <Checkbox
+          inputClassName="pf-v5-u-mt-xs"
+          key={key}
+          isChecked={!!values[input.name]?.[item.name]}
+          onChange={(_e, value) => {
+            const newVal = value && item.options ? item.options?.[0]?.name : value;
+            input.onChange({
+              ...values[input.name],
+              [item.name]: newVal,
+            });
+          }}
+          label={
+            <ExpandableSection toggleText={item.title} isIndented>
+              {item.description}
+              {item.options && (
+                <FormGroup role="radiogroup" fieldId={`${item.name}-radiogroup`}>
+                  {item.options?.map((option, key) => (
+                    <Radio
+                      key={key}
+                      name={`${item.name}-radio`}
+                      isChecked={values[input.name]?.[item.name] === option.name}
+                      onChange={() => {
+                        input.onChange({
+                          ...values[input.name],
+                          [item.name]: option.name,
+                        });
+                      }}
+                      label={
+                        <React.Fragment>
+                          {option.title}{' '}
+                          {option.description && (
+                            <Tooltip content={option.description}>
+                              <OutlinedQuestionCircleIcon />
+                            </Tooltip>
+                          )}
+                        </React.Fragment>
+                      }
+                      id={`${item.name}-option-${key}`}
+                    />
+                  ))}
+                </FormGroup>
+              )}
+            </ExpandableSection>
+          }
+          id={`${item.name}-checkbox`}
+          name={item.name}
+        />
+      ))}
+    </FormGroup>
+  );
+};
+
+export default ExpandableCheckbox;

--- a/src/smart-components/common/form-renderer.tsx
+++ b/src/smart-components/common/form-renderer.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import FormButtons from './FormButtons';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
 import TextField from '@data-driven-forms/pf4-component-mapper/text-field';
 import Textarea from '@data-driven-forms/pf4-component-mapper/textarea';
 import ReactFormRender from '@data-driven-forms/react-form-renderer/form-renderer';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import FormTemplateCommonProps from '@data-driven-forms/common/form-template';
 
-const FormRenderer = ({ formTemplateProps, ...props }) => (
+const FormRenderer: React.FC<{ formTemplateProps?: FormTemplateCommonProps } & FormTemplateCommonProps> = ({ formTemplateProps, ...props }) => (
   <ReactFormRender
     componentMapper={{
       [componentTypes.TEXT_FIELD]: TextField,
@@ -17,9 +17,5 @@ const FormRenderer = ({ formTemplateProps, ...props }) => (
     {...props}
   />
 );
-
-FormRenderer.propTypes = {
-  formTemplateProps: PropTypes.object,
-};
 
 export default FormRenderer;

--- a/src/smart-components/user/invite-users/invite-users-modal-common-auth.tsx
+++ b/src/smart-components/user/invite-users/invite-users-modal-common-auth.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import FormRenderer from '../../common/form-renderer';
+import ModalFormTemplate from '../../common/ModalFormTemplate';
+import { useIntl } from 'react-intl';
+import messages from '../../../Messages';
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+import AccordionCheckbox from '../../common/expandable-checkbox';
+import { addUsers } from '../../../redux/actions/user-actions';
+import { useDispatch } from 'react-redux';
+import { useFlag } from '@unleash/proxy-client-react';
+import {
+  MANAGE_SUBSCRIPTIONS_VIEW_ALL,
+  MANAGE_SUBSCRIPTIONS_VIEW_EDIT_ALL,
+  MANAGE_SUBSCRIPTIONS_VIEW_EDIT_USER,
+} from '../../../helpers/user/user-helper';
+import { useOutletContext } from 'react-router-dom';
+
+const ExpandableCheckboxComponent = 'expandableCheckbox';
+const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type SubmitValues = {
+  'email-addresses': string;
+  'invite-message'?: string;
+  'customer-portal-permissions'?: {
+    'is-org-admin'?: boolean;
+    'manage-support-cases'?: boolean;
+    'download-software-updates'?: boolean;
+    'manage-subscriptions'?:
+      | typeof MANAGE_SUBSCRIPTIONS_VIEW_EDIT_USER
+      | typeof MANAGE_SUBSCRIPTIONS_VIEW_ALL
+      | typeof MANAGE_SUBSCRIPTIONS_VIEW_EDIT_ALL;
+  };
+};
+
+const InviteUsers = () => {
+  const { fetchData } = useOutletContext<{ fetchData: (isSubmit: boolean) => void }>();
+  const isCommonAuth = useFlag('platform.rbac.common-auth-model');
+  const dispatch = useDispatch();
+  const onCancel = () => {
+    fetchData(false);
+  };
+  const onSubmit = (values: SubmitValues) => {
+    const action = addUsers(
+      {
+        emails: values['email-addresses']?.split(/[\s,]+/),
+        message: values['invite-message'],
+        isAdmin: values['customer-portal-permissions']?.['is-org-admin'],
+        manageSupportCases: values['customer-portal-permissions']?.['manage-support-cases'],
+        downloadUpdates: values['customer-portal-permissions']?.['download-software-updates'],
+        mangeSubscriptions: values['customer-portal-permissions']?.['manage-subscriptions'],
+      },
+      isCommonAuth
+    );
+    action.payload.then(() => fetchData(true));
+    dispatch(action);
+  };
+  const intl = useIntl();
+  const schema = React.useMemo(
+    () => ({
+      description: intl.formatMessage(messages.inviteUsersDescription),
+      fields: [
+        {
+          component: componentTypes.TEXTAREA,
+          label: intl.formatMessage(messages.inviteUsersFormEmailsFieldTitle),
+          name: 'email-addresses',
+          placeholder: intl.formatMessage(messages.inviteUsersFormEmailsFieldDescription),
+          rows: 5,
+          isRequired: true,
+          validate: [
+            {
+              type: validatorTypes.REQUIRED,
+            },
+            (value: string) =>
+              value.split(/[\s,]+/).every((email: string) => EMAIL_REGEXP.test(email))
+                ? undefined
+                : intl.formatMessage(messages.inviteUsersFormEmailsFieldError),
+          ],
+        },
+        {
+          component: componentTypes.TEXTAREA,
+          label: intl.formatMessage(messages.inviteUsersMessageTitle),
+          name: 'invite-message',
+          rows: 3,
+        },
+        {
+          component: ExpandableCheckboxComponent,
+          items: [
+            {
+              name: 'is-org-admin',
+              title: intl.formatMessage(messages.inviteUsersFormIsAdminFieldTitle),
+              description: intl.formatMessage(messages.inviteUsersFormIsAdminFieldDescription),
+            },
+            {
+              name: 'manage-support-cases',
+              title: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsFieldTitle),
+              description: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsFieldDescription),
+            },
+            {
+              name: 'download-software-updates',
+              title: intl.formatMessage(messages.inviteUsersFormDownloadSoftwareUpdatesFieldTitle),
+              description: intl.formatMessage(messages.inviteUsersFormDownloadSoftwareUpdatesFieldDescription),
+            },
+            {
+              name: 'manage-subscriptions',
+              title: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsFieldTitle),
+              description: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsFieldDescription),
+              options: [
+                {
+                  name: MANAGE_SUBSCRIPTIONS_VIEW_EDIT_USER,
+                  title: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewEditUsersOnlyTitle),
+                  description: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewEditUsersOnlyDescription),
+                },
+                {
+                  name: MANAGE_SUBSCRIPTIONS_VIEW_ALL,
+                  title: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewAllTitle),
+                  description: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewAllDescription),
+                },
+                {
+                  name: MANAGE_SUBSCRIPTIONS_VIEW_EDIT_ALL,
+                  title: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewEditAllTitle),
+                  description: intl.formatMessage(messages.inviteUsersFormManageSubscriptionsViewEditAllDescription),
+                },
+              ],
+            },
+          ],
+          name: 'customer-portal-permissions',
+        },
+      ],
+    }),
+    []
+  );
+  return (
+    <FormRenderer
+      schema={schema}
+      formFields={[]}
+      componentMapper={{
+        ...componentMapper,
+        [ExpandableCheckboxComponent]: AccordionCheckbox,
+      }}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+      FormTemplate={(props: unknown[]) => (
+        <ModalFormTemplate
+          saveLabel={intl.formatMessage(messages.inviteUsersTitle)}
+          cancelLabel={intl.formatMessage(messages.cancel)}
+          alert={undefined}
+          {...props}
+          ModalProps={{ onClose: onCancel, isOpen: true, variant: 'medium', title: intl.formatMessage(messages.inviteUsersTitle) }}
+        />
+      )}
+    />
+  );
+};
+
+export default InviteUsers;

--- a/src/smart-components/user/users.tsx
+++ b/src/smart-components/user/users.tsx
@@ -17,6 +17,7 @@ const Users = () => {
   const activeUserPermissions = useContext(PermissionsContext);
   const { appNavClick } = useChrome();
   const isITLess = useFlag('platform.rbac.itless');
+  const isCommonAuthModel = useFlag('platform.rbac.common-auth-model');
 
   const description = <ActiveUser linkDescription={intl.formatMessage(messages.addNewUsersText)} />;
 
@@ -30,7 +31,7 @@ const Users = () => {
       isSelectable: !isITLess ? false : activeUserPermissions.userAccessAdministrator || activeUserPermissions.orgAdmin,
       isCompact: false,
     },
-    usesMetaInURL: isITLess ? !location.pathname.includes(paths['invite-users'].link) : true,
+    usesMetaInURL: isITLess || isCommonAuthModel ? !location.pathname.includes(paths['invite-users'].link) : true,
   };
 
   return (

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -200,7 +200,12 @@ const pathnames = {
   },
   'users-and-user-groups': {
     link: '/users-and-user-groups',
-    path: '/users-and-user-groups/*',
+    path: '/users-and-user-groups',
+    title: 'Users & User Groups',
+  },
+  'invite-group-users': {
+    link: '/users-and-user-groups/invite',
+    path: '/users-and-user-groups/invite',
     title: 'Users & User Groups',
   },
 };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Add visuals to invite users to console.redhat.com.

This PR only adds the modal visuals and calls action which is just dummy Promise, because we don't have API ready yet.

[RHCLOUD-36068](https://issues.redhat.com/browse/RHCLOUD-36068)

---

### Screenshots

![Screenshot 2024-11-14 at 13 15 05](https://github.com/user-attachments/assets/cc37e68e-f070-4719-8d36-54ba56270c86)



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
