### PR TITLE
Remove openshift asset from WS details

### DIFF
--- a/src/features/workspaces/workspace-detail/components/AssetsCards.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/AssetsCards.stories.tsx
@@ -12,12 +12,12 @@ const meta: Meta<typeof AssetsCards> = {
         component: `
 AssetsCards component that displays two predefined asset management cards for Insights and OpenShift.
 - Uses PatternFly Card and Panel components for consistent styling
-- Shows Insights and OpenShift asset management options
+- Shows Insights asset management options
 - Each card includes a logo, title, description, and navigation link
 - Links are workspace-specific and include the workspace name in the URL
 - Uses internationalization for all text content
 
-**Note:** In Storybook, the external SVG icons (Insights and OpenShift logos) are not available and will show as broken images.
+**Note:** In Storybook, the external SVG icon (Insights logo) is not available and will show as a broken image.
         `,
       },
     },
@@ -35,8 +35,8 @@ AssetsCards component that displays two predefined asset management cards for In
             fontSize: '14px',
           }}
         >
-          <strong>⚠️ Storybook Note:</strong> The external SVG icons (Insights and OpenShift logos) are not available in this environment and will
-          show as broken images. The component functionality is still fully testable.
+          <strong>⚠️ Storybook Note:</strong> The external SVG icon (Insights logo) is not available in this environment and will show as a broken
+          image. The component functionality is still fully testable.
         </div>
         <Story />
       </div>
@@ -58,9 +58,5 @@ export const Default: Story = {
     const insightsLink = await canvas.findByRole('link', { name: /.*insights.*/i });
     await expect(insightsLink).toBeInTheDocument();
     await expect(insightsLink).toHaveAttribute('href', '/insights/inventory?workspace=my-workspace');
-
-    const openshiftLink = await canvas.findByRole('link', { name: /.*openshift.*/i });
-    await expect(openshiftLink).toBeInTheDocument();
-    await expect(openshiftLink).toHaveAttribute('href', '/openshift/?workspace=my-workspace');
   },
 };

--- a/src/features/workspaces/workspace-detail/components/AssetsCards.tsx
+++ b/src/features/workspaces/workspace-detail/components/AssetsCards.tsx
@@ -23,9 +23,7 @@ interface AssetsCardsProps {
 
 const AssetsCards: React.FunctionComponent<AssetsCardsProps> = ({ workspaceName }: AssetsCardsProps) => {
   const InsightsIcon = '/apps/frontend-assets/console-landing/insights.svg';
-  const OpenShiftIcon = '/apps/frontend-assets/console-landing/openshift.svg';
   const InsightsNavURL = `/insights/inventory?workspace=${workspaceName}`;
-  const OpenShiftNavURL = `/openshift/?workspace=${workspaceName}`;
   const intl = useIntl();
   const AssetsCardsWidths = {
     md: '100px',
@@ -52,18 +50,6 @@ const AssetsCards: React.FunctionComponent<AssetsCardsProps> = ({ workspaceName 
               <CardFooter>
                 <Button variant="link" component="a" href={InsightsNavURL} icon={<ArrowRightIcon />} iconPosition="end" isInline>
                   {intl.formatMessage(Messages.assetManagementInsightsNav)}
-                </Button>
-              </CardFooter>
-            </Card>
-            <Card>
-              <CardHeader>
-                <Brand src={OpenShiftIcon} alt="OpenShift logo" widths={AssetsCardsIconWidths} />
-              </CardHeader>
-              <CardTitle>{intl.formatMessage(Messages.assetManagementOpenShift)}</CardTitle>
-              <CardBody>{intl.formatMessage(Messages.assetManagementOpenShiftOverview)}</CardBody>
-              <CardFooter>
-                <Button variant="link" component="a" href={OpenShiftNavURL} icon={<ArrowRightIcon />} iconPosition="end" isInline>
-                  {intl.formatMessage(Messages.assetManagementOpenShiftNav)}
                 </Button>
               </CardFooter>
             </Card>


### PR DESCRIPTION
For [RHCLOUD-41320](https://issues.redhat.com/browse/RHCLOUD-41320)

<img width="1509" height="822" alt="image" src="https://github.com/user-attachments/assets/19bc3ff8-0a3b-425d-8743-4076116acdfc" />

## Summary by Sourcery

Remove the OpenShift asset management card and related references from the workspace detail AssetsCards component, and update Storybook documentation and tests to reflect only the Insights option.

Enhancements:
- Remove OpenShift icon, URL, and card markup from the AssetsCards component

Documentation:
- Update Storybook stories to remove OpenShift references and adjust notes for only the Insights icon

Tests:
- Remove OpenShift link assertions from the component Canvas test