### PR TITLE
fix(permissions): view WS list for users with groups read

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -115,7 +115,9 @@ objects:
                       args:
                         - platform.rbac.workspaces-list
                         - true
-                    - method: isOrgAdmin
+                    - method: loosePermissions
+                      args:
+                        - - 'inventory:groups:read'
                   product: Identity & Access Management
                 - segmentRef:
                     frontendName: access-requests


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update permission check to use loose permissions instead of org admin check