### PR TITLE
fix: allow users to see the full list of permissions for their own profile

### DIFF
--- a/src/smart-components/myUserAccess/MUAHome.js
+++ b/src/smart-components/myUserAccess/MUAHome.js
@@ -22,7 +22,12 @@ const MyUserAccess = () => {
   const [bundleParam, setBundleParam] = useState(bundle);
   const { userAccessAdministrator } = useContext(PermissionsContext);
   useEffect(() => {
-    chrome.auth.getUser().then(({ identity, entitlements }) => setUser({ entitlements, isOrgAdmin: identity?.user?.is_org_admin }));
+    chrome.auth.getUser().then(({ identity, entitlements }) =>
+      setUser({
+        entitlements,
+        isOrgAdmin: identity?.user?.is_org_admin,
+      }),
+    );
     !bundle && setSearchParams({ bundle: DEFAULT_MUA_BUNDLE });
   }, []);
   const enhancedEntitlements = {
@@ -76,7 +81,7 @@ const MyUserAccess = () => {
             </div>
           )}
           <section>
-            <MUAContent entitlements={enhancedEntitlements} isOrgAdmin={user.isOrgAdmin} isUserAccessAdmin={userAccessAdministrator} />
+            <MUAContent entitlements={enhancedEntitlements} isOrgAdmin={user.isOrgAdmin} isUserAccessAdmin={true} />
           </section>
         </React.Fragment>
       ) : (


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->


[RHCLOUD-32064](https://issues.redhat.com/browse/RHCLOUD-32064)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Allow users to view the complete list of permissions on their own profile by bypassing the administrative check

Bug Fixes:
- Always enable the userAccessAdministrator flag in MyUserAccess to display all permission bundles for the current user

Enhancements:
- Clean up the formatting of the setUser call in the useEffect hook