### PR TITLE
feat: enable sorting and filtering for users table

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -391,6 +391,16 @@ export default defineMessages({
     description: 'Filter by data key label',
     defaultMessage: 'Filter by {key}',
   },
+  filterByUsername: {
+    id: 'filterByUsername',
+    description: 'Filter by username label',
+    defaultMessage: 'Filter by username',
+  },
+  filterByEmail: {
+    id: 'filterByEmail',
+    description: 'Filter by email label',
+    defaultMessage: 'Filter by email',
+  },
   editGroupSuccessTitle: {
     id: 'editGroupSuccessTitle',
     description: 'Edit group success notification title',


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
- Allows for sorting based on `username` (Currently the only field supported by the API)
- Allows for filtering based on `username` and `email` (Currently the only fields supported by the API)

[RHCLOUD-35605](https://issues.redhat.com/browse/RHCLOUD-35605)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->

#### After:
![image](https://github.com/user-attachments/assets/a004c31c-1200-4df4-9173-1cdb6fdd85cf)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
