### PR TITLE
fix(UserAccess): make user access cards look selected

### DIFF
--- a/src/presentational-components/myUserAccess/MUACard.js
+++ b/src/presentational-components/myUserAccess/MUACard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { List, ListItem, Stack, StackItem, Title, Card, CardTitle, CardBody } from '@patternfly/react-core';
+import { List, ListItem, Stack, StackItem, Title, Card, CardTitle, CardBody, CardHeader } from '@patternfly/react-core';
 
 import { bundleData } from './bundles';
 import useSearchParams from '../../hooks/useSearchParams';
@@ -11,6 +11,12 @@ import './MUACard.scss';
 
 const MUACard = ({ header, entitlements, isDisabled }) => {
   const { bundle: bundleParam } = useSearchParams('bundle');
+  const [, setIsChecked] = React.useState('');
+
+  const onChange = (event) => {
+    setIsChecked(event.currentTarget.id);
+  };
+
   return (
     <React.Fragment>
       {header && (
@@ -36,6 +42,7 @@ const MUACard = ({ header, entitlements, isDisabled }) => {
                   to={{ pathname: '', search: `bundle=${key}` }}
                 >
                   <Card
+                    ouiaId={`${data.title}-card`}
                     key={data.title}
                     isFlat={isDisabled || key !== bundleParam}
                     isSelectable={!isDisabled}
@@ -44,8 +51,20 @@ const MUACard = ({ header, entitlements, isDisabled }) => {
                       'pf-v5-u-background-color-disabled-color-300': isDisabled,
                     })}
                   >
-                    <CardTitle className="pf-v5-u-font-weight-light"> {data.title}</CardTitle>
-                    <CardBody>
+                    <CardHeader
+                      selectableActions={{
+                        selectableActionId: '',
+                        name: data.title,
+                        variant: 'single',
+                        onChange,
+                      }}
+                    >
+                      <CardTitle className="pf-v5-u-font-weight-light" data-ouia-component-id={`${data.title}-card-title`}>
+                        {data.title}
+                      </CardTitle>
+                    </CardHeader>
+
+                    <CardBody data-ouia-component-id={`${data.title}-card-body`}>
                       <List className="pf-v5-u-color-400 pf-v5-u-font-size-sm rbac-c-mua-bundles__card--applist" isPlain>
                         {Object.entries(data.apps || {}).map(([appName]) => (
                           <ListItem key={appName}> {appName} </ListItem>


### PR DESCRIPTION
### Description
This makes the user access cards look more selected by adding a radio button and a blue outline around the selected card. I've also added OUIA IDs to the cards.

[RHCLOUD-31861](https://issues.redhat.com/browse/RHCLOUD-31861) and [RHCLOUD-30863](https://issues.redhat.com/browse/RHCLOUD-30863)

---

### Screenshots

#### Before:
![image](https://github.com/user-attachments/assets/a4c0be99-4f05-467c-8943-28ec9ad973da)


#### After:
![image](https://github.com/user-attachments/assets/e16e2ac7-da27-4cb6-9b64-05089a0447e8)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
