### PR TITLE
feat(workspaces): allow ungrouped ws to have inventory detail

### DIFF
--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -112,7 +112,7 @@ const WorkspaceListTable = () => {
       row: Object.values({
         name:
           hideWorkspaceDetails && !globalWs ? (
-            workspace?.type === 'standard' ? (
+            ['standard', 'ungrouped-hosts'].includes(workspace?.type) ? (
               <Link
                 replace
                 to={`/insights/inventory/workspaces/${workspace.id}`}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

We have to allow inventory details for ungrouped hosts as well.

## Summary by Sourcery

New Features:
- Enable inventory detail links for ungrouped-hosts workspaces in the workspaces list