### PR TITLE
feat(workspaces): initial pass at workspace permission utility

### DIFF
--- a/src/smart-components/workspaces/managed-selector/TreeViewWorkspaceItem.ts
+++ b/src/smart-components/workspaces/managed-selector/TreeViewWorkspaceItem.ts
@@ -8,6 +8,7 @@ import Workspace, { isWorkspace } from './Workspace';
 interface TreeViewWorkspaceItem extends TreeViewDataItem {
   parentTreeViewItem?: TreeViewWorkspaceItem;
   workspace: Workspace;
+  disabled?: boolean;
 }
 
 /**

--- a/src/smart-components/workspaces/managed-selector/WorkspacePermissions.ts
+++ b/src/smart-components/workspaces/managed-selector/WorkspacePermissions.ts
@@ -1,0 +1,47 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { ResourceDefinition } from '@redhat-cloud-services/rbac-client/types';
+import { useEffect, useState } from 'react';
+
+export enum WorkspacePermissions {
+  AllPermission = 'inventory:groups:*',
+  ReadPermission = 'inventory:groups:read',
+  WritePermission = 'inventory:groups:write',
+}
+
+export type WorkspacePermissionsValues = `${WorkspacePermissions}`;
+
+export type WorkspacePermissionsObject = Partial<Record<WorkspacePermissions, ResourceDefinition[]>>;
+
+export const useWorkspacePermissions = (): [WorkspacePermissionsObject, Error | undefined] => {
+  const { getUserPermissions } = useChrome();
+  const [workspacePermissions, setWorkspacePermissions] = useState<WorkspacePermissionsObject>({});
+  const [workspacePermissionsError, setWorkspacePermissionsError] = useState<Error>();
+
+  useEffect(() => {
+    getUserPermissions()
+      .then((userPermissions) => {
+        const result: WorkspacePermissionsObject = {};
+        result[WorkspacePermissions.AllPermission] = userPermissions.find(
+          ({ permission }) => permission === WorkspacePermissions.AllPermission,
+        )?.resourceDefinitions;
+        result[WorkspacePermissions.ReadPermission] = userPermissions.find(
+          ({ permission }) => permission === WorkspacePermissions.ReadPermission,
+        )?.resourceDefinitions;
+        result[WorkspacePermissions.WritePermission] = userPermissions.find(
+          ({ permission }) => permission === WorkspacePermissions.WritePermission,
+        )?.resourceDefinitions;
+        setWorkspacePermissions(result);
+      })
+      .catch((error) => setWorkspacePermissionsError(new Error('Error fetching user workspace permissions', error)));
+  }, []);
+
+  return [workspacePermissions, workspacePermissionsError];
+};
+
+export const canViewWorkspaceById = (workspaceId: string, workspacePermissions: WorkspacePermissionsObject): boolean => {
+  return (
+    !!workspacePermissions[WorkspacePermissions.AllPermission] ||
+    (!!workspacePermissions[WorkspacePermissions.ReadPermission] &&
+      workspacePermissions[WorkspacePermissions.ReadPermission].some((item) => item.attributeFilter.value.includes(workspaceId)))
+  );
+};

--- a/src/smart-components/workspaces/managed-selector/WorkspaceTreeBuilder.ts
+++ b/src/smart-components/workspaces/managed-selector/WorkspaceTreeBuilder.ts
@@ -1,8 +1,9 @@
 import { TreeViewWorkspaceItem } from './TreeViewWorkspaceItem';
 import Workspace from './Workspace';
+import { WorkspacePermissionsObject, canViewWorkspaceById } from './WorkspacePermissions';
 import WorkspaceType from './WorkspaceType';
 
-function buildWorkspaceTree(wps: Workspace[]): TreeViewWorkspaceItem | undefined {
+function buildWorkspaceTree(wps: Workspace[], workspacePermissions: WorkspacePermissionsObject | undefined): TreeViewWorkspaceItem | undefined {
   if (wps.length == 0) {
     return undefined;
   }
@@ -47,6 +48,11 @@ function buildWorkspaceTree(wps: Workspace[]): TreeViewWorkspaceItem | undefined
   const nodes: TreeViewWorkspaceItem[] = [rootWorkspace];
   while (nodes.length > 0) {
     const node = nodes.pop();
+
+    // TODO temporary POC - PF tree view list item does not currently support adding custom styles or disabling programatically
+    if (node && node.id && workspacePermissions && !canViewWorkspaceById(node.workspace.id, workspacePermissions)) {
+      node.name = `DISABLED ${node.name}`;
+    }
 
     // Find all the children workspaces of the given node by looping through
     // all the available workspaces.


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Adds workspace permissions utility hook and ties into the managed selector component.

* There is still and issue where PF does not currently support disabling tree view list items (nor gives us access to the underlying component). See https://github.com/patternfly/patternfly-react/issues/11893.
* This also does not yet disable an entire sub-tree if no nodes are accessible. 

https://issues.redhat.com/browse/RHCLOUD-40591

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before (or with `withPermissions` set to `false` on `ManagedSelector` props):
![image](https://github.com/user-attachments/assets/97bbfc3e-03d4-4564-9972-b605f0e1e05a)


#### After:
![image](https://github.com/user-attachments/assets/a5a2cac4-36c0-477b-b51b-9086e09be4e3)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
