### PR TITLE
Increase viewport width

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
     // required for the SSO redirect
     chromeWebSecurity: false,
     video: false,
+    viewportWidth: 1300,
     setupNodeEvents(on, config) {
       require('cypress-localstorage-commands/plugin')(on, config);
       return config;

--- a/cypress/e2e/create-workspace.cy.ts
+++ b/cypress/e2e/create-workspace.cy.ts
@@ -1,6 +1,6 @@
 describe('Workspaces page', { testIsolation: false }, () => {
   before(() => {
-    cy.login();
+    cy.login(true);
 
     cy.visit('/iam/access-management/workspaces');
     cy.get('[data-ouia-component-id="ContentHeader-title"]', { timeout: 30000 });

--- a/cypress/e2e/user-access.cy.ts
+++ b/cypress/e2e/user-access.cy.ts
@@ -2,7 +2,7 @@ const API_TIMEOUT = 30000;
 const testUsername = 'platform-experience-ui';
 
 const waitForUsersTable = () => {
-  cy.get('table[data-ouia-component-id="users-table"]', { timeout: 100000 }).should('be.visible');
+  cy.get('table[aria-label="users table"]', { timeout: 100000 }).should('be.visible');
 };
 
 const navigateToUsersTable = () => {

--- a/src/smart-components/access-management/users-and-user-groups/user-groups/UserGroupsTable.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/user-groups/UserGroupsTable.tsx
@@ -350,7 +350,7 @@ const UserGroupsTable: React.FC<UserGroupsTableProps> = ({
         />
         <DataViewTable
           variant="compact"
-          aria-label="Users Table"
+          aria-label="users table"
           ouiaId={`${ouiaId}-table`}
           columns={sortableColumns}
           rows={rows}

--- a/src/smart-components/access-management/users-and-user-groups/users/UsersTable.tsx
+++ b/src/smart-components/access-management/users-and-user-groups/users/UsersTable.tsx
@@ -492,7 +492,7 @@ const UsersTable: React.FC<UsersTableProps> = ({ onAddUserClick, focusedUser, de
         />
         <DataViewTable
           variant="compact"
-          aria-label="Users Table"
+          aria-label="users table"
           ouiaId={`${ouiaId}-table`}
           columns={sortableColumns}
           rows={rows}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When we are running tests cypress defaults to smaller screen, that breaks our flow since some elements are hidden or changed. This PR fixes such issue by setting direct width to 1300px. There's also flaky test in users table where it tries to access ouiaId which is not present on the screen that's because we are using users table at one test and in other we are using users and groups. This PR changes from ouia ID to aria-label so we are testing directly what user can see and interact with.

