### PR TITLE
Revert "Revert "Edit role page""

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1581,6 +1581,11 @@ export default defineMessages({
     description: 'Message warning that only roles in given role has been filtered',
     defaultMessage: 'This role list has been filtered to only show roles that are not currently in your group.',
   },
+  editCustomRole: {
+    id: 'editCustomRole',
+    description: 'Edit custom role label',
+    defaultMessage: 'Edit custom role',
+  },
   defaultAccessGroupEditWarning: {
     id: 'defaultAccessGroupEditWarning',
     description: 'Message warning that editing a Default access group will rename it',
@@ -2701,5 +2706,25 @@ export default defineMessages({
     id: 'assetManagementOpenShiftNav',
     description: 'take me to Red Hat OpenShift',
     defaultMessage: 'Take me to Red Hat OpenShift',
+  },
+  searchByApplicationPlaceholder: {
+    id: 'searchByApplicationPlaceholder',
+    description: 'search by application placeholder',
+    defaultMessage: 'Search by application',
+  },
+  searchByResourceTypePlaceholder: {
+    id: 'searchByResourceTypePlaceholder',
+    description: 'search by resource type placeholder',
+    defaultMessage: 'Search by resource type',
+  },
+  searchByOperationPlaceholder: {
+    id: 'searchByOperationPlaceholder',
+    description: 'search by operation placeholder',
+    defaultMessage: 'Search by operation',
+  },
+  saveChanges: {
+    id: 'saveChanges',
+    description: 'save changes button label',
+    defaultMessage: 'Save changes',
   },
 });

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -30,6 +30,7 @@ const AddRolePermissionWizard = lazy(() => import('./smart-components/role/add-r
 const ResourceDefinitions = lazy(() => import('./smart-components/role/role-resource-definitions'));
 const EditResourceDefinitionsModal = lazy(() => import('./smart-components/role/edit-resource-definitions-modal'));
 const newRolesTable = lazy(() => import('./smart-components/role/RolesTable'));
+const newEditRole = lazy(() => import('./smart-components/role/edit-role/edit-role'));
 
 const Groups = lazy(() => import('./smart-components/group/groups'));
 const Group = lazy(() => import('./smart-components/group/group'));
@@ -176,6 +177,10 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
               element: AddRoleWizard,
             },
           ],
+        },
+        {
+          path: pathnames['edit-role'].path,
+          element: newEditRole,
         },
       ]
     : [

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -179,7 +179,7 @@ const getRoutes = ({ enableServiceAccounts, isITLess, isWorkspacesFlag, isCommon
           ],
         },
         {
-          path: pathnames['edit-role'].path,
+          path: `${pathnames.roles.link}/${pathnames['edit-role'].path}`,
           element: newEditRole,
         },
       ]

--- a/src/hooks/useAppNavigate.js
+++ b/src/hooks/useAppNavigate.js
@@ -1,11 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { mergeToBasename } from '../presentational-components/shared/AppLink';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const useAppNavigate = (linkBasename) => {
   const navigate = useNavigate();
+  const isWorkspacesFlag = useFlag('platform.rbac.workspaces');
 
   return (to, options) => {
-    return navigate(mergeToBasename(to, linkBasename), options);
+    return navigate(mergeToBasename(to, linkBasename || isWorkspacesFlag ? '/iam/access-management' : undefined), options);
   };
 };
 

--- a/src/hooks/useAppNavigate.js
+++ b/src/hooks/useAppNavigate.js
@@ -7,7 +7,7 @@ const useAppNavigate = (linkBasename) => {
   const isWorkspacesFlag = useFlag('platform.rbac.workspaces');
 
   return (to, options) => {
-    return navigate(mergeToBasename(to, linkBasename || isWorkspacesFlag ? '/iam/access-management' : undefined), options);
+    return navigate(mergeToBasename(to, linkBasename || (isWorkspacesFlag ? '/iam/access-management' : undefined)), options);
   };
 };
 

--- a/src/redux/actions/role-actions.js
+++ b/src/redux/actions/role-actions.js
@@ -102,6 +102,12 @@ export const updateRole = (roleId, data, useCustomAccess) => {
     payload: RoleHelper.updateRole(roleId, data, useCustomAccess),
     meta: {
       notifications: {
+        fulfilled: {
+          variant: 'success',
+          title: intl.formatMessage(messages.editRoleSuccessTitle),
+          dismissDelay: 8000,
+          description: intl.formatMessage(messages.editRoleSuccessDescription),
+        },
         rejected: (payload) => ({
           variant: 'danger',
           title: intl.formatMessage(messages.editRoleErrorTitle),

--- a/src/redux/store.d.ts
+++ b/src/redux/store.d.ts
@@ -8,6 +8,7 @@ export type RBACStore = {
   groupReducer: GroupStore;
   roleReducer: RoleStore;
   workspacesReducer: WorkspacesStore;
+  permissionReducer: any;
 };
 
 declare module 'react-redux' {

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -9,11 +9,12 @@ import { FormTemplate } from '@data-driven-forms/pf4-component-mapper';
 import { useDispatch, useSelector } from 'react-redux';
 import { addGroup, fetchGroup, fetchGroups, updateGroup } from '../../../../../redux/actions/group-actions';
 import { RBACStore } from '../../../../../redux/store';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { EditGroupUsersAndServiceAccounts } from './EditUserGroupUsersAndServiceAccounts';
 import RbacBreadcrumbs from '../../../../../presentational-components/shared/breadcrumbs';
 import { mergeToBasename } from '../../../../../presentational-components/shared/AppLink';
 import pathnames from '../../../../../utilities/pathnames';
+import useAppNavigate from '../../../../../hooks/useAppNavigate';
 
 interface EditUserGroupProps {
   createNewGroup?: boolean;
@@ -24,7 +25,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   const dispatch = useDispatch();
   const params = useParams();
   const groupId = params.groupId;
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
 
   const pageTitle = createNewGroup
     ? intl.formatMessage(Messages.usersAndUserGroupsCreateUserGroup)
@@ -132,7 +133,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   );
 
   const returnToPreviousPage = () => {
-    navigate(-1);
+    navigate(pathnames['user-groups'].link);
   };
 
   const handleSubmit = async (values: Record<string, any>) => {

--- a/src/smart-components/role/RolesTable.tsx
+++ b/src/smart-components/role/RolesTable.tsx
@@ -27,7 +27,7 @@ import messages from '../../Messages';
 import { debouncedFetch, mappedProps } from '../../helpers/shared/helpers';
 import { Role } from '../../redux/reducers/role-reducer';
 import { RBACStore } from '../../redux/store';
-import { Outlet, useNavigate, useSearchParams } from 'react-router-dom';
+import { Outlet, useSearchParams } from 'react-router-dom';
 import paths from '../../utilities/pathnames';
 import RolesDetails from './RolesTableDetails';
 import {
@@ -41,8 +41,8 @@ import {
 import { DataViewTextFilter, DataViewTh, DataViewTr, DataViewTrObject, useDataViewFilters } from '@patternfly/react-data-view';
 import { PER_PAGE_OPTIONS } from '../../helpers/shared/pagination';
 import { SearchIcon } from '@patternfly/react-icons';
-import { mergeToBasename } from '../../presentational-components/shared/AppLink';
 import pathnames from '../../utilities/pathnames';
+import useAppNavigate from '../../hooks/useAppNavigate';
 
 const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
   return (
@@ -106,13 +106,13 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
     setSearchParams,
   });
 
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
 
   const handleEditRole = useCallback((role: Role) => {
     if (!role) {
       return;
     }
-    navigate(mergeToBasename(paths['edit-role'].link.replace(':roleId', role.uuid)));
+    navigate(paths['edit-role'].path.replace(':roleId', role.uuid));
   }, []);
 
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
@@ -282,7 +282,7 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
             }
             actions={
               <ResponsiveActions breakpoint="lg" ouiaId={`${ouiaId}-actions-dropdown`}>
-                <ResponsiveAction ouiaId="add-role-button" onClick={() => navigate(mergeToBasename(paths['add-role'].link))} isPinned>
+                <ResponsiveAction ouiaId="add-role-button" onClick={() => navigate(paths['add-role'].path)} isPinned>
                   {intl.formatMessage(messages.createRole)}
                 </ResponsiveAction>
                 <ResponsiveAction

--- a/src/smart-components/role/RolesTable.tsx
+++ b/src/smart-components/role/RolesTable.tsx
@@ -108,6 +108,13 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
 
   const navigate = useNavigate();
 
+  const handleEditRole = useCallback((role: Role) => {
+    if (!role) {
+      return;
+    }
+    navigate(mergeToBasename(paths['edit-role'].link.replace(':roleId', role.uuid)));
+  }, []);
+
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
   const sortByIndex = useMemo(() => COLUMNHEADERS.findIndex((item) => (item.isSortable ? item.key === sortBy : '')), [sortBy]);
 
@@ -191,7 +198,7 @@ const RolesTable: React.FunctionComponent<RolesTableProps> = ({ selectedRole }) 
           cell: (
             <ActionsColumn
               items={[
-                { title: 'Edit role', onClick: () => console.log('Editing role') },
+                { title: 'Edit role', onClick: () => handleEditRole(role) },
                 {
                   title: 'Delete role',
                   isDisabled: role.system,

--- a/src/smart-components/role/edit-role/edit-role-permissions.tsx
+++ b/src/smart-components/role/edit-role/edit-role-permissions.tsx
@@ -1,0 +1,235 @@
+import { UseFieldApiConfig, useFieldApi, useFormApi } from '@data-driven-forms/react-form-renderer';
+import { EmptyState, EmptyStateHeader, EmptyStateIcon, FormGroup, Pagination } from '@patternfly/react-core';
+import {
+  DataView,
+  DataViewTable,
+  DataViewToolbar,
+  DataViewTh,
+  DataViewState,
+  DataViewTextFilter,
+  useDataViewFilters,
+  useDataViewPagination,
+  useDataViewSelection,
+} from '@patternfly/react-data-view';
+import { SearchIcon } from '@patternfly/react-icons';
+import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
+import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import { RBACStore } from '../../../redux/store';
+import { useSearchParams } from 'react-router-dom';
+import messages from '../../../Messages';
+import { PER_PAGE_OPTIONS } from '../../../helpers/shared/pagination';
+import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
+import { listPermissions } from '../../../redux/actions/permission-action';
+
+interface PermissionsFilters {
+  application: string;
+  resourceType: string;
+  operation: string;
+}
+
+interface ExtendedUseFieldApiConfig extends UseFieldApiConfig {
+  roleId?: string;
+}
+
+const EmptyTable: React.FC<{ titleText: string }> = ({ titleText }) => (
+  <EmptyState>
+    <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<EmptyStateIcon icon={SearchIcon} />} />
+  </EmptyState>
+);
+
+export const EditRolePermissions: React.FC<ExtendedUseFieldApiConfig> = (props) => {
+  const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const intl = useIntl();
+  const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
+  const formOptions = useFormApi();
+  const { input } = useFieldApi({ ...props, formOptions });
+
+  const columns = [
+    {
+      label: intl.formatMessage(messages.application),
+      key: 'application',
+    },
+    {
+      label: intl.formatMessage(messages.resourceType),
+      key: 'resourceType',
+    },
+    { label: intl.formatMessage(messages.operation), key: 'operation' },
+  ];
+
+  const sortableColumns: DataViewTh[] = columns.map((column) => ({
+    cell: column.label,
+  }));
+
+  const { filters, onSetFilters, clearAllFilters } = useDataViewFilters<PermissionsFilters>({
+    initialFilters: {
+      application: searchParams.get('application') || '',
+      resourceType: searchParams.get('resourceType') || '',
+      operation: searchParams.get('operation') || '',
+    },
+    searchParams,
+    setSearchParams,
+  });
+
+  const pagination = useDataViewPagination({
+    perPage: 10,
+    searchParams,
+    setSearchParams,
+  });
+  const { page, perPage, onSetPage, onPerPageSelect } = pagination;
+
+  const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
+  const { selected, onSelect, isSelected } = selection;
+
+  const { permissions, totalCount, isLoading } = useSelector((state: RBACStore) => ({
+    permissions: state?.permissionReducer?.permission?.data,
+    totalCount: state?.permissionReducer?.permission?.meta?.count || 0,
+    isLoading: state.permissionReducer?.isLoading,
+  }));
+
+  const loadingHeader = <SkeletonTableHead columns={columns.map((col) => col.label)} />;
+  const loadingBody = <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />;
+
+  const fetchData = useCallback(
+    (apiProps: { count: number; limit: number; offset: number; filters?: PermissionsFilters }) => {
+      const { limit, offset, filters } = apiProps;
+      dispatch(
+        // @ts-expect-error not all args are used
+        listPermissions({
+          limit,
+          offset,
+          application: filters?.application || '',
+          resourceType: filters?.resourceType || '',
+          verb: filters?.operation || '',
+          allowed_only: false,
+        })
+      );
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    fetchData({
+      limit: perPage,
+      offset: (page - 1) * perPage,
+      count: totalCount || 0,
+      filters,
+    });
+  }, [fetchData, page, perPage, filters, totalCount]);
+
+  useEffect(() => {
+    input.onChange(selected.map((permission) => permission.id));
+  }, [selected]);
+
+  useEffect(() => {
+    if (isLoading) {
+      setActiveState(DataViewState.loading);
+    } else {
+      setActiveState(totalCount === 0 ? DataViewState.empty : undefined);
+    }
+  }, [totalCount, isLoading]);
+
+  const handleBulkSelect = (value: BulkSelectValue) => {
+    if (value === BulkSelectValue.none) {
+      onSelect(false);
+    } else if (value === BulkSelectValue.page) {
+      onSelect(true, rows);
+    } else if (value === BulkSelectValue.nonePage) {
+      onSelect(false, rows);
+    }
+  };
+
+  useEffect(() => {
+    onSelect(false);
+    if (props.initialValue) {
+      onSelect(
+        true,
+        props.initialValue.map((permission: string) => ({ id: permission }))
+      );
+    }
+  }, [props.initialValue]);
+
+  const rows = useMemo(() => {
+    return permissions.map((permission: any) => ({
+      id: permission.permission,
+      row: [permission.application, permission.resource_type, permission.verb],
+    }));
+  }, [permissions]);
+
+  const pageSelected = rows.length > 0 && rows.every(isSelected);
+  const pagePartiallySelected = !pageSelected && rows.some(isSelected);
+
+  const paginationComponent = (
+    <Pagination
+      perPageOptions={PER_PAGE_OPTIONS}
+      itemCount={totalCount}
+      page={page}
+      perPage={perPage}
+      onSetPage={onSetPage}
+      onPerPageSelect={onPerPageSelect}
+    />
+  );
+
+  return (
+    <React.Fragment>
+      <FormGroup label="Select permissions" fieldId="role-permissions">
+        <DataView ouiaId="edit-role-permissions" selection={selection} activeState={activeState}>
+          <DataViewToolbar
+            ouiaId="edit-role-permissions-toolbar"
+            bulkSelect={
+              <BulkSelect
+                isDataPaginated
+                pageCount={rows.length}
+                selectedCount={selected.length}
+                totalCount={totalCount}
+                pageSelected={pageSelected}
+                pagePartiallySelected={pagePartiallySelected}
+                onSelect={handleBulkSelect}
+              />
+            }
+            pagination={React.cloneElement(paginationComponent, { isCompact: true })}
+            filters={
+              <DataViewFilters ouiaId="edit-role-permissions-filters" onChange={(_e, values) => onSetFilters(values)} values={filters}>
+                <DataViewTextFilter
+                  filterId="application"
+                  title={intl.formatMessage(messages.application)}
+                  placeholder={intl.formatMessage(messages.searchByApplicationPlaceholder)}
+                  ouiaId="application-filter"
+                />
+                <DataViewTextFilter
+                  filterId="resourceType"
+                  title={intl.formatMessage(messages.resourceType || { id: 'resourceType', defaultMessage: 'Resource Type' })}
+                  placeholder={intl.formatMessage(messages.searchByResourceTypePlaceholder)}
+                  ouiaId="resource-type-filter"
+                />
+                <DataViewTextFilter
+                  filterId="operation"
+                  title={intl.formatMessage(messages.operation)}
+                  placeholder={intl.formatMessage(messages.searchByOperationPlaceholder)}
+                  ouiaId="operation-filter"
+                />
+              </DataViewFilters>
+            }
+            clearAllFilters={clearAllFilters}
+          />
+          <DataViewTable
+            variant="compact"
+            aria-label="Permissions Table"
+            ouiaId="permissions-table"
+            columns={sortableColumns}
+            rows={rows}
+            headStates={{ loading: loadingHeader }}
+            bodyStates={{
+              loading: loadingBody,
+              empty: <EmptyTable titleText={intl.formatMessage(messages.noPermissions)} />,
+            }}
+          />
+          <DataViewToolbar ouiaId="edit-role-permissions-footer-toolbar" pagination={paginationComponent} />
+        </DataView>
+      </FormGroup>
+    </React.Fragment>
+  );
+};

--- a/src/smart-components/role/edit-role/edit-role.tsx
+++ b/src/smart-components/role/edit-role/edit-role.tsx
@@ -1,0 +1,160 @@
+import ContentHeader from '@patternfly/react-component-groups/dist/esm/ContentHeader';
+import { PageSection, PageSectionVariants, Spinner } from '@patternfly/react-core';
+import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { useIntl } from 'react-intl';
+import Messages from '../../../Messages';
+import RbacBreadcrumbs from '../../../presentational-components/shared/breadcrumbs';
+import { mergeToBasename } from '../../../presentational-components/shared/AppLink';
+import pathnames from '../../../utilities/pathnames';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { fetchRole, updateRole } from '../../../redux/actions/role-actions';
+import { RBACStore } from '../../../redux/store';
+import { FormRenderer, componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+import { FormTemplate } from '@data-driven-forms/pf4-component-mapper';
+import { EditRolePermissions } from './edit-role-permissions';
+
+export const EditRole: FunctionComponent = () => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const { roleId } = useParams();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const pageTitle = intl.formatMessage(Messages.editCustomRole);
+  const [initialFormData, setInitialFormData] = useState<any>(null);
+  const { selectedRole } = useSelector((state: RBACStore) => state.roleReducer);
+
+  const breadcrumbsList = useMemo(
+    () => [
+      {
+        title: intl.formatMessage(Messages.roles),
+        to: mergeToBasename(pathnames['roles'].link),
+      },
+      {
+        title: pageTitle,
+        isActive: true,
+      },
+    ],
+    [intl, pageTitle]
+  );
+
+  const navigateToRoles = () => {
+    dispatch(fetchRole(roleId));
+    navigate(mergeToBasename(pathnames['roles'].link), { replace: true });
+  };
+
+  const handleSubmit = async (values: any) => {
+    const initialPermissions = initialFormData?.access.map((access: any) => access.permission);
+    if (
+      values.name !== initialFormData?.name ||
+      values.description !== initialFormData?.description ||
+      values['role-permissions'] !== initialPermissions
+    ) {
+      await Promise.all([
+        dispatch(
+          updateRole(roleId, {
+            name: values.name,
+            display_name: values.name,
+            description: values.description || null,
+            access: values['role-permissions'].map((permission: string) => ({
+              permission,
+              resourceDefinitions: [],
+            })),
+          })
+        ),
+      ]);
+      await Promise.all([roleId ? dispatch(fetchRole(roleId)) : Promise.resolve()]);
+      navigateToRoles();
+    } else {
+      navigateToRoles();
+    }
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await Promise.all([roleId ? dispatch(fetchRole(roleId)) : Promise.resolve()]);
+      } finally {
+        if (selectedRole) {
+          setInitialFormData(selectedRole);
+          setIsLoading(false);
+        }
+      }
+    };
+    if (roleId && isLoading) {
+      fetchData();
+    }
+  }, [dispatch, roleId, selectedRole?.uuid]);
+
+  const schema = useMemo(
+    () => ({
+      fields: [
+        {
+          name: 'name',
+          label: intl.formatMessage(Messages.name),
+          component: componentTypes.TEXT_FIELD,
+          validate: [
+            { type: validatorTypes.REQUIRED },
+            (value: string) => {
+              if (value === initialFormData?.name) {
+                return undefined;
+              }
+            },
+          ],
+          initialValue: initialFormData?.name,
+          isRequired: true,
+        },
+        {
+          name: 'description',
+          label: intl.formatMessage(Messages.description),
+          component: componentTypes.TEXTAREA,
+          initialValue: initialFormData?.description,
+        },
+        {
+          name: 'role-permissions',
+          component: 'role-permissions',
+          roleId: roleId,
+          initialValue: initialFormData?.access.map((access: any) => access.permission),
+        },
+      ],
+    }),
+    [initialFormData, roleId, intl]
+  );
+
+  return (
+    <React.Fragment>
+      <section className="pf-v5-c-page__main-breadcrumb">
+        <RbacBreadcrumbs {...breadcrumbsList} />
+      </section>
+      <ContentHeader title={pageTitle} />
+      <PageSection data-ouia-component-id="edit-role-form" className="pf-v5-u-m-lg-on-lg" variant={PageSectionVariants.light} isWidthLimited>
+        {isLoading || !initialFormData ? (
+          <div style={{ textAlign: 'center' }}>
+            <Spinner />
+          </div>
+        ) : (
+          <FormRenderer
+            schema={schema}
+            componentMapper={{
+              ...componentMapper,
+              'role-permissions': EditRolePermissions,
+            }}
+            onSubmit={handleSubmit}
+            onCancel={navigateToRoles}
+            FormTemplate={FormTemplate}
+            FormTemplateProps={{
+              disableSubmit: ['pristine', 'invalid'],
+              submitLabel: intl.formatMessage(Messages.saveChanges),
+            }}
+            debug={(values) => {
+              console.log('values:', values);
+            }}
+          />
+        )}
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default EditRole;

--- a/src/smart-components/role/edit-role/edit-role.tsx
+++ b/src/smart-components/role/edit-role/edit-role.tsx
@@ -3,45 +3,30 @@ import { PageSection, PageSectionVariants, Spinner } from '@patternfly/react-cor
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import Messages from '../../../Messages';
-import RbacBreadcrumbs from '../../../presentational-components/shared/breadcrumbs';
-import { mergeToBasename } from '../../../presentational-components/shared/AppLink';
 import pathnames from '../../../utilities/pathnames';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { fetchRole, updateRole } from '../../../redux/actions/role-actions';
 import { RBACStore } from '../../../redux/store';
 import { FormRenderer, componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
 import { FormTemplate } from '@data-driven-forms/pf4-component-mapper';
 import { EditRolePermissions } from './edit-role-permissions';
+import useAppNavigate from '../../../hooks/useAppNavigate';
 
 export const EditRole: FunctionComponent = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const { roleId } = useParams();
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
   const [isLoading, setIsLoading] = useState(true);
-  const pageTitle = intl.formatMessage(Messages.editCustomRole);
+  const pageTitle = intl.formatMessage(Messages.edit);
   const [initialFormData, setInitialFormData] = useState<any>(null);
   const { selectedRole } = useSelector((state: RBACStore) => state.roleReducer);
 
-  const breadcrumbsList = useMemo(
-    () => [
-      {
-        title: intl.formatMessage(Messages.roles),
-        to: mergeToBasename(pathnames['roles'].link),
-      },
-      {
-        title: pageTitle,
-        isActive: true,
-      },
-    ],
-    [intl, pageTitle]
-  );
-
   const navigateToRoles = () => {
     dispatch(fetchRole(roleId));
-    navigate(mergeToBasename(pathnames['roles'].link), { replace: true });
+    navigate(pathnames['roles'].link, { replace: true });
   };
 
   const handleSubmit = async (values: any) => {
@@ -124,10 +109,7 @@ export const EditRole: FunctionComponent = () => {
 
   return (
     <React.Fragment>
-      <section className="pf-v5-c-page__main-breadcrumb">
-        <RbacBreadcrumbs {...breadcrumbsList} />
-      </section>
-      <ContentHeader title={pageTitle} />
+      <ContentHeader title={`${pageTitle} ${selectedRole?.display_name || ''}`} />
       <PageSection data-ouia-component-id="edit-role-form" className="pf-v5-u-m-lg-on-lg" variant={PageSectionVariants.light} isWidthLimited>
         {isLoading || !initialFormData ? (
           <div style={{ textAlign: 'center' }}>

--- a/src/smart-components/workspaces/WorkspaceActions.tsx
+++ b/src/smart-components/workspaces/WorkspaceActions.tsx
@@ -16,10 +16,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import messages from '../../Messages';
 import { WarningModal } from '@patternfly/react-component-groups';
 import { Workspace } from '../../redux/reducers/workspaces-reducer';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import pathnames from '../../utilities/pathnames';
 import paths from '../../utilities/pathnames';
 import { mergeToBasename } from '../../presentational-components/shared/AppLink';
+import useAppNavigate from '../../hooks/useAppNavigate';
 
 enum ActionType {
   EDIT_WORKSPACE = 'EDIT_WORKSPACE',
@@ -48,7 +49,7 @@ const WorkspaceActions: React.FC<WorkspaceActionsProps> = ({ isDisabled = false,
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const intl = useIntl();
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
 
   const toggle = (
     <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen} isDisabled={isDisabled} variant="default">
@@ -83,7 +84,7 @@ const WorkspaceActions: React.FC<WorkspaceActionsProps> = ({ isDisabled = false,
       setIsDeleteModalOpen(true);
     }
     if (action === ActionType.EDIT_WORKSPACE) {
-      navigate(mergeToBasename(paths['edit-workspace'].link.replace(':workspaceId', currentWorkspace.id)));
+      navigate(paths['edit-workspace'].link.replace(':workspaceId', currentWorkspace.id));
     }
   };
 

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -145,7 +145,7 @@ const pathnames = {
   },
   'edit-role': {
     link: '/roles/edit/:roleId',
-    path: 'edit/:roleId',
+    path: '/roles/edit/:roleId',
     title: 'Edit role',
   },
   'role-detail': {

--- a/src/utilities/pathnames.js
+++ b/src/utilities/pathnames.js
@@ -145,7 +145,7 @@ const pathnames = {
   },
   'edit-role': {
     link: '/roles/edit/:roleId',
-    path: '/roles/edit/:roleId',
+    path: 'edit/:roleId',
     title: 'Edit role',
   },
   'role-detail': {


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac-ui#1812

## Summary by Sourcery

Re-introduce the ability to edit custom RBAC roles.

New Features:
- Add an "Edit custom role" page allowing users to modify a role's name, description, and permissions.
- Include an interactive table on the edit page to view, filter, and select permissions.

Enhancements:
- Implement a custom `useAppNavigate` hook for application-wide navigation consistency.
- Show a success notification upon successful role updates.

Chores:
- Add necessary UI text labels for the new edit role interface.
- Update routing to include the edit role page.
- Include the permission reducer in the Redux store type definition.