### PR TITLE
feat(workspacewizard): expose workspace wizard through fec

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -20,7 +20,7 @@ module.exports = {
     exposes: {
       './MyUserAccess': path.resolve(__dirname, './src/entries/MyUserAccess.js'),
       './IamUserAccess': path.resolve(__dirname, './src/entries/IamUserAccess.js'),
-      './CreateWorkspaceWizard': path.resolve(__dirname, './src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx'),
+      './CreateWorkspaceWizardModule': path.resolve(__dirname, './src/smart-components/workspaces/create-workspace/CreateWorkspaceWizardModule.tsx'),
     },
     exclude: ['react-router-dom'],
     shared: [{ 'react-router-dom': { singleton: true, version: '^6.18.0', requiredVersion: '*' } }],

--- a/fec.config.js
+++ b/fec.config.js
@@ -20,6 +20,7 @@ module.exports = {
     exposes: {
       './MyUserAccess': path.resolve(__dirname, './src/entries/MyUserAccess.js'),
       './IamUserAccess': path.resolve(__dirname, './src/entries/IamUserAccess.js'),
+      './CreateWorkspaceWizard': path.resolve(__dirname, './src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx'),
     },
     exclude: ['react-router-dom'],
     shared: [{ 'react-router-dom': { singleton: true, version: '^6.18.0', requiredVersion: '*' } }],

--- a/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
+++ b/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
@@ -10,14 +10,8 @@ import { createWorkspace } from '../../../redux/actions/workspaces-actions';
 import SetEarMark from './SetEarMark';
 import Review from './Review';
 import SetDetails from './SetDetails';
-import { Provider } from 'react-redux';
-import registry, { RegistryContext } from '../../../utilities/store';
-import { IntlProvider } from 'react-intl';
-import messages from '../../../locales/data.json';
 
-export const locale = 'en';
-
-interface CreateWorkspaceWizardProps {
+export interface CreateWorkspaceWizardProps {
   afterSubmit: () => void;
   onCancel: () => void;
 }
@@ -58,20 +52,4 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
   );
 };
 
-const CreateWorkspaceWizardWrapper: React.FC<CreateWorkspaceWizardProps> = ({ ...props }) => {
-  return (
-    <IntlProvider locale={locale} messages={messages[locale]}>
-      <RegistryContext.Provider
-        value={{
-          getRegistry: () => registry,
-        }}
-      >
-        <Provider store={registry.getStore()}>
-          <CreateWorkspaceWizard {...props} />
-        </Provider>
-      </RegistryContext.Provider>
-    </IntlProvider>
-  );
-};
-
-export default CreateWorkspaceWizardWrapper;
+export default CreateWorkspaceWizard;

--- a/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
+++ b/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
@@ -10,8 +10,12 @@ import { createWorkspace } from '../../../redux/actions/workspaces-actions';
 import SetEarMark from './SetEarMark';
 import Review from './Review';
 import SetDetails from './SetDetails';
-import { Store } from 'redux';
 import { Provider } from 'react-redux';
+import registry, { RegistryContext } from '../../../utilities/store';
+import { IntlProvider } from 'react-intl';
+import messages from '../../../locales/data.json';
+
+export const locale = 'en';
 
 interface CreateWorkspaceWizardProps {
   afterSubmit: () => void;
@@ -54,13 +58,19 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
   );
 };
 
-const CreateWorkspaceWizardWrapper: React.FC<{ store?: Store } & CreateWorkspaceWizardProps> = ({ store, ...props }) => {
-  return store ? (
-    <Provider store={store}>
-      <CreateWorkspaceWizard {...props} />
-    </Provider>
-  ) : (
-    <CreateWorkspaceWizard {...props} />
+const CreateWorkspaceWizardWrapper: React.FC<CreateWorkspaceWizardProps> = ({ ...props }) => {
+  return (
+    <IntlProvider locale={locale} messages={messages[locale]}>
+      <RegistryContext.Provider
+        value={{
+          getRegistry: () => registry,
+        }}
+      >
+        <Provider store={registry.getStore()}>
+          <CreateWorkspaceWizard {...props} />
+        </Provider>
+      </RegistryContext.Provider>
+    </IntlProvider>
   );
 };
 

--- a/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
+++ b/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizard.tsx
@@ -10,6 +10,8 @@ import { createWorkspace } from '../../../redux/actions/workspaces-actions';
 import SetEarMark from './SetEarMark';
 import Review from './Review';
 import SetDetails from './SetDetails';
+import { Store } from 'redux';
+import { Provider } from 'react-redux';
 
 interface CreateWorkspaceWizardProps {
   afterSubmit: () => void;
@@ -52,4 +54,14 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
   );
 };
 
-export default CreateWorkspaceWizard;
+const CreateWorkspaceWizardWrapper: React.FC<{ store?: Store } & CreateWorkspaceWizardProps> = ({ store, ...props }) => {
+  return store ? (
+    <Provider store={store}>
+      <CreateWorkspaceWizard {...props} />
+    </Provider>
+  ) : (
+    <CreateWorkspaceWizard {...props} />
+  );
+};
+
+export default CreateWorkspaceWizardWrapper;

--- a/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizardModule.tsx
+++ b/src/smart-components/workspaces/create-workspace/CreateWorkspaceWizardModule.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import registry, { RegistryContext } from '../../../utilities/store';
+import { IntlProvider } from 'react-intl';
+import messages from '../../../locales/data.json';
+import CreateWorkspaceWizard, { CreateWorkspaceWizardProps } from './CreateWorkspaceWizard';
+
+export const locale = 'en';
+
+const CreateWorkspaceWizardModule: React.FunctionComponent<CreateWorkspaceWizardProps> = ({ ...props }) => {
+  return (
+    <IntlProvider locale={locale} messages={messages[locale]}>
+      <RegistryContext.Provider
+        value={{
+          getRegistry: () => registry,
+        }}
+      >
+        <Provider store={registry.getStore()}>
+          <CreateWorkspaceWizard {...props} />
+        </Provider>
+      </RegistryContext.Provider>
+    </IntlProvider>
+  );
+};
+
+export default CreateWorkspaceWizardModule;


### PR DESCRIPTION
### Description
part of [RHCLOUD-34248](https://issues.redhat.com/browse/RHCLOUD-34248)

I need to expose the Workspaces Wizard so that I can use it in the widget-layout repo

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
