### PR TITLE
feat: add dropdown to make user an org admin workspaces

### DIFF
--- a/src/smart-components/access-management/users-and-user-groups/users/UsersTable.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/users/UsersTable.tsx
@@ -41,8 +41,13 @@ import { PER_PAGE_OPTIONS } from '../../../../helpers/shared/pagination';
 import messages from '../../../../Messages';
 import paths from '../../../../utilities/pathnames';
 import PermissionsContext from '../../../../utilities/permissions-context';
+import OrgAdminDropdown from '../../../user/OrgAdminDropdown';
+import { useFlag } from '@unleash/proxy-client-react';
 
-const COLUMNS: string[] = ['Username', 'Email', 'First name', 'Last name', 'Status', 'Org admin'];
+const authModel = useFlag('platform.rbac.common-auth-model');
+const COLUMNS: string[] = authModel
+  ? ['Org admin', 'Username', 'Email', 'First name', 'Last name', 'Status']
+  : ['Username', 'Email', 'First name', 'Last name', 'Status', 'Org admin'];
 
 const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
   return (
@@ -210,6 +215,27 @@ const UsersTable: React.FunctionComponent<UsersTableProps> = ({ onAddUserClick, 
       id: user.username,
       is_active: user.is_active,
       row: [
+        authModel && orgAdmin ? (
+          <OrgAdminDropdown
+            key={`dropdown-${user.username}`}
+            isOrgAdmin={user.is_org_admin}
+            username={user.username}
+            intl={intl}
+            userId={user.uuid}
+            fetchData={() => {
+              fetchData({
+                limit: perPage,
+                offset: (page - 1) * perPage,
+                orderBy: 'username',
+                count: totalCount || 0,
+              });
+            }}
+          />
+        ) : user.is_org_admin ? (
+          intl.formatMessage(messages['usersAndUserGroupsYes'])
+        ) : (
+          intl.formatMessage(messages['usersAndUserGroupsNo'])
+        ),
         user.username,
         user.email,
         user.first_name,
@@ -225,7 +251,8 @@ const UsersTable: React.FunctionComponent<UsersTableProps> = ({ onAddUserClick, 
             labelOff={intl.formatMessage(messages['usersAndUserGroupsInactive'])}
           ></Switch>,
         ],
-        user.is_org_admin ? intl.formatMessage(messages['usersAndUserGroupsYes']) : intl.formatMessage(messages['usersAndUserGroupsNo']),
+        !authModel &&
+          (user.is_org_admin ? intl.formatMessage(messages['usersAndUserGroupsYes']) : intl.formatMessage(messages['usersAndUserGroupsNo'])),
         {
           cell: (
             <ActionsColumn


### PR DESCRIPTION
### Description
Added dropdown to make user an org admin for workspaces

[RHCLOUD-37492](https://issues.redhat.com/browse/RHCLOUD-37492)

---

### Screenshots
<img width="1720" alt="Snímek obrazovky 2025-02-28 v 15 03 51" src="https://github.com/user-attachments/assets/f207d187-959e-48d8-a668-f7e320becf9a" />


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
