### PR TITLE
fix(admin-group): when we don't have admin group do not break

### DIFF
--- a/src/smart-components/user/user.js
+++ b/src/smart-components/user/user.js
@@ -136,7 +136,7 @@ const User = () => {
                             group.description,
                             {
                               title:
-                                adminGroup.uuid === group.uuid ? null : (
+                                adminGroup?.uuid === group.uuid ? null : (
                                   <AppLink
                                     to={pathnames['user-add-group-roles'].link.replace(':username', username).replace(':groupId', group.uuid)}
                                     state={{ name: group.name }}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Currently if somehow default admin group returns empty array the details of user's role will break the UI. This fixed such issue by using safe accessor.


---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [x] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [x] _(Optional) QE: Has been mentioned_
- [x] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [x] _(Optional) UX: Has been mentioned_
##
