### PR TITLE
fix: use inline style when calling workspaces api

### DIFF
--- a/src/helpers/workspaces/workspaces-helper.ts
+++ b/src/helpers/workspaces/workspaces-helper.ts
@@ -7,27 +7,28 @@ import { getWorkspacesApi } from './api';
 const workspacesApi = getWorkspacesApi();
 
 export async function getWorkspaces(config: WorkspacesListParams = {}) {
-  return await workspacesApi.listWorkspaces({ limit: 10000, ...config });
+  return workspacesApi.listWorkspaces(config.limit ?? 10000, config.offset ?? 0, config.type ?? 'default', config.options ?? {});
 }
 
 export async function getWorkspace(workspaceId: string) {
-  return workspacesApi.getWorkspace({ id: workspaceId });
+  return workspacesApi.getWorkspace(workspaceId, false, {});
 }
 
 export async function createWorkspace(config: WorkspaceCreateBody) {
-  return workspacesApi.createWorkspace({
-    workspacesCreateWorkspaceRequest: {
+  return workspacesApi.createWorkspace(
+    {
       parent_id: config.parent_id,
       name: config.name,
       description: config.description,
     },
-  });
+    {},
+  );
 }
 
 export async function updateWorkspace(config: WorkspacesPatchParams) {
-  return workspacesApi.updateWorkspace(config);
+  return workspacesApi.updateWorkspace(config.id, config.workspacesPatchWorkspaceRequest, {});
 }
 
 export async function deleteWorkspace(config: WorkspacesDeleteParams) {
-  return workspacesApi.deleteWorkspace(config);
+  return workspacesApi.deleteWorkspace(config.id, {});
 }


### PR DESCRIPTION
The current version of the rbac-client is buggy
and its types are wrong when using the object passing style

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->


---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
