### PR TITLE
feat: add create user group to user group list

### DIFF
--- a/cypress/e2e/users-and-user-groups.cy.ts
+++ b/cypress/e2e/users-and-user-groups.cy.ts
@@ -142,4 +142,11 @@ describe('Users and User Groups page', () => {
     cy.get('[data-ouia-component-id="iam-user-groups-table-actions-dropdown-menu-control"]').click();
     cy.get('[data-ouia-component-id="iam-user-groups-table-actions-dropdown-menu-control"] button').contains('Delete user group').click();
   });
+
+  it('should be able to open the Create User Groups Wizard from the toolbar', () => {
+    cy.get('[data-ouia-component-id="add-group-wizard"]').should('not.exist');
+    cy.get('[data-ouia-component-id="user-groups-tab-button"]').click();
+    cy.get('[data-ouia-component-id="iam-user-groups-table-actions-dropdown-action-0"]').click();
+    cy.get('[data-ouia-component-id="add-group-wizard"]').should('exist');
+  });
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2391,4 +2391,9 @@ export default defineMessages({
     description: 'confirm button for deleting role',
     defaultMessage: 'Delete role',
   },
+  createUserGroup: {
+    id: 'createUserGroup',
+    description: 'create user group button label',
+    defaultMessage: 'Create user group',
+  },
 });

--- a/src/smart-components/access-management/UserGroupsTable.tsx
+++ b/src/smart-components/access-management/UserGroupsTable.tsx
@@ -18,6 +18,7 @@ import { Group } from '../../redux/reducers/group-reducer';
 import { DataViewTrObject, DataViewState, EventTypes, useDataViewEventsContext } from '@patternfly/react-data-view';
 import { SearchIcon } from '@patternfly/react-icons';
 import { ResponsiveAction, ResponsiveActions, SkeletonTable, WarningModal } from '@patternfly/react-component-groups';
+import AddGroupWizard from '../group/add-group/add-group-wizard';
 
 const COLUMNS: string[] = ['User group name', 'Description', 'Users', 'Service accounts', 'Roles', 'Workspaces', 'Last modified'];
 
@@ -47,6 +48,7 @@ const UserGroupsTable: React.FunctionComponent<UserGroupsTableProps> = ({
   focusedGroup,
 }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+  const [isAddGroupWizardOpen, setIsAddGroupWizardOpen] = React.useState(false);
   const [currentGroups, setCurrentGroups] = React.useState<Group[]>([]);
   const dispatch = useDispatch();
   const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
@@ -225,6 +227,11 @@ const UserGroupsTable: React.FunctionComponent<UserGroupsTableProps> = ({
 
   return (
     <Fragment>
+      {isAddGroupWizardOpen && (
+        <div data-ouia-component-id="add-group-wizard">
+          <AddGroupWizard pagination={{ limit: 20 }} filters={{}} enableRoles={false} setIsWizardOpen={setIsAddGroupWizardOpen} />
+        </div>
+      )}
       {isDeleteModalOpen && (
         <WarningModal
           ouiaId={`${ouiaId}-remove-user-modal`}
@@ -266,6 +273,9 @@ const UserGroupsTable: React.FunctionComponent<UserGroupsTableProps> = ({
           }
           actions={
             <ResponsiveActions breakpoint="lg" ouiaId={`${ouiaId}-actions-dropdown`}>
+              <ResponsiveAction isPinned isPersistent onClick={() => setIsAddGroupWizardOpen(true)}>
+                {intl.formatMessage(messages.createUserGroup)}
+              </ResponsiveAction>
               <ResponsiveAction
                 isDisabled={selected.length === 0 || selected.some(isRowSystemOrPlatformDefault)}
                 onClick={() => console.log('EDIT USER GROUP')}

--- a/src/smart-components/group/add-group/schema.js
+++ b/src/smart-components/group/add-group/schema.js
@@ -9,7 +9,7 @@ import { createIntl, createIntlCache } from 'react-intl';
 import messages from '../../../Messages';
 import providerMessages from '../../../locales/data.json';
 
-export const schemaBuilder = (container, enableServiceAccounts) => {
+export const schemaBuilder = (container, enableServiceAccounts, enableRoles) => {
   const cache = createIntlCache();
   const intl = createIntl({ locale, messages: providerMessages }, cache);
   return {
@@ -26,7 +26,7 @@ export const schemaBuilder = (container, enableServiceAccounts) => {
         fields: [
           {
             name: 'name-and-description',
-            nextStep: 'add-roles',
+            nextStep: enableRoles ? 'add-roles' : 'add-users',
             title: intl.formatMessage(messages.nameAndDescription),
             fields: [
               {
@@ -51,17 +51,21 @@ export const schemaBuilder = (container, enableServiceAccounts) => {
               },
             ],
           },
-          {
-            name: 'add-roles',
-            nextStep: 'add-users',
-            title: intl.formatMessage(messages.addRoles),
-            fields: [
-              {
-                component: 'set-roles',
-                name: 'roles-list',
-              },
-            ],
-          },
+          ...(enableRoles
+            ? [
+                {
+                  name: 'add-roles',
+                  nextStep: 'add-users',
+                  title: intl.formatMessage(messages.addRoles),
+                  fields: [
+                    {
+                      component: 'set-roles',
+                      name: 'roles-list',
+                    },
+                  ],
+                },
+              ]
+            : []),
           {
             name: 'add-users',
             nextStep: enableServiceAccounts ? 'add-service-accounts' : 'review',

--- a/src/smart-components/group/add-group/summary-content.js
+++ b/src/smart-components/group/add-group/summary-content.js
@@ -47,20 +47,22 @@ const SummaryContent = () => {
                   <Text component={TextVariants.p}>{description}</Text>
                 </GridItem>
               </Grid>
-              <Grid>
-                <GridItem md={3}>
-                  <Text component={TextVariants.h4} className="rbac-bold-text">
-                    {intl.formatMessage(messages.roles)}
-                  </Text>
-                </GridItem>
-                <GridItem md={9}>
-                  {selectedRoles.map((role, index) => (
-                    <Text className="pf-v5-u-mb-0" key={index}>
-                      {role.label}
+              {selectedRoles && (
+                <Grid>
+                  <GridItem md={3}>
+                    <Text component={TextVariants.h4} className="rbac-bold-text">
+                      {intl.formatMessage(messages.roles)}
                     </Text>
-                  ))}
-                </GridItem>
-              </Grid>
+                  </GridItem>
+                  <GridItem md={9}>
+                    {selectedRoles.map((role, index) => (
+                      <Text className="pf-v5-u-mb-0" key={index}>
+                        {role.label}
+                      </Text>
+                    ))}
+                  </GridItem>
+                </Grid>
+              )}
               <Grid>
                 <GridItem md={3}>
                   <Text component={TextVariants.h4} className="rbac-bold-text">


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Enable use of the `add-group-wizard` from the new User Groups page.

- [x] I can create a user group for my organization within the Users and User Groups’ group tab, including a required name and optional description.
- [x] I am notified if the user group name has already been used for my organization.
- [x] I am prompted to add users to the user group as part of the user group creation flow.
- [x] I can add principal users and service accounts from their respective tabs.
- [x] I can confirm or cancel the request.
- [x] Upon cancellation, I am redirected to the previous page/task. 
- [x] Upon saving, I am presented with a success message and redirected to the User Group list. 
- [x] I am presented with an error message if the user group is not saved successfully.

[RHCLOUD-32235](https://issues.redhat.com/browse/RHCLOUD-32235)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
![image](https://github.com/user-attachments/assets/396249b2-95fc-4bc1-a56a-b91f80c47860)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
