### PR TITLE
fix(itless): fix itless users activate dropdown

### DIFF
--- a/src/smart-components/group/add-group/users-list-itless.js
+++ b/src/smart-components/group/add-group/users-list-itless.js
@@ -168,7 +168,7 @@ const UsersListItless = ({ selectedUsers, setSelectedUsers, userLinks, usesMetaI
 
   const toolbarDropdowns = () => {
     const onToggle = () => {
-      setIsToolbarDropdownOpen(!isToolbarDropdownOpen);
+      setIsToolbarDropdownOpen((isToolbarDropdownOpen) => !isToolbarDropdownOpen);
     };
     const onToolbarDropdownSelect = async (_event) => {
       const userActivationStatusMap = { activate: true, deactivate: false };


### PR DESCRIPTION
### Description
This fixes an issue in the users itless table where the activate/deactivate dropdown would not close after opening. 

[RHCLOUD-40519](https://issues.redhat.com/browse/RHCLOUD-40519)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
