### PR TITLE
feat: delete workspace disable when non empty

### DIFF
--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -4,8 +4,6 @@ import { Outlet, useSearchParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { fetchWorkspaces } from '../../redux/actions/workspaces-actions';
 import {
-  BulkSelect,
-  BulkSelectValue,
   ErrorState,
   ResponsiveAction,
   ResponsiveActions,
@@ -23,7 +21,6 @@ import {
   DataViewToolbar,
   DataViewTrTree,
   useDataViewSelection,
-  DataViewTrObject,
 } from '@patternfly/react-data-view';
 import { Workspace } from '../../redux/reducers/workspaces-reducer';
 import { RBACStore } from '../../redux/store';
@@ -128,6 +125,7 @@ const WorkspaceListTable = () => {
         rowActions: {
           cell: (
             <ActionsColumn
+              isDisabled={workspace.children && workspace.children.length > 0}
               items={[
                 {
                   title: 'Delete workspace',
@@ -180,10 +178,6 @@ const WorkspaceListTable = () => {
     dispatch(fetchWorkspaces());
   }, [dispatch]);
 
-  const handleBulkSelect = (value: BulkSelectValue) => {
-    selection.onSelect(value === BulkSelectValue.all, value === BulkSelectValue.all ? workspaces : []);
-  };
-
   const hasAssets = useMemo(() => {
     return selection.selected.filter((ws) => ws.children && ws.children?.length > 0).length > 0 ? true : false;
   }, [selection.selected, workspaces]);
@@ -235,15 +229,6 @@ const WorkspaceListTable = () => {
       )}
       <DataView selection={selection} activeState={activeState}>
         <DataViewToolbar
-          bulkSelect={
-            <BulkSelect
-              canSelectAll
-              isDataPaginated={false}
-              totalCount={workspaces.length}
-              selectedCount={selection.selected.length}
-              onSelect={handleBulkSelect}
-            />
-          }
           clearAllFilters={clearAllFilters}
           filters={
             <DataViewTextFilter
@@ -261,17 +246,6 @@ const WorkspaceListTable = () => {
             <ResponsiveActions>
               <ResponsiveAction ouiaId="create-workspace-button" isPinned onClick={() => navigate({ pathname: pathnames['create-workspace'].link })}>
                 {intl.formatMessage(messages.createWorkspace)}
-              </ResponsiveAction>
-              <ResponsiveAction
-                ouiaId="delete-workspace-button"
-                isDisabled={selection.selected.length === 0}
-                onClick={() => {
-                  handleModalToggle(
-                    workspaces.filter((workspace) => selection.selected.some((selectedRow: DataViewTrObject) => selectedRow.id === workspace.id))
-                  );
-                }}
-              >
-                {intl.formatMessage(messages.workspacesActionDeleteWorkspace)}
               </ResponsiveAction>
             </ResponsiveActions>
           }


### PR DESCRIPTION
### Description
Delete a Workspace - disable when non empty

[RHCLOUD-35615](https://issues.redhat.com/browse/RHCLOUD-35615)

---

### Screenshots

<img width="1726" alt="Snímek obrazovky 2025-04-23 v 15 23 20" src="https://github.com/user-attachments/assets/2494c5b8-7723-4f22-9f24-66e5f5e7a376" />

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Modify workspace deletion behavior to prevent deleting non-empty workspaces

New Features:
- Disable delete action for workspaces that contain child elements

Enhancements:
- Remove bulk delete functionality for workspaces