### PR TITLE
feat: create edit user group page

### DIFF
--- a/cypress/e2e/users-and-user-groups.cy.ts
+++ b/cypress/e2e/users-and-user-groups.cy.ts
@@ -171,4 +171,12 @@ describe('Users and User Groups page', () => {
     cy.get('[data-ouia-component-id="iam-user-groups-table-actions-dropdown-action-0"]').click();
     cy.get('[data-ouia-component-id="add-group-wizard"]').should('exist');
   });
+
+  it('should be able to open Edit User Group page from row actions', () => {
+    cy.get('[data-ouia-component-id="user-groups-tab-button"]').click();
+    cy.get('[data-ouia-component-id^="iam-user-groups-table-table-td-0-7"]').click();
+    cy.get('[data-ouia-component-id^="iam-user-groups-table-table-td-0-7"] button').contains('Edit user group').click();
+    cy.url().should('include', '/iam/access-management/users-and-user-groups/edit-group');
+    cy.get('[data-ouia-component-id="edit-user-group-form"]').should('be.visible');
+  });
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2528,4 +2528,9 @@ export default defineMessages({
     description: 'create user group button label',
     defaultMessage: 'Create user group',
   },
+  selectUsersAndOrServiceAccounts: {
+    id: 'selectUsersAndOrServiceAccounts',
+    description: 'select users and/or service accounts label',
+    defaultMessage: 'Select users and/or service accounts',
+  },
 });

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -47,6 +47,7 @@ const QuickstartsTest = lazy(() => import('./smart-components/quickstarts/quicks
 const UsersAndUserGroups = lazy(() => import('./smart-components/access-management/users-and-user-groups/users-and-user-groups'));
 const UsersView = lazy(() => import('./smart-components/access-management/users-and-user-groups/users/UsersView'));
 const UserGroupsView = lazy(() => import('./smart-components/access-management/users-and-user-groups/user-groups/UserGroupsView'));
+const EditUserGroup = lazy(() => import('./smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup'));
 
 const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel }: Record<string, boolean>) => [
   {
@@ -74,6 +75,10 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
         ],
       },
     ],
+  },
+  {
+    path: pathnames['users-and-user-groups-edit-group'].path,
+    element: EditUserGroup,
   },
   {
     path: pathnames.overview.path,

--- a/src/redux/reducers/group-reducer.ts
+++ b/src/redux/reducers/group-reducer.ts
@@ -36,7 +36,7 @@ export interface GroupStore {
     filters: any;
     pagination: { count: number };
   };
-  selectedGroup: {
+  selectedGroup: Group & {
     addRoles: any;
     members: { meta: PaginationDefaultI; data?: any[] };
     serviceAccounts: { meta: PaginationDefaultI; data?: any[] };

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/UserGroupsTable.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/UserGroupsTable.tsx
@@ -177,7 +177,7 @@ const UserGroupsTable: React.FunctionComponent<UserGroupsTableProps> = ({
               items={[
                 {
                   title: intl.formatMessage(messages['usersAndUserGroupsEditUserGroup']),
-                  onClick: () => console.log('EDIT USER GROUP'),
+                  onClick: () => navigate(pathnames['users-and-user-groups-edit-group'].link.replace(':groupId', group.uuid)),
                 },
                 {
                   title: intl.formatMessage(messages['usersAndUserGroupsDeleteUserGroup']),

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -1,0 +1,186 @@
+import ContentHeader from '@patternfly/react-component-groups/dist/esm/ContentHeader';
+import { PageSection, PageSectionVariants, Spinner } from '@patternfly/react-core';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useIntl } from 'react-intl';
+import Messages from '../../../../../Messages';
+import { FormRenderer, componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+import { FormTemplate } from '@data-driven-forms/pf4-component-mapper';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchGroup, fetchGroups, updateGroup } from '../../../../../redux/actions/group-actions';
+import { RBACStore } from '../../../../../redux/store';
+import { useNavigate, useParams } from 'react-router-dom';
+import { EditGroupUsersAndServiceAccounts } from './EditUserGroupUsersAndServiceAccounts';
+import RbacBreadcrumbs from '../../../../../presentational-components/shared/breadcrumbs';
+import { mergeToBasename } from '../../../../../presentational-components/shared/AppLink';
+import pathnames from '../../../../../utilities/pathnames';
+
+export const EditUserGroup: React.FunctionComponent = () => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const params = useParams();
+  const groupId = params.groupId;
+  const navigate = useNavigate();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [initialFormData, setInitialFormData] = useState<{
+    name?: string;
+    description?: string;
+    users?: string[];
+    serviceAccounts?: string[];
+  } | null>(null);
+
+  const group = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup);
+  const allGroups = useSelector((state: RBACStore) => state.groupReducer?.groups?.data || []);
+  const groupUsers = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.members?.data || []);
+  const groupServiceAccounts = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.serviceAccounts?.data || []);
+
+  const breadcrumbsList = useMemo(
+    () => [
+      {
+        title: intl.formatMessage(Messages.userGroups),
+        to: mergeToBasename(pathnames['users-and-user-groups'].link),
+      },
+      {
+        title: intl.formatMessage(Messages.usersAndUserGroupsEditUserGroup),
+        isActive: true,
+      },
+    ],
+    [intl]
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await Promise.all([
+          dispatch(fetchGroups({ limit: 1000, offset: 0, orderBy: 'name', usesMetaInURL: true })),
+          groupId ? dispatch(fetchGroup(groupId)) : Promise.resolve(),
+        ]);
+      } finally {
+        if (group) {
+          setInitialFormData({
+            name: group.name,
+            description: group.description,
+            users: groupUsers.map((user) => user.username),
+            serviceAccounts: groupServiceAccounts.map((sa) => sa.clientId),
+          });
+        }
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [dispatch, groupId, group?.uuid]);
+
+  const schema = useMemo(
+    () => ({
+      fields: [
+        {
+          name: 'name',
+          label: intl.formatMessage(Messages.name),
+          component: componentTypes.TEXT_FIELD,
+          validate: [
+            { type: validatorTypes.REQUIRED },
+            (value: string) => {
+              if (value === initialFormData?.name) {
+                return undefined;
+              }
+
+              const isDuplicate = allGroups.some(
+                (existingGroup) => existingGroup.name.toLowerCase() === value?.toLowerCase() && existingGroup.uuid !== groupId
+              );
+
+              return isDuplicate ? intl.formatMessage(Messages.groupNameTakenTitle) : undefined;
+            },
+          ],
+          initialValue: initialFormData?.name,
+          isRequired: true,
+        },
+        {
+          name: 'description',
+          label: intl.formatMessage(Messages.description),
+          component: componentTypes.TEXTAREA,
+          initialValue: initialFormData?.description,
+          isRequired: true,
+        },
+        {
+          name: 'users-and-service-accounts',
+          component: 'users-and-service-accounts',
+          groupId: groupId,
+          initialUsers: initialFormData?.users || [],
+          initialServiceAccounts: initialFormData?.serviceAccounts || [],
+          initialValue: {
+            users: {
+              initial: initialFormData?.users || [],
+              updated: initialFormData?.users || [],
+            },
+            serviceAccounts: {
+              initial: initialFormData?.serviceAccounts || [],
+              updated: initialFormData?.serviceAccounts || [],
+            },
+          },
+        },
+      ],
+    }),
+    [initialFormData, allGroups, groupId, intl]
+  );
+
+  const returnToPreviousPage = () => {
+    navigate(-1);
+  };
+
+  const handleSubmit = async (values: Record<string, any>) => {
+    if (values.name !== group?.name || values.description !== group?.description) {
+      dispatch(updateGroup({ uuid: groupId, name: values.name, description: values.description }));
+    }
+
+    if (values['users-and-service-accounts']) {
+      const { users, serviceAccounts } = values['users-and-service-accounts'];
+      if (users.updated.length > 0) {
+        const addedUsers = users.updated.filter((user: string) => !users.initial.includes(user));
+        const removedUsers = users.initial.filter((user: string) => !users.updated.includes(user));
+        console.log(`Users added: ${addedUsers} and removed: ${removedUsers}`);
+      }
+      if (serviceAccounts.updated.length > 0) {
+        const addedServiceAccounts = serviceAccounts.updated.filter((serviceAccount: string) => !serviceAccounts.initial.includes(serviceAccount));
+        const removedServiceAccounts = serviceAccounts.initial.filter((serviceAccount: string) => !serviceAccounts.updated.includes(serviceAccount));
+        console.log(`Service accounts added: ${addedServiceAccounts} and removed: ${removedServiceAccounts}`);
+      }
+      returnToPreviousPage();
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <section className="pf-v5-c-page__main-breadcrumb">
+        <RbacBreadcrumbs {...breadcrumbsList} />
+      </section>
+      <ContentHeader title={intl.formatMessage(Messages.usersAndUserGroupsEditUserGroup)} subtitle={''} />
+      <PageSection data-ouia-component-id="edit-user-group-form" className="pf-v5-u-m-lg-on-lg" variant={PageSectionVariants.light} isWidthLimited>
+        {isLoading || !initialFormData ? (
+          <div style={{ textAlign: 'center' }}>
+            <Spinner />
+          </div>
+        ) : (
+          <FormRenderer
+            schema={schema}
+            componentMapper={{
+              ...componentMapper,
+              'users-and-service-accounts': EditGroupUsersAndServiceAccounts,
+            }}
+            onSubmit={handleSubmit}
+            onCancel={returnToPreviousPage}
+            FormTemplate={FormTemplate}
+            FormTemplateProps={{
+              disableSubmit: ['pristine', 'invalid'],
+            }}
+            debug={(values) => {
+              console.log('values:', values);
+            }}
+          />
+        )}
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default EditUserGroup;

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupServiceAccounts.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupServiceAccounts.tsx
@@ -1,0 +1,214 @@
+import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, Pagination } from '@patternfly/react-core';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DataView, DataViewState, DataViewTable, DataViewToolbar, useDataViewPagination, useDataViewSelection } from '@patternfly/react-data-view';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchServiceAccountsForGroup } from '../../../../../redux/actions/group-actions';
+import { mappedProps } from '../../../../../helpers/shared/helpers';
+import { fetchServiceAccounts } from '../../../../../redux/actions/service-account-actions';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { ServiceAccountsState } from '../../../../../redux/reducers/service-account-reducer';
+import { LAST_PAGE, ServiceAccount } from '../../../../../helpers/service-account/service-account-helper';
+import { BulkSelect, BulkSelectValue, SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
+import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import { TableState } from './EditUserGroupUsersAndServiceAccounts';
+import Messages from '../../../../../Messages';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { SearchIcon } from '@patternfly/react-icons';
+
+const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
+  return (
+    <EmptyState>
+      <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<EmptyStateIcon icon={SearchIcon} />} />
+      <EmptyStateBody>
+        <FormattedMessage
+          {...Messages['usersEmptyStateSubtitle']}
+          values={{
+            br: <br />,
+          }}
+        />
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+interface EditGroupServiceAccountsTableProps {
+  groupId?: string;
+  onChange: (serviceAccounts: TableState) => void;
+  initialServiceAccountIds: string[];
+}
+
+const PER_PAGE_OPTIONS = [
+  { title: '5', value: 5 },
+  { title: '10', value: 10 },
+  { title: '20', value: 20 },
+  { title: '50', value: 50 },
+  { title: '100', value: 100 },
+];
+
+const reducer = ({ serviceAccountReducer }: { serviceAccountReducer: ServiceAccountsState }) => ({
+  serviceAccounts: serviceAccountReducer.serviceAccounts,
+  status: serviceAccountReducer.status,
+  isLoading: serviceAccountReducer.isLoading,
+  limit: serviceAccountReducer.limit,
+  offset: serviceAccountReducer.offset,
+});
+
+const EditGroupServiceAccountsTable: React.FunctionComponent<EditGroupServiceAccountsTableProps> = ({
+  groupId,
+  onChange,
+  initialServiceAccountIds,
+}) => {
+  const dispatch = useDispatch();
+  const pagination = useDataViewPagination({ perPage: 20 });
+  const { page, perPage, onSetPage, onPerPageSelect } = pagination;
+  const { auth, getEnvironmentDetails } = useChrome();
+  const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
+  const intl = useIntl();
+
+  const columns = useMemo(
+    () => [
+      intl.formatMessage(Messages.name),
+      intl.formatMessage(Messages.description),
+      intl.formatMessage(Messages.clientId),
+      intl.formatMessage(Messages.owner),
+      intl.formatMessage(Messages.timeCreated),
+    ],
+    [intl]
+  );
+
+  const selection = useDataViewSelection({
+    matchOption: (a, b) => a.id === b.id,
+  });
+  const { onSelect, selected } = selection;
+
+  useEffect(() => {
+    onSelect(false);
+    const initialSelectedServiceAccounts = initialServiceAccountIds.map((id) => ({ id }));
+    onSelect(true, initialSelectedServiceAccounts);
+  }, [initialServiceAccountIds]);
+
+  const { serviceAccounts, status, isLoading } = useSelector(reducer);
+  const totalCount = useMemo(() => {
+    if (!serviceAccounts) return 0;
+    const currentCount = (page - 1) * perPage + serviceAccounts.length;
+    return status === LAST_PAGE ? currentCount : currentCount + 1;
+  }, [serviceAccounts, page, perPage, status]);
+
+  useEffect(() => {
+    if (isLoading) {
+      setActiveState(DataViewState.loading);
+    } else {
+      setActiveState(serviceAccounts.length === 0 ? DataViewState.empty : undefined);
+    }
+  }, [serviceAccounts.length, isLoading]);
+
+  const fetchData = useCallback(
+    async (apiProps: { count: number; limit: number; offset: number; orderBy: string }) => {
+      if (groupId) {
+        const { count, limit, offset, orderBy } = apiProps;
+        const env = getEnvironmentDetails();
+        const token = await auth.getToken();
+        dispatch(fetchServiceAccounts({ ...mappedProps({ count, limit, offset, orderBy, token, sso: env?.sso }) }));
+        dispatch(fetchServiceAccountsForGroup(groupId, {}));
+      }
+    },
+    [dispatch, groupId]
+  );
+
+  useEffect(() => {
+    fetchData({
+      limit: perPage,
+      offset: (page - 1) * perPage,
+      orderBy: 'username',
+      count: totalCount || 0,
+    });
+  }, [fetchData, page, perPage]);
+
+  const processedServiceAccounts = serviceAccounts ? serviceAccounts.slice(0, perPage) : [];
+  const rows = useMemo(
+    () =>
+      processedServiceAccounts.map((account: ServiceAccount) => ({
+        id: account.uuid,
+        row: [
+          account.name,
+          account.description,
+          account.clientId,
+          account.createdBy,
+          <DateFormat key={`${account.name}-date`} date={account.createdAt} />,
+        ],
+      })),
+    [processedServiceAccounts, groupId]
+  );
+
+  useEffect(() => {
+    onChange({ initial: initialServiceAccountIds, updated: selection.selected.map((user) => user.id) });
+  }, [selection.selected, initialServiceAccountIds]);
+
+  const handleBulkSelect = (value: BulkSelectValue) => {
+    if (value === BulkSelectValue.none) {
+      onSelect(false);
+    } else if (value === BulkSelectValue.page) {
+      onSelect(true, rows);
+    } else if (value === BulkSelectValue.nonePage) {
+      onSelect(false, rows);
+    }
+  };
+
+  const pageSelected = rows.length > 0 && rows.every((row) => selection.isSelected(row));
+  const pagePartiallySelected = !pageSelected && rows.some((row) => selection.isSelected(row));
+
+  return (
+    <DataView selection={{ ...selection }} activeState={activeState}>
+      <DataViewToolbar
+        pagination={
+          <Pagination
+            isCompact
+            perPageOptions={PER_PAGE_OPTIONS}
+            itemCount={totalCount}
+            page={page}
+            perPage={perPage}
+            onSetPage={onSetPage}
+            onPerPageSelect={onPerPageSelect}
+            toggleTemplate={() => {
+              const firstIndex = (page - 1) * perPage + 1;
+              const lastIndex = Math.min(page * perPage, totalCount);
+              const totalNumber = status === LAST_PAGE ? (page - 1) * perPage + serviceAccounts.length : 'many';
+              return (
+                <React.Fragment>
+                  <b>
+                    {firstIndex} - {lastIndex}
+                  </b>{' '}
+                  of <b>{totalNumber}</b>
+                </React.Fragment>
+              );
+            }}
+          />
+        }
+        bulkSelect={
+          <BulkSelect
+            pageCount={serviceAccounts.length}
+            selectedCount={selected.length}
+            totalCount={totalCount}
+            pageSelected={pageSelected}
+            pagePartiallySelected={pagePartiallySelected}
+            onSelect={handleBulkSelect}
+          />
+        }
+      />
+      <DataViewTable
+        variant="compact"
+        columns={columns}
+        rows={rows}
+        headStates={{
+          loading: <SkeletonTableHead columns={columns} />,
+        }}
+        bodyStates={{
+          loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
+          empty: <EmptyTable titleText={intl.formatMessage(Messages.usersEmptyStateTitle)} />,
+        }}
+      />
+    </DataView>
+  );
+};
+
+export default EditGroupServiceAccountsTable;

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsers.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsers.tsx
@@ -1,0 +1,178 @@
+import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, Pagination } from '@patternfly/react-core';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DataView, DataViewState, DataViewTable, DataViewToolbar, useDataViewPagination, useDataViewSelection } from '@patternfly/react-data-view';
+import { useDispatch, useSelector } from 'react-redux';
+import { RBACStore } from '../../../../../redux/store';
+import { fetchUsers } from '../../../../../redux/actions/user-actions';
+import { mappedProps } from '../../../../../helpers/shared/helpers';
+import { BulkSelect, BulkSelectValue, SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
+import { TableState } from './EditUserGroupUsersAndServiceAccounts';
+import { FormattedMessage, useIntl } from 'react-intl';
+import Messages from '../../../../../Messages';
+import { SearchIcon } from '@patternfly/react-icons';
+
+const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
+  return (
+    <EmptyState>
+      <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<EmptyStateIcon icon={SearchIcon} />} />
+      <EmptyStateBody>
+        <FormattedMessage
+          {...Messages['usersEmptyStateSubtitle']}
+          values={{
+            br: <br />,
+          }}
+        />
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+interface EditGroupUsersTableProps {
+  onChange: (userDiff: TableState) => void;
+  groupId: string;
+  initialUserIds: string[];
+}
+
+const PER_PAGE_OPTIONS = [
+  { title: '5', value: 5 },
+  { title: '10', value: 10 },
+  { title: '20', value: 20 },
+  { title: '50', value: 50 },
+  { title: '100', value: 100 },
+];
+
+const EditGroupUsersTable: React.FunctionComponent<EditGroupUsersTableProps> = ({ onChange, groupId, initialUserIds }) => {
+  const dispatch = useDispatch();
+  const pagination = useDataViewPagination({ perPage: 20 });
+  const { page, perPage, onSetPage, onPerPageSelect } = pagination;
+  const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
+  const intl = useIntl();
+
+  const columns = useMemo(
+    () => [
+      intl.formatMessage(Messages.orgAdmin),
+      intl.formatMessage(Messages.username),
+      intl.formatMessage(Messages.email),
+      intl.formatMessage(Messages.firstName),
+      intl.formatMessage(Messages.lastName),
+      intl.formatMessage(Messages.status),
+    ],
+    [intl]
+  );
+
+  const selection = useDataViewSelection({
+    matchOption: (a, b) => a.id === b.id,
+  });
+  const { selected, onSelect, isSelected } = selection;
+
+  useEffect(() => {
+    onSelect(false);
+    const initialSelectedUsers = initialUserIds.map((id) => ({ id }));
+    onSelect(true, initialSelectedUsers);
+  }, [initialUserIds]);
+
+  const { users, totalCount, isLoading } = useSelector((state: RBACStore) => ({
+    users: state.userReducer?.users?.data || [],
+    totalCount: state.userReducer?.users?.meta?.count,
+    isLoading: state.userReducer?.isUserDataLoading,
+  }));
+
+  const rows = useMemo(
+    () =>
+      users.map((user) => ({
+        id: user.username,
+        row: [
+          user.is_org_admin ? intl.formatMessage(Messages.yes) : intl.formatMessage(Messages.no),
+          user.username,
+          user.email,
+          user.first_name,
+          user.last_name,
+          user.is_active ? intl.formatMessage(Messages.active) : intl.formatMessage(Messages.inactive),
+        ],
+      })),
+    [users, groupId]
+  );
+
+  const fetchData = useCallback(
+    (apiProps: { count: number; limit: number; offset: number; orderBy: string }) => {
+      const { count, limit, offset, orderBy } = apiProps;
+      dispatch(fetchUsers({ ...mappedProps({ count, limit, offset, orderBy }), usesMetaInURL: true }));
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (isLoading) {
+      setActiveState(DataViewState.loading);
+    } else {
+      setActiveState(users.length === 0 ? DataViewState.empty : undefined);
+    }
+  }, [users.length, isLoading]);
+
+  useEffect(() => {
+    fetchData({
+      limit: perPage,
+      offset: (page - 1) * perPage,
+      orderBy: 'username',
+      count: totalCount || 0,
+    });
+  }, [fetchData, page, perPage]);
+
+  useEffect(() => {
+    onChange({ initial: initialUserIds, updated: selection.selected.map((user) => user.id) });
+  }, [selection.selected, initialUserIds]);
+
+  const pageSelected = rows.length > 0 && rows.every(isSelected);
+  const pagePartiallySelected = !pageSelected && rows.some(isSelected);
+  const handleBulkSelect = (value: BulkSelectValue) => {
+    if (value === BulkSelectValue.none) {
+      onSelect(false);
+    } else if (value === BulkSelectValue.page) {
+      onSelect(true, rows);
+    } else if (value === BulkSelectValue.nonePage) {
+      onSelect(false, rows);
+    }
+  };
+
+  return (
+    <DataView selection={{ ...selection }} activeState={activeState}>
+      <DataViewToolbar
+        pagination={
+          <Pagination
+            perPageOptions={PER_PAGE_OPTIONS}
+            itemCount={totalCount}
+            page={page}
+            perPage={perPage}
+            onSetPage={onSetPage}
+            onPerPageSelect={onPerPageSelect}
+          />
+        }
+        bulkSelect={
+          <BulkSelect
+            isDataPaginated
+            pageCount={users.length}
+            selectedCount={selected.length}
+            totalCount={totalCount}
+            pageSelected={pageSelected}
+            pagePartiallySelected={pagePartiallySelected}
+            onSelect={handleBulkSelect}
+          />
+        }
+      />
+      <DataViewTable
+        variant="compact"
+        columns={columns}
+        rows={rows}
+        headStates={{
+          loading: <SkeletonTableHead columns={columns} />,
+        }}
+        bodyStates={{
+          loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
+          empty: <EmptyTable titleText={intl.formatMessage(Messages.usersEmptyStateTitle)} />,
+        }}
+      />
+    </DataView>
+  );
+};
+
+export default EditGroupUsersTable;

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsersAndServiceAccounts.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsersAndServiceAccounts.tsx
@@ -1,0 +1,83 @@
+import { FormGroup, Tab, Tabs } from '@patternfly/react-core';
+import React, { useState, useEffect } from 'react';
+import { UseFieldApiConfig, useFieldApi, useFormApi } from '@data-driven-forms/react-form-renderer';
+import EditGroupServiceAccountsTable from './EditUserGroupServiceAccounts';
+import EditGroupUsersTable from './EditUserGroupUsers';
+import { useIntl } from 'react-intl';
+import Messages from '../../../../../Messages';
+
+export interface TableState {
+  initial: string[];
+  updated: string[];
+}
+
+interface ExtendedUseFieldApiConfig extends UseFieldApiConfig {
+  initialUsers?: string[];
+  initialServiceAccounts?: string[];
+}
+
+export const EditGroupUsersAndServiceAccounts: React.FunctionComponent<ExtendedUseFieldApiConfig> = (props) => {
+  const [activeTabKey, setActiveTabKey] = useState(0);
+  const formOptions = useFormApi();
+  const { input, groupId, initialUsers = [], initialServiceAccounts = [] } = useFieldApi(props);
+  const intl = useIntl();
+
+  // Initialize form values once when the component mounts
+  useEffect(() => {
+    const initialState = {
+      users: {
+        initial: initialUsers,
+        updated: initialUsers,
+      },
+      serviceAccounts: {
+        initial: initialServiceAccounts,
+        updated: initialServiceAccounts,
+      },
+    };
+
+    if (!formOptions.getState().values[input.name]) {
+      input.onChange(initialState);
+    }
+  }, [initialUsers, initialServiceAccounts]);
+
+  const handleUserChange = (users: TableState) => {
+    const currentValue = formOptions.getState().values[input.name] || {};
+    input.onChange({
+      ...currentValue,
+      users,
+    });
+  };
+
+  const handleServiceAccountsChange = (serviceAccounts: TableState) => {
+    const currentValue = formOptions.getState().values[input.name] || {};
+    input.onChange({
+      ...currentValue,
+      serviceAccounts,
+    });
+  };
+
+  const handleTabSelect = (_: React.MouseEvent<HTMLElement, MouseEvent>, key: string | number) => {
+    setActiveTabKey(Number(key));
+  };
+
+  return (
+    <React.Fragment>
+      <FormGroup label={intl.formatMessage(Messages.selectUsersAndOrServiceAccounts)}>
+        <Tabs activeKey={activeTabKey} onSelect={handleTabSelect}>
+          <Tab eventKey={0} title={intl.formatMessage(Messages.users)}>
+            <EditGroupUsersTable groupId={groupId} onChange={handleUserChange} initialUserIds={initialUsers} />
+          </Tab>
+          <Tab eventKey={1} title={intl.formatMessage(Messages.serviceAccounts)}>
+            <EditGroupServiceAccountsTable
+              groupId={groupId}
+              onChange={handleServiceAccountsChange}
+              initialServiceAccountIds={initialServiceAccounts}
+            />
+          </Tab>
+        </Tabs>
+      </FormGroup>
+    </React.Fragment>
+  );
+};
+
+export default EditGroupUsersAndServiceAccounts;

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -218,6 +218,11 @@ const pathnames = {
     path: 'user-groups/*',
     title: 'Users & User Groups',
   },
+  'users-and-user-groups-edit-group': {
+    link: '/users-and-user-groups/edit-group/:groupId',
+    path: '/users-and-user-groups/edit-group/:groupId',
+    title: 'Edit group',
+  },
   'invite-group-users': {
     link: '/users-and-user-groups/users/invite',
     path: 'invite',


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Created the Edit User Group page

- [x] I can edit an existing user group by performing any or all of the following actions: 
- [x] I can rename the user group.
- [x] I can update the description of the user group.
- [x] I am notified if the updated user group name has already been used for my organization.
- [x] I can confirm or cancel the request.
- [x] Upon cancellation, I am redirected to the previous page/task. 
- [x] Upon saving, I am presented with a success message and redirected to the User Group list. 
- [x] I am presented with an error message if the user group is not saved successfully.
### Will be handled in future ticket
- [ ] I can add or remove principal users and service accounts from the user group from their respective tabs.

Currently values are diffed and displayed, then logged to the console. Another ticket will handle sending out the appropriate requests.

[RHCLOUD-32236](https://issues.redhat.com/browse/RHCLOUD-32236)

Improve the integration between DataView and data-driven-forms, and potentially create a custom DataView component which could simplify this logic and enable disabling the submit button when no changes have been made here:
[RHCLOUD-37436](https://issues.redhat.com/browse/RHCLOUD-37436) & [RHCLOUD-37435](https://issues.redhat.com/browse/RHCLOUD-37435)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### After:
![image](https://github.com/user-attachments/assets/ecbb998f-f8a7-44fe-b1ea-57939ec895fe)

---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [X] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
