### PR TITLE
Update edit and create validators with workspace IDs to disallow duplicates 

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1276,6 +1276,11 @@ export default defineMessages({
     description: 'Workspace name label',
     defaultMessage: 'Workspace name',
   },
+  workspaceNameTaken: {
+    id: 'workspaceNameTaken',
+    description: 'Workspace name taken error title',
+    defaultMessage: 'Workspace name already taken',
+  },
   workspaceDescription: {
     id: 'workspaceDescription',
     description: 'Create newworkspace action label',

--- a/src/smart-components/workspaces/EditWorkspaceModal.tsx
+++ b/src/smart-components/workspaces/EditWorkspaceModal.tsx
@@ -56,11 +56,13 @@ const EditWorkspaceModal: React.FunctionComponent<EditWorkspaceModalProps> = ({ 
           component: componentTypes.TEXT_FIELD,
           validate: [
             { type: validatorTypes.REQUIRED },
-            (value: string) => {
+            (value: string, { id }: any) => {
               if (value === initialFormData?.name) {
                 return undefined;
               }
-              const isDuplicate = allWorkspaces.some((existingWorkspace) => existingWorkspace.name.toLowerCase() === value?.toLowerCase());
+              const isDuplicate = allWorkspaces.some(
+                (existingWorkspace) => existingWorkspace.name.toLowerCase() === value?.toLowerCase() && existingWorkspace.id !== id
+              );
               return isDuplicate ? intl.formatMessage(messages.groupNameTakenTitle) : undefined;
             },
           ],

--- a/src/smart-components/workspaces/create-workspace/schema.tsx
+++ b/src/smart-components/workspaces/create-workspace/schema.tsx
@@ -8,6 +8,8 @@ import { Workspace } from '../../../redux/reducers/workspaces-reducer';
 import providerMessages from '../../../locales/data.json';
 import messages from '../../../Messages';
 import { Button, Text } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
+import { RBACStore } from '../../../redux/store';
 
 // hardcoded for now
 export const BUNDLES = [
@@ -42,6 +44,7 @@ export interface CreateWorkspaceFormValues {
 export const schemaBuilder = (enableBillingFeatures: boolean) => {
   const cache = createIntlCache();
   const intl = createIntl({ locale, messages: providerMessages as any }, cache); // eslint-disable-line @typescript-eslint/no-explicit-any
+  const allWorkspaces = useSelector((state: RBACStore) => state.workspacesReducer.workspaces || []);
 
   return {
     fields: [
@@ -103,6 +106,12 @@ export const schemaBuilder = (enableBillingFeatures: boolean) => {
                 validate: [
                   {
                     type: validatorTypes.REQUIRED,
+                  },
+                  (value: string, { id }: any) => {
+                    const isDuplicate = allWorkspaces.some(
+                      (existingWorkspace) => existingWorkspace.name.toLowerCase() === value?.toLowerCase() && existingWorkspace.id !== id
+                    );
+                    return isDuplicate ? intl.formatMessage(messages.workspaceNameTaken) : undefined;
                   },
                   {
                     type: validatorTypes.MAX_LENGTH,


### PR DESCRIPTION
For [RHCLOUD-39757](https://issues.redhat.com/browse/RHCLOUD-39757). On edit, the workspace name validator would always come up as a duplicate because its name already existed in the `allWorkspaces` array which would prevent being able to submit on description change only.  