### PR TITLE
feat(workspacewizard): disable ws parent select

### DIFF
--- a/src/smart-components/workspaces/create-workspace/SetDetails.tsx
+++ b/src/smart-components/workspaces/create-workspace/SetDetails.tsx
@@ -45,9 +45,12 @@ const SetDetails = () => {
       );
   }, [workspaces.length]);
 
+  const defaultWorkspace = workspaces.find((workspace) => workspace.name === 'Default Workspace');
+  formOptions.change(WORKSPACE_PARENT, defaultWorkspace);
+
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle isFullWidth style={{ maxWidth: '100%' }} ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
-      {values[WORKSPACE_PARENT]?.name}
+    <MenuToggle isFullWidth style={{ maxWidth: '100%' }} isDisabled ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
+      {defaultWorkspace?.name}
     </MenuToggle>
   );
 
@@ -77,13 +80,9 @@ const SetDetails = () => {
             <Select
               ouiaId="SetDetails-parent-select"
               isOpen={isOpen}
-              selected={values[WORKSPACE_PARENT]?.id}
+              selected={defaultWorkspace?.id}
               onSelect={(_e, value) => {
-                value &&
-                  formOptions.change(
-                    WORKSPACE_PARENT,
-                    workspaces.find((item) => item.id === value)
-                  );
+                value && formOptions.change(WORKSPACE_PARENT, defaultWorkspace);
                 setIsOpen(false);
               }}
               onOpenChange={(isOpen) => setIsOpen(isOpen)}
@@ -91,11 +90,9 @@ const SetDetails = () => {
               shouldFocusToggleOnSelect
             >
               <SelectList>
-                {workspaces.map((item, idx) => (
-                  <SelectOption key={`${item.name}-${idx}`} value={item.id}>
-                    {item.name}
-                  </SelectOption>
-                ))}
+                <SelectOption key={`${defaultWorkspace?.name}-${defaultWorkspace?.id}`} isSelected value={defaultWorkspace?.id}>
+                  {defaultWorkspace?.name}
+                </SelectOption>
               </SelectList>
             </Select>
           )}

--- a/src/smart-components/workspaces/create-workspace/SetDetails.tsx
+++ b/src/smart-components/workspaces/create-workspace/SetDetails.tsx
@@ -45,8 +45,13 @@ const SetDetails = () => {
       );
   }, [workspaces.length]);
 
-  const defaultWorkspace = workspaces.find((workspace) => workspace.name === 'Default Workspace');
-  formOptions.change(WORKSPACE_PARENT, defaultWorkspace);
+  const defaultWorkspace = workspaces.find((workspace) => workspace.type === 'default');
+
+  useEffect(() => {
+    if (defaultWorkspace) {
+      formOptions.change(WORKSPACE_PARENT, defaultWorkspace);
+    }
+  }, [defaultWorkspace, formOptions.change]);
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle isFullWidth style={{ maxWidth: '100%' }} isDisabled ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>


### PR DESCRIPTION
### Description
This disables parent select for all new Workspaces created and preselects Default Workspace. 

[RHCLOUD-39753](https://issues.redhat.com/browse/RHCLOUD-39753)

---

### Screenshots

![image](https://github.com/user-attachments/assets/380d65d0-5dd8-413c-af15-a5929e799ecc)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Disable the workspace parent selection in the Create Workspace wizard and automatically assign the Default Workspace as the parent for all new workspaces.

Enhancements:
- Always preselect the Default Workspace as parent in the workspace creation wizard
- Disable the parent workspace dropdown to prevent changing the selection