### PR TITLE
feat(role wizard): include add role wizard to new role page

### DIFF
--- a/cypress/e2e/roles.cy.ts
+++ b/cypress/e2e/roles.cy.ts
@@ -205,4 +205,17 @@ describe('Roles page', () => {
     cy.wait('@filterRoles', { timeout: 15000 });
     cy.get('table tbody tr').should('have.length', 1);
   });
+
+  it('should open the add roles wizard', () => {
+    cy.get('button[data-ouia-component-id="add-role-button"]').click();
+    cy.get('div[data-ouia-component-id="add-role-wizard"]').should('exist');
+    cy.contains('Create Role').should('be.visible');
+  });
+
+  it('should close the add role wizard on cancel', () => {
+    cy.get('button[data-ouia-component-id="add-role-button"]').click();
+    cy.get('div[data-ouia-component-id="add-role-wizard"]').should('exist');
+    cy.contains('Cancel').click();
+    cy.get('div[data-ouia-component-id="add-role-wizard"]').should('not.exist');
+  });
 });

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -154,7 +154,7 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
       },
     ],
   },
-  ...(!isWorkspacesFlag
+  ...(isWorkspacesFlag
     ? [
         {
           path: pathnames.roles.path,

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -154,11 +154,17 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
       },
     ],
   },
-  ...(isWorkspacesFlag
+  ...(!isWorkspacesFlag
     ? [
         {
           path: pathnames.roles.path,
           element: newRolesTable,
+          childRoutes: [
+            {
+              path: pathnames['add-role'].path,
+              element: AddRoleWizard,
+            },
+          ],
         },
       ]
     : [

--- a/src/smart-components/role/RolesTable.tsx
+++ b/src/smart-components/role/RolesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState, useRef, useMemo } from 'react';
+import React, { useEffect, useCallback, useState, useRef, useMemo, Suspense } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useDataViewSelection, useDataViewPagination } from '@patternfly/react-data-view/dist/dynamic/Hooks';
 import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
@@ -27,7 +27,8 @@ import messages from '../../Messages';
 import { debouncedFetch, mappedProps } from '../../helpers/shared/helpers';
 import { Role } from '../../redux/reducers/role-reducer';
 import { RBACStore } from '../../redux/store';
-import { useSearchParams } from 'react-router-dom';
+import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
+import paths from '../../utilities/pathnames';
 import RolesDetails from './RolesTableDetails';
 import {
   ResponsiveAction,
@@ -40,6 +41,8 @@ import {
 import { DataViewTextFilter, DataViewTh, DataViewTr, DataViewTrObject, useDataViewFilters } from '@patternfly/react-data-view';
 import { PER_PAGE_OPTIONS } from '../../helpers/shared/pagination';
 import { SearchIcon } from '@patternfly/react-icons';
+import { mergeToBasename } from '../../presentational-components/shared/AppLink';
+import pathnames from '../../utilities/pathnames';
 
 const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
   return (
@@ -102,6 +105,8 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
     searchParams,
     setSearchParams,
   });
+
+  const navigate = useNavigate();
 
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
   const sortByIndex = useMemo(() => COLUMNHEADERS.findIndex((item) => (item.isSortable ? item.key === sortBy : '')), [sortBy]);
@@ -270,6 +275,9 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
             }
             actions={
               <ResponsiveActions breakpoint="lg" ouiaId={`${ouiaId}-actions-dropdown`}>
+                <ResponsiveAction ouiaId="add-role-button" onClick={() => navigate(mergeToBasename(paths['add-role'].link))} isPinned>
+                  {intl.formatMessage(messages.createRole)}
+                </ResponsiveAction>
                 <ResponsiveAction
                   isDisabled={selected.length === 0 || selected.some(isRowSystemOrPlatformDefault)}
                   onClick={() => {
@@ -332,6 +340,16 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
             }
           />
         </DataView>
+        <Suspense>
+          <Outlet
+            context={{
+              [pathnames['add-role'].path]: {
+                pagination,
+                filters: { display_name: filters.display_name },
+              },
+            }}
+          />
+        </Suspense>
       </PageSection>
     </React.Fragment>
   );

--- a/src/smart-components/role/add-role/schema.js
+++ b/src/smart-components/role/add-role/schema.js
@@ -27,6 +27,7 @@ export const schemaBuilder = (container, featureFlag) => {
         inModal: true,
         showTitles: true,
         crossroads: ['role-type'],
+        'data-ouia-component-id': 'add-role-wizard',
         title: intl.formatMessage(messages.createRole),
         style: { overflow: 'hidden' },
         container,


### PR DESCRIPTION
### Description
[RHCLOUD-32239](https://issues.redhat.com/browse/RHCLOUD-32239)

Adds the Add Role Wizard to the new Roles page. For MVP we are recycling the old wizard. 

---

### Screenshots

https://github.com/user-attachments/assets/1d073f58-db64-438c-8c44-b7eb631979fb



---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
