### PR TITLE
test: add tests to activate and deactivate users

### DIFF
--- a/cypress/e2e/user-access.cy.ts
+++ b/cypress/e2e/user-access.cy.ts
@@ -1,12 +1,53 @@
+const API_TIMEOUT = 30000;
+const testUsername = 'platform-experience-ui';
+
+const waitForUsersTable = () => {
+  cy.get('table[data-ouia-component-id="users-table"]', { timeout: 100000 }).should('be.visible');
+};
+
+const navigateToUsersTable = () => {
+  cy.login();
+  cy.visit('/iam/user-access/users');
+  waitForUsersTable();
+};
+
+const filterTestUser = (username: string) => {
+  cy.get('#filter-by-username').clear().type(username, { delay: 100 });
+  cy.contains('tr', username).should('be.visible');
+};
+
+const clearAllFilters = () => {
+  cy.get('button[data-ouia-component-id="ClearFilters"]')
+    .should('be.visible')
+    .click();
+
+  waitForUsersTable();
+};
+
+const findUserRowByStatus = (status: 'Active' | 'Inactive') => {
+  return cy.get('table tbody tr').filter(`:contains(${status})`).first();
+};
+
+const toggleUserStatus = (row: Cypress.Chainable<JQuery<HTMLElement>>) => {
+  row.within(() => {
+    cy.get('input[type="checkbox"][data-testid="user-status-toggle"]')
+      .should('exist')
+      .click({ force: true });
+  });
+};
+
+const selectUsersByStatus = (status: 'Active' | 'Inactive', count: number) => {
+  cy.get('table tbody tr')
+    .filter(`:contains(${status})`)
+    .then((rows) => {
+      const slicedRows = Array.from(rows).slice(0, count);
+      cy.wrap(slicedRows).each((el) => {
+        cy.wrap(el).find('input[type="checkbox"][aria-label^="Select row"]').click({ force: true });
+      });
+    });
+};
+
 describe('Make user an org admin', () => {
-  const testUsername = 'platform-experience-ui';
-  const API_TIMEOUT = 30000;
-
-  const filterTestUser = (username: string) => {
-    cy.get('#filter-by-username').clear().type(username, { delay: 100 });
-    cy.contains('tr', username).should('be.visible');
-  };
-
   const setOrgAdminViaUI = (username: string, targetState: 'Yes' | 'No') => {
     cy.contains('tr', username).within(() => {
       cy.get('button.pf-v5-c-menu-toggle')
@@ -15,9 +56,7 @@ describe('Make user an org admin', () => {
           const currentState = $btn.text().trim();
           if (currentState !== targetState) {
             cy.wrap($btn).click();
-
             cy.get('[role="menu"]').should('be.visible');
-
             cy.contains('[role="menuitem"], button', targetState).click();
           }
         });
@@ -25,9 +64,7 @@ describe('Make user an org admin', () => {
   };
 
   beforeEach(() => {
-    cy.login();
-    cy.visit('/iam/user-access/users');
-    cy.get('table[data-ouia-component-id="users-table"]', { timeout: 100000 }).should('be.visible');
+    navigateToUsersTable();
     filterTestUser(testUsername);
   });
 
@@ -38,5 +75,88 @@ describe('Make user an org admin', () => {
     }).as('setOrgAdmin');
     setOrgAdminViaUI(testUsername, 'Yes');
     cy.wait('@setOrgAdmin', { timeout: API_TIMEOUT });
+  });
+});
+
+describe('Activate/deactivate users from users table', () => {
+  beforeEach(() => {
+    navigateToUsersTable();
+    clearAllFilters();
+  });
+
+  describe('Single user action via toggle', () => {
+    it('activates an inactive user', () => {
+      cy.intercept('POST', '**/account/v1/accounts/**/users/**/status', {
+        statusCode: 200,
+        body: { status: 'enabled' },
+      }).as('enableUser');
+
+      findUserRowByStatus('Inactive').then((row) => {
+        toggleUserStatus(cy.wrap(row));
+        cy.wait('@enableUser', { timeout: API_TIMEOUT });
+      });
+    });
+
+    it('deactivates an active user', () => {
+      cy.intercept('POST', '**/account/v1/accounts/**/users/**/status', {
+        statusCode: 200,
+        body: { status: 'disabled' },
+      }).as('disableUser');
+
+      findUserRowByStatus('Active').then((row) => {
+        toggleUserStatus(cy.wrap(row));
+        cy.wait('@disableUser', { timeout: API_TIMEOUT });
+      });
+    });
+  });
+
+  describe('Bulk action via dropdown', () => {
+    const triggerBulkAction = (actionLabel: string) => {
+      cy.get('button[aria-label="kebab dropdown toggle"]').click();
+      cy.get('ul[role="menu"]').within(() => {
+        cy.contains('li', actionLabel).click();
+      });
+
+      cy.get('div[data-ouia-component-id="toggle-status-modal"]').should('be.visible');
+
+      cy.get('div[data-ouia-component-id="toggle-status-modal"]')
+        .find('.pf-v5-c-modal-box__title-text')
+        .should('contain.text', actionLabel);
+
+      cy.get('input[data-ouia-component-id="toggle-status-modal-confirm-checkbox"]').check();
+
+      cy.get('div[data-ouia-component-id="toggle-status-modal"]')
+        .find('button[data-ouia-component-id="toggle-status-modal-confirm-button"]')
+        .should('not.be.disabled')
+        .click();
+
+      cy.get('div[data-ouia-component-id="toggle-status-modal"]').should('not.exist');
+    };
+
+    it('activates multiple inactive users', () => {
+      cy.intercept('POST', '**/account/v1/accounts/**/users/**/status', {
+        statusCode: 200,
+        body: { status: 'enabled' },
+      }).as('bulkEnable');
+
+      selectUsersByStatus('Inactive', 2);
+      triggerBulkAction('Activate users');
+
+      cy.wait('@bulkEnable', { timeout: API_TIMEOUT }).its('request.body').should('deep.equal', { status: 'enabled' });
+      cy.wait('@bulkEnable');
+    });
+
+    it('deactivates multiple active users', () => {
+      cy.intercept('POST', '**/account/v1/accounts/**/users/**/status', {
+        statusCode: 200,
+        body: { status: 'disabled' },
+      }).as('bulkDisable');
+
+      selectUsersByStatus('Active', 2);
+      triggerBulkAction('Deactivate users');
+
+      cy.wait('@bulkDisable', { timeout: API_TIMEOUT }).its('request.body').should('deep.equal', { status: 'disabled' });
+      cy.wait('@bulkDisable');
+    });
   });
 });

--- a/src/smart-components/user/ActivateToggle.tsx
+++ b/src/smart-components/user/ActivateToggle.tsx
@@ -12,6 +12,7 @@ const ActivateToggle: React.FC<{
   return user.external_source_id ? (
     <Switch
       id={user.username}
+      data-testid="user-status-toggle"
       key={user.uuid}
       isChecked={user.is_active}
       onChange={(e, value) => handleToggle(e, value, [user])}


### PR DESCRIPTION
### Description
test: add tests to activate and deactivate users

[RHCLOUD-36886](https://issues.redhat.com/browse/RHCLOUD-36886)

---

### Screenshots
<img width="510" alt="Snímek obrazovky 2025-06-11 v 13 40 55" src="https://github.com/user-attachments/assets/6ccad09c-6b36-4ded-a992-e34554947d08" />



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Add and organize Cypress E2E tests for user activation and deactivation, including single and bulk action scenarios, and refactor shared test utilities for reuse

Enhancements:
- Extract common Cypress helpers for navigating to the users table, filtering, and toggling user status
- Refactor existing org admin tests to use the newly introduced utilities

Tests:
- Add a test suite for activating and deactivating a single user via the toggle switch
- Add a test suite for activating and deactivating multiple users through bulk actions and confirmation modal
- Stub and verify user status network requests and request payloads in activation/deactivation tests