### PR TITLE
Add workspaces to user-access bundle

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -90,7 +90,6 @@ objects:
                   href: /iam/user-access/users
                   icon: PlaceholderIcon
                   product: Identity & Access Management
-
                 - id: roles
                   title: Roles
                   href: /iam/user-access/roles
@@ -99,6 +98,16 @@ objects:
                   title: Groups
                   href: /iam/user-access/groups
                   icon: PlaceholderIcon
+                  product: Identity & Access Management
+                - id: workspaces
+                  title: Workspaces
+                  href: /iam/user-access/workspaces
+                  icon: PlaceholderIcon
+                  permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces-list
+                        - true
                   product: Identity & Access Management
                 - segmentRef:
                     frontendName: access-requests


### PR DESCRIPTION
For [RHCLOUD-38980](https://issues.redhat.com/browse/RHCLOUD-38980). Follow up to https://github.com/RedHatInsights/chrome-service-backend/pull/838

## Summary by Sourcery

New Features:
- Introduce a new 'Workspaces' navigation item in the Identity & Access Management section with a feature flag-controlled permission