### PR TITLE
Add conditional edit/delete button disabling

### DIFF
--- a/cypress/e2e/edit-workspaces.cy.ts
+++ b/cypress/e2e/edit-workspaces.cy.ts
@@ -1,0 +1,79 @@
+describe('Filter workspaces', () => {
+  const mockWorkspaces = {
+    meta: {
+      count: 3,
+      limit: 100,
+      offset: 0,
+    },
+    data: [
+      {
+        name: 'Root Workspace',
+        id: '01938960-94c7-79e3-aecb-549ad25003b8',
+        parent_id: null,
+        description: null,
+        created: '2024-12-02T21:57:08.423927Z',
+        modified: '2024-12-02T21:57:08.504809Z',
+        type: 'root',
+      },
+      {
+        name: 'Default Workspace',
+        id: '01939c7c-e19a-7f60-a38a-1937cbd55f0c',
+        parent_id: '01938960-94c7-79e3-aecb-549ad25003b8',
+        description: null,
+        created: '2024-12-06T15:00:50.202053Z',
+        modified: '2024-12-06T15:00:50.213196Z',
+        type: 'default',
+      },
+      {
+        name: 'xyc',
+        id: '0193d8ee-06d5-76a3-af0b-2b002431016d',
+        parent_id: '01939c7c-e19a-7f60-a38a-1937cbd55f0c',
+        description: null,
+        created: '2024-12-18T08:41:38.261872Z',
+        modified: '2024-12-18T08:41:38.271103Z',
+        type: 'standard',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    cy.login();
+
+    // mock the workspaces
+    cy.intercept('GET', '**/api/rbac/v2/workspaces/*', {
+      statusCode: 200,
+      body: mockWorkspaces,
+    }).as('getWorkspaces');
+
+    cy.visit('/iam/access-management/workspaces');
+    cy.wait('@getWorkspaces', { timeout: 30000 });
+
+    // check if Workspaces heading exists on the page
+    cy.contains('Workspaces').should('exist');
+
+    // expand tree
+    cy.get('[aria-label="Expand row 0"]').click();
+    cy.get('[aria-label="Expand row 1"]').click();
+  });
+
+  it('should not let user edit or delete root workspace', () => {
+    // click the menu button on the root workspace and ensure edit and delete are disabled
+    cy.get('[data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"]').click();
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-1"]').should('have.class', 'pf-m-disabled');
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-2"]').should('have.class', 'pf-m-disabled');
+  });
+
+  it('should let user edit but not delete a default workspace', () => {
+    // click the menu button on the default workspace and ensure edit is enabled and delete is disabled
+    cy.get('[data-ouia-component-id="OUIA-Generated-MenuToggle-plain-2"]').last().click();
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-1"]').should('not.have.class', 'pf-m-disabled');
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-2"]').should('have.class', 'pf-m-disabled');
+  });
+
+  it('should let user edit and delete a standard workspace', () => {
+    // click the menu button on a standard workspace and ensure edit and delete are enabled
+    cy.get('[data-ouia-component-id="OUIA-Generated-MenuToggle-plain-3"]').last().click();
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-1"]').should('not.have.class', 'pf-m-disabled');
+    cy.get('[data-ouia-component-id="OUIA-Generated-DropdownItem-2"]').should('not.have.class', 'pf-m-disabled');
+  });
+});

--- a/src/redux/reducers/workspaces-reducer.ts
+++ b/src/redux/reducers/workspaces-reducer.ts
@@ -10,7 +10,7 @@ export interface WorkspaceCreateBody {
 
 export interface Workspace extends WorkspaceCreateBody {
   id: string;
-  type: 'standard' | 'default' | 'root';
+  type: 'standard' | 'default' | 'root' | 'ungrouped-hosts';
   parent_id: string;
 }
 

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -145,7 +145,7 @@ const WorkspaceListTable = () => {
   };
 
   const canModify = (workspace: Workspace, action: 'edit' | 'delete') => {
-    if (userPermissions.resourceDefinitions.length === 0 || userPermissions.resourceDefinitions.includes(workspace.id)) {
+    if (userPermissions.permission === 'inventory:groups:write' && (userPermissions.resourceDefinitions.length === 0 || userPermissions.resourceDefinitions.includes(workspace.id))) {
       if (action === 'edit' && isValidEditType(workspace)) {
         return true;
       } else if (action === 'delete' && isValidDeleteType(workspace)) {

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -145,7 +145,10 @@ const WorkspaceListTable = () => {
   };
 
   const canModify = (workspace: Workspace, action: 'edit' | 'delete') => {
-    if (userPermissions.permission === 'inventory:groups:write' && (userPermissions.resourceDefinitions.length === 0 || userPermissions.resourceDefinitions.includes(workspace.id))) {
+    if (
+      userPermissions.permission === 'inventory:groups:write' &&
+      (userPermissions.resourceDefinitions.length === 0 || userPermissions.resourceDefinitions.includes(workspace.id))
+    ) {
       if (action === 'edit' && isValidEditType(workspace)) {
         return true;
       } else if (action === 'delete' && isValidDeleteType(workspace)) {

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -268,7 +268,7 @@ const WorkspaceListTable = () => {
     chrome.getUserPermissions().then((permissions) => {
       setUserPermissions(permissions.find(({ permission }) => ['inventory:groups:write', 'inventory:groups:*'].includes(permission)));
     });
-  }, []);
+  }, [chrome.getUserPermissions]);
 
   if (error) {
     return <ErrorState errorDescription={error} />;

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -217,7 +217,7 @@ const WorkspaceListTable = () => {
                     handleModalToggle([workspace]);
                   },
                   isDisabled: (workspace.children && workspace.children.length > 0) || !canModify(workspace, 'delete'),
-                  isDanger: !(workspace.children && workspace.children.length > 0),
+                  isDanger: !(workspace.children && workspace.children.length > 0) && canModify(workspace, 'delete'),
                 },
               ]}
             />

--- a/src/smart-components/workspaces/WorkspaceListTable.tsx
+++ b/src/smart-components/workspaces/WorkspaceListTable.tsx
@@ -32,9 +32,15 @@ import { Workspace } from '../../redux/reducers/workspaces-reducer';
 import { RBACStore } from '../../redux/store';
 import pathnames from '../../utilities/pathnames';
 import paths from '../../utilities/pathnames';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 interface WorkspaceFilters {
   name: string;
+}
+
+interface PermissionObject {
+  permission: string;
+  resourceDefinitions: string[];
 }
 
 const mapWorkspacesToHierarchy = (workspaceData: Workspace[]): Workspace | undefined => {
@@ -96,8 +102,13 @@ const WorkspaceListTable = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const navigate = useAppNavigate();
+  const chrome = useChrome();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [currentWorkspaces, setCurrentWorkspaces] = useState<Workspace[]>([]);
+  const [userPermissions, setUserPermissions] = useState<PermissionObject>({
+    permission: '',
+    resourceDefinitions: [],
+  });
 
   const hideWorkspaceDetails = useFlag('platform.rbac.workspaces-list');
   const globalWs = useFlag('platform.rbac.workspaces');
@@ -105,6 +116,44 @@ const WorkspaceListTable = () => {
   const handleModalToggle = (workspaces: Workspace[]) => {
     setCurrentWorkspaces(workspaces);
     setIsDeleteModalOpen(!isDeleteModalOpen);
+  };
+
+  const isValidEditType = (workspace: Workspace) => {
+    switch (workspace.type) {
+      case 'root':
+        return false;
+      case 'default':
+        return true;
+      case 'ungrouped-hosts':
+        return false;
+      case 'standard':
+        return true;
+    }
+  };
+
+  const isValidDeleteType = (workspace: Workspace) => {
+    switch (workspace.type) {
+      case 'root':
+        return false;
+      case 'default':
+        return false;
+      case 'ungrouped-hosts':
+        return false;
+      case 'standard':
+        return true;
+    }
+  };
+
+  const canModify = (workspace: Workspace, action: 'edit' | 'delete') => {
+    if (userPermissions.resourceDefinitions.length === 0 || userPermissions.resourceDefinitions.includes(workspace.id)) {
+      if (action === 'edit' && isValidEditType(workspace)) {
+        return true;
+      } else if (action === 'delete' && isValidDeleteType(workspace)) {
+        return true;
+      }
+    } else {
+      return false;
+    }
   };
 
   const buildRows = (workspaces: Workspace[]): DataViewTrTree[] =>
@@ -143,14 +192,18 @@ const WorkspaceListTable = () => {
                   onClick: () => {
                     navigate(paths['edit-workspaces-list'].link.replace(':workspaceId', workspace.id));
                   },
+                  isDisabled: !canModify(workspace, 'edit'),
                 },
-                { title: <Divider component="li" key="divider" /> },
+                {
+                  title: <Divider component="li" key="divider" />,
+                  isSeparator: true,
+                },
                 {
                   title: 'Delete workspace',
                   onClick: () => {
                     handleModalToggle([workspace]);
                   },
-                  isDisabled: workspace.children && workspace.children.length > 0,
+                  isDisabled: workspace.children && workspace.children.length > 0 && !canModify(workspace, 'delete'),
                   isDanger: !(workspace.children && workspace.children.length > 0),
                 },
               ]}
@@ -197,6 +250,16 @@ const WorkspaceListTable = () => {
   useEffect(() => {
     dispatch(fetchWorkspaces());
   }, [dispatch]);
+
+  useEffect(() => {
+    chrome.getUserPermissions().then((permissions) => {
+      setUserPermissions(
+        permissions.find((obj) => {
+          return obj.permission === 'inventory:groups:write';
+        }),
+      );
+    });
+  }, []);
 
   if (error) {
     return <ErrorState errorDescription={error} />;


### PR DESCRIPTION
For [RHCLOUD-39840](https://issues.redhat.com/browse/RHCLOUD-39840)

Conditionally disables a workspace's edit/delete button based on workspace type as well as user permissions. Also adds basic e2e tests to test workspace type conditions.

<img width="1115" alt="image" src="https://github.com/user-attachments/assets/7c05bdf5-82e3-4995-85f0-a7ec869c2b75" />

## Summary by Sourcery

Add conditional disabling of workspace edit and delete actions based on workspace type and user RBAC permissions.

New Features:
- Fetch and store user RBAC permissions via Chrome to control workspace actions

Enhancements:
- Extend workspace type enum to include 'ungrouped-hosts'
- Disable edit/delete buttons dynamically according to workspace type and user permission

Tests:
- Add Cypress e2e tests to verify edit/delete button states for root, default, and standard workspaces based on permissions