### PR TITLE
[DO NOT MERGE] feat(users): unify users for itless and commercial

### DIFF
--- a/src/smart-components/user/users.tsx
+++ b/src/smart-components/user/users.tsx
@@ -18,6 +18,7 @@ const Users = () => {
   const { appNavClick } = useChrome();
   const isITLess = useFlag('platform.rbac.itless');
   const isCommonAuthModel = useFlag('platform.rbac.common-auth-model');
+  const commonUsersTable = useFlag('platform.rbac.common.userstable');
 
   const description = <ActiveUser linkDescription={intl.formatMessage(messages.addNewUsersText)} />;
 
@@ -43,7 +44,15 @@ const Users = () => {
       </StackItem>
       <StackItem>
         <Section type="content" id="users">
-          {isITLess ? <UsersListItless {...usersListProps} /> : <UsersListNotSelectable {...usersListProps} />}
+          {!commonUsersTable ? (
+            isITLess ? (
+              <UsersListItless {...usersListProps} />
+            ) : (
+              <UsersListNotSelectable {...usersListProps} />
+            )
+          ) : (
+            <UsersListNotSelectable {...usersListProps} />
+          )}
         </Section>
       </StackItem>
     </Stack>


### PR DESCRIPTION
### Description

putting up a PR so I can test something inboundry

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Introduce a feature flag to unify user table rendering across ITLess and commercial modes by defaulting to the non-selectable list when enabled

New Features:
- Add `platform.rbac.common.userstable` feature flag to toggle a unified user table
- Use `commonUsersTable` in Users component to always render the non-selectable user list when enabled, otherwise preserve existing ITLess behavior