### PR TITLE
fix: tweak MUA mobile/tablet breakpoints

### DIFF
--- a/src/smart-components/myUserAccess/MUAContent.js
+++ b/src/smart-components/myUserAccess/MUAContent.js
@@ -22,14 +22,14 @@ const MUAContent = ({ entitlements, isOrgAdmin, isUserAccessAdmin }) => {
   return (
     <OrgAdminContext.Provider value={hasAdminAccess}>
       <Grid>
-        <GridItem className="pf-m-3-col-on-md rbac-l-myUserAccess-section__cards rbac-m-hide-on-sm">
+        <GridItem className="pf-m-3-col-on-lg rbac-l-myUserAccess-section__cards">
           <Stack>
             <StackItem data-testid="entitle-section" className="rbac-l-myUserAccess-section__cards--entitled">
               <MUACard entitlements={entitledBundles} />
             </StackItem>
           </Stack>
         </GridItem>
-        <GridItem className="pf-m-9-col-on-md rbac-l-myUserAccess-section__table">
+        <GridItem className="pf-m-12-col pf-m-9-col-on-xl rbac-l-myUserAccess-section__table">
           <Title headingLevel="h3" size="xl">
             {intl.formatMessage(hasAdminAccess ? messages.yourRoles : messages.yourPermissions, {
               name: bundleData.find(({ entitlement }) => entitlement === bundle)?.title,

--- a/src/smart-components/myUserAccess/MUAContent.scss
+++ b/src/smart-components/myUserAccess/MUAContent.scss
@@ -1,9 +1,14 @@
-.rbac-l-myUserAccess-section__cards--unentitled {
-  .pf-v5-c-title {
-    border-top: 1px solid var(--pf-v5-global--BorderColor--100);
-    padding-top: var(--pf-v5-global--spacer--md);
+@media only screen and (max-width: 1200px) {
+  .rbac-l-myUserAccess-section__cards {
+    display: none;
   }
-  .rbac-c-mua-cardWrapper {
-    cursor: not-allowed;
+  .rbac-l-myUserAccess-section__cards--unentitled {
+    .pf-v5-c-title {
+      border-top: 1px solid var(--pf-v5-global--BorderColor--100);
+      padding-top: var(--pf-v5-global--spacer--md);
+    }
+    .rbac-c-mua-cardWrapper {
+      cursor: not-allowed;
+    }
   }
 }

--- a/src/smart-components/myUserAccess/MUAHome.scss
+++ b/src/smart-components/myUserAccess/MUAHome.scss
@@ -27,7 +27,7 @@
 }
 .rbac-l-myUserAccess-section__cards {border-right: 1px solid var(--pf-v5-global--BorderColor--100);}
 
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 1200px) {
   .sticky {
     position: sticky;
     position: -webkit-sticky;


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Adjust breakpoints for mobile and tablet layout

[RHCLOUD-40161](https://issues.redhat.com/browse/RHCLOUD-40161)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2025-06-09 at 9 55 38 AM](https://github.com/user-attachments/assets/0ebbde30-66b2-4b9f-8329-2fb3eb0e718c)


#### After:
![Screenshot 2025-06-09 at 10 13 03 AM](https://github.com/user-attachments/assets/4a841d55-5445-414e-afb6-a88d6d08e8a9)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Tweak mobile and tablet breakpoints in the My User Access layout to improve responsiveness by hiding card sections, updating grid column modifiers, and extending sticky behavior under a 1200px viewport width.

Bug Fixes:
- Hide the card section for My User Access when the screen width is below 1200px
- Update grid items to use a 3-column layout at the lg breakpoint for cards and a 9-column layout at the xl breakpoint for tables
- Extend sticky sidebar positioning to apply up to a 1200px viewport width