### PR TITLE
feat(workspaces): redirect to inventory ws detail

### DIFF
--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Outlet, useSearchParams } from 'react-router-dom';
+import { Link, Outlet, useSearchParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { deleteWorkspace, fetchWorkspaces } from '../../redux/actions/workspaces-actions';
 import {
@@ -110,7 +110,9 @@ const WorkspaceListTable = () => {
     workspaces.map((workspace) => ({
       row: Object.values({
         name: hideWorkspaceDetails ? (
-          workspace.name
+          <Link replace to={`/insights/inventory/workspaces/${workspace.id}`} key={`${workspace.id}-inventory-link`} className="rbac-m-hide-on-sm">
+            {workspace.name}
+          </Link>
         ) : (
           <AppLink
             to={pathnames['workspace-detail'].link.replace(':workspaceId', workspace.id)}


### PR DESCRIPTION
### Description
If platform.rbac.workspaces-list  is enabled then redirect to the Inventory Workspaces details page

[RHCLOUD-39755](https://issues.redhat.com/browse/RHCLOUD-39755)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

New Features:
- Redirect users to the Inventory Workspaces detail page when the `platform.rbac.workspaces-list` feature flag is enabled