### PR TITLE
feat(workspaceDetails): should be hidden when platform.rbac.workspaces-list flag is on

### DIFF
--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -49,7 +49,7 @@ const UsersView = lazy(() => import('./smart-components/access-management/users-
 const UserGroupsView = lazy(() => import('./smart-components/access-management/users-and-user-groups/user-groups/UserGroupsView'));
 const EditUserGroup = lazy(() => import('./smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup'));
 
-const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel }: Record<string, boolean>) => [
+const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel, hideWorkspaceDetails }: Record<string, boolean>) => [
   {
     path: pathnames['users-and-user-groups'].path,
     element: UsersAndUserGroups,
@@ -98,7 +98,7 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
       },
     ],
   },
-  {
+  !hideWorkspaceDetails && {
     path: pathnames['workspace-detail'].path,
     element: WorkspaceDetail,
   },
@@ -318,6 +318,7 @@ const Routing = () => {
   const enableServiceAccounts =
     (isBeta() && useFlag('platform.rbac.group-service-accounts')) || (!isBeta() && useFlag('platform.rbac.group-service-accounts.stable'));
   const isWorkspacesFlag = useFlag('platform.rbac.workspaces');
+  const hideWorkspaceDetails = useFlag('platform.rbac.workspaces-list');
 
   useEffect(() => {
     const currPath = Object.values(pathnames).find(
@@ -335,7 +336,7 @@ const Routing = () => {
     }
   }, [location.pathname, updateDocumentTitle]);
 
-  const routes = getRoutes({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel });
+  const routes = getRoutes({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommonAuthModel, hideWorkspaceDetails });
   const renderedRoutes = useMemo(() => renderRoutes(routes as never), [routes]);
 
   const { getBundle, getApp } = useChrome();

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -34,6 +34,7 @@ import useAppNavigate from '../../hooks/useAppNavigate';
 import { EmptyState, EmptyStateHeader, EmptyStateIcon, EmptyStateBody, ButtonVariant } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { ActionsColumn } from '@patternfly/react-table';
+import { useFlag } from '@unleash/proxy-client-react';
 
 interface WorkspaceFilters {
   name: string;
@@ -102,6 +103,8 @@ const WorkspaceListTable = () => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [currentWorkspaces, setCurrentWorkspaces] = useState<Workspace[]>([]);
 
+  const hideWorkspaceDetails = useFlag('platform.rbac.workspaces-list');
+
   const handleModalToggle = (workspaces: Workspace[]) => {
     setCurrentWorkspaces(workspaces);
     setIsDeleteModalOpen(!isDeleteModalOpen);
@@ -110,7 +113,9 @@ const WorkspaceListTable = () => {
   const buildRows = (workspaces: Workspace[]): DataViewTrTree[] =>
     workspaces.map((workspace) => ({
       row: Object.values({
-        name: (
+        name: hideWorkspaceDetails ? (
+          workspace.name
+        ) : (
           <AppLink
             to={pathnames['workspace-detail'].link.replace(':workspaceId', workspace.id)}
             key={`${workspace.id}-detail`}


### PR DESCRIPTION
### Description
When the `platform.rbac.workspaces-list ` flag is on, the workspaces details page is hidden

[RHCLOUD-38982](https://issues.redhat.com/browse/RHCLOUD-38982)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Flag enabled:
![image](https://github.com/user-attachments/assets/eabfeb40-cf05-42fe-9402-f3284f91c346)


#### Flag disabled:
![image](https://github.com/user-attachments/assets/2c531e77-c0bc-4bb9-bfce-ae5e04f0bcd0)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
