### PR TITLE
Add workspaces to iam section of services dropdown

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -38,6 +38,13 @@ objects:
           icon: PlaceholderIcon
         - section: iam
           group: iam
+          id: workspaces
+          href: /iam/user-access/workspaces
+          title: Workspaces
+          description: ""
+          icon: PlaceholderIcon
+        - section: iam
+          group: iam
           id: authFactors
           href: /iam/authentication-policy/authentication-factors
           title: Authentication Factors


### PR DESCRIPTION
For [RHCLOUD-39756](https://issues.redhat.com/browse/RHCLOUD-39756)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5ec1a259-54c6-49df-9ff4-c87e0a41df1f" />

## Summary by Sourcery

New Features:
- Add 'Workspaces' option under the IAM section in the services dropdown