### PR TITLE
Revert "chore(deps): bump http-proxy-middleware from 2.0.6 to 2.0.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13660,9 +13660,7 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Reverts RedHatInsights/insights-rbac-ui#1814

## Summary by Sourcery

Chores:
- Restore http-proxy-middleware version to 2.0.6 by reverting the previous bump