### PR TITLE
Add initial workspace roles table

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2798,4 +2798,14 @@ export default defineMessages({
     description: 'save changes button label',
     defaultMessage: 'Save changes',
   },
+  unableToLoadUsers: {
+    id: 'unableToLoadUsers',
+    description: 'Unable to load users error title',
+    defaultMessage: 'Unable to load users',
+  },
+  unableToLoadRoles: {
+    id: 'unableToLoadRoles',
+    description: 'Unable to load roles error title',
+    defaultMessage: 'Unable to load roles',
+  },
 });

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2808,4 +2808,14 @@ export default defineMessages({
     description: 'Unable to load roles error title',
     defaultMessage: 'Unable to load roles',
   },
+  groupNoUsersAssigned: {
+    id: 'groupNoUsersAssigned',
+    description: 'Message when group has no users assigned',
+    defaultMessage: 'This group currently has no users assigned to it.',
+  },
+  groupNoRolesAssigned: {
+    id: 'groupNoRolesAssigned',
+    description: 'Message when group has no roles assigned',
+    defaultMessage: 'This group currently has no roles assigned to it.',
+  },
 });

--- a/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsRolesView.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsRolesView.tsx
@@ -60,7 +60,7 @@ const GroupDetailsRolesView: React.FunctionComponent<GroupRolesViewProps> = ({ g
       <div className="pf-v5-u-pt-md">
         <EmptyState variant="sm">
           <EmptyStateHeader titleText="No roles found" icon={<EmptyStateIcon icon={KeyIcon} />} headingLevel="h4" />
-          <EmptyStateBody>This group currently has no roles assigned to it.</EmptyStateBody>
+          <EmptyStateBody>{intl.formatMessage(messages.groupNoRolesAssigned)}</EmptyStateBody>
         </EmptyState>
       </div>
     );

--- a/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.tsx
@@ -64,7 +64,7 @@ const GroupDetailsUsersView: React.FunctionComponent<GroupDetailsUsersViewProps>
       <div className="pf-v5-u-pt-md">
         <EmptyState variant="sm">
           <EmptyStateHeader titleText="No users found" icon={<EmptyStateIcon icon={UsersIcon} />} headingLevel="h4" />
-          <EmptyStateBody>This group currently has no users assigned to it.</EmptyStateBody>
+          <EmptyStateBody>{intl.formatMessage(messages.groupNoUsersAssigned)}</EmptyStateBody>
         </EmptyState>
       </div>
     );

--- a/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.stories.tsx
@@ -1,0 +1,401 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import React from 'react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { Provider } from 'react-redux';
+// @ts-ignore - redux-mock-store doesn't have TypeScript definitions
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import promiseMiddleware from 'redux-promise-middleware';
+import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
+import { GroupDetailsDrawer } from './GroupDetailsDrawer';
+import { IntlProvider } from 'react-intl';
+import { Group } from '../../../../redux/groups/reducer';
+import { User } from '../../../../redux/users/reducer';
+import { Role } from '../../../../redux/roles/reducer';
+import { Button, Card, CardBody } from '@patternfly/react-core';
+
+// Redux store setup
+const middlewares = [thunk, promiseMiddleware, notificationsMiddleware()];
+const mockStore = configureStore(middlewares);
+
+// Mock users data
+const mockUsers: User[] = [
+  {
+    username: 'john.doe',
+    email: 'john.doe@example.com',
+    first_name: 'John',
+    last_name: 'Doe',
+    is_active: true,
+    is_org_admin: false,
+    external_source_id: 1,
+    uuid: 1,
+  },
+  {
+    username: 'jane.smith',
+    email: 'jane.smith@example.com',
+    first_name: 'Jane',
+    last_name: 'Smith',
+    is_active: true,
+    is_org_admin: false,
+    external_source_id: 2,
+    uuid: 2,
+  },
+];
+
+// Mock roles data
+const mockRoles: Role[] = [
+  {
+    uuid: '1',
+    name: 'Administrator',
+    display_name: 'Administrator',
+    description: 'Full administrative access',
+    platform_default: false,
+    admin_default: true,
+    created: '2024-01-15T10:30:00Z',
+    modified: '2024-01-20T14:45:00Z',
+    access: [],
+    accessCount: 0,
+    applications: [],
+    external_role_id: '',
+    external_tenant: '',
+    groups_in: [],
+    groups_in_count: 0,
+    system: false,
+    policyCount: 0,
+  },
+  {
+    uuid: '2',
+    name: 'User Manager',
+    display_name: 'User Manager',
+    description: 'Manage users and groups',
+    platform_default: false,
+    admin_default: false,
+    created: '2024-01-16T11:30:00Z',
+    modified: '2024-01-21T15:45:00Z',
+    access: [],
+    accessCount: 0,
+    applications: [],
+    external_role_id: '',
+    external_tenant: '',
+    groups_in: [],
+    groups_in_count: 0,
+    system: false,
+    policyCount: 0,
+  },
+];
+
+const mockGroup: Group = {
+  uuid: 'group-1',
+  name: 'Platform Administrators',
+  description: 'Full access to all platform resources and administrative functions',
+  principalCount: 12,
+  roleCount: 8,
+  created: '2024-01-15T10:30:00Z',
+  modified: '2024-01-20T14:45:00Z',
+  admin_default: true,
+  platform_default: false,
+  system: false,
+};
+
+const createInitialState = (overrides: any = {}) => ({
+  groupReducer: {
+    selectedGroup: {
+      members: { data: mockUsers, isLoading: false },
+      roles: { data: mockRoles, isLoading: false },
+      error: null,
+    },
+    ...overrides,
+  },
+});
+
+// Story decorator to provide necessary context
+const withProviders = (Story: React.ComponentType, context: { parameters?: { mockState?: { groupReducer?: any } } }) => {
+  const initialState = createInitialState(context.parameters?.mockState?.groupReducer || {});
+  const store = mockStore(initialState);
+
+  return (
+    <Provider store={store}>
+      <IntlProvider locale="en" messages={{}}>
+        <div style={{ height: '600px', padding: '16px' }}>
+          <Story />
+        </div>
+      </IntlProvider>
+    </Provider>
+  );
+};
+
+const meta: Meta<typeof GroupDetailsDrawer> = {
+  component: GroupDetailsDrawer,
+  tags: ['autodocs', 'workspaces', 'group-details-drawer'],
+  decorators: [withProviders],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+The GroupDetailsDrawer is a reusable component for displaying group details with users and roles tabs.
+
+## Key Features
+- **Reusable Design**: Can be used with any content that needs group detail viewing
+- **Data Management**: Handles Redux state for group members and roles
+- **Loading States**: Shows loading, error, and empty states appropriately
+- **Tabbed Interface**: Users and Roles tabs with proper data display
+- **Internationalization**: Uses message keys for all text content
+
+## Props Interface
+- \`isOpen\`: Boolean to control drawer visibility
+- \`group\`: Group object with details to display
+- \`onClose\`: Callback function when drawer is closed
+- \`ouiaId\`: OUIA identifier for testing
+- \`children\`: React nodes to render as drawer content
+
+## Integration
+The drawer wraps content and provides the group details panel. When a group is selected,
+it fetches and displays the group's members and roles in separate tabs.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    isOpen: {
+      description: 'Controls drawer visibility',
+      control: { type: 'boolean' },
+    },
+    group: {
+      description: 'Group object to display details for',
+      control: { type: 'object' },
+    },
+    onClose: {
+      description: 'Callback when drawer is closed',
+      action: 'drawer-closed',
+    },
+    ouiaId: {
+      description: 'OUIA identifier for testing',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Interactive example with drawer functionality
+const DrawerExample = ({
+  isOpen: initialIsOpen = false,
+  group = mockGroup,
+  onClose = fn(),
+  ouiaId = 'group-details-drawer',
+}: {
+  isOpen?: boolean;
+  group?: Group;
+  onClose?: () => void;
+  ouiaId?: string;
+}) => {
+  const [isOpen, setIsOpen] = React.useState(initialIsOpen);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    if (onClose) onClose();
+  };
+
+  return (
+    <GroupDetailsDrawer isOpen={isOpen} group={isOpen ? group : undefined} onClose={handleClose} ouiaId={ouiaId}>
+      <Card>
+        <CardBody>
+          <h2>Content Area</h2>
+          <p>This represents the main content that the drawer wraps around.</p>
+          <Button onClick={() => setIsOpen(true)} disabled={isOpen}>
+            Open Group Details Drawer
+          </Button>
+          {isOpen && (
+            <p style={{ marginTop: '1rem', color: '#6a6e73' }}>
+              Drawer is open - click on the drawer panel to see group details with Users and Roles tabs.
+            </p>
+          )}
+        </CardBody>
+      </Card>
+    </GroupDetailsDrawer>
+  );
+};
+
+// Default story showing drawer functionality
+export const Default: Story = {
+  render: (args) => <DrawerExample {...args} />,
+  args: {
+    isOpen: false,
+    group: mockGroup,
+    onClose: fn(),
+    ouiaId: 'group-details-drawer',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default group details drawer showing users and roles tabs with mock data.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Initially drawer should be closed
+    await expect(canvas.queryByText('Platform Administrators')).not.toBeInTheDocument();
+
+    // Open drawer by clicking button
+    const openButton = await canvas.findByRole('button', { name: /open group details drawer/i });
+    await userEvent.click(openButton);
+
+    // Wait for drawer to open and show group name
+    await expect(canvas.findByText('Platform Administrators')).resolves.toBeInTheDocument();
+
+    // Verify tabs are present - Roles tab should be active by default
+    const rolesTab = await canvas.findByRole('tab', { name: /roles/i });
+    const usersTab = await canvas.findByRole('tab', { name: /users/i });
+
+    await expect(rolesTab).toBeInTheDocument();
+    await expect(usersTab).toBeInTheDocument();
+
+    // Verify roles content is visible (default active tab)
+    await expect(canvas.findByText('Administrator')).resolves.toBeInTheDocument();
+    await expect(canvas.findByText('User Manager')).resolves.toBeInTheDocument();
+
+    // Switch to Users tab
+    await userEvent.click(usersTab);
+
+    // Verify users content is now visible
+    await expect(canvas.findByText('john.doe')).resolves.toBeInTheDocument();
+    await expect(canvas.findByText('Jane')).resolves.toBeInTheDocument();
+    await expect(canvas.findByText('Doe')).resolves.toBeInTheDocument();
+  },
+};
+
+// Open state for documentation
+export const OpenState: Story = {
+  render: (args) => <DrawerExample {...args} />,
+  args: {
+    isOpen: true,
+    group: mockGroup,
+    onClose: fn(),
+    ouiaId: 'group-details-drawer-open',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Drawer in open state showing the group details panel with tabs.',
+      },
+    },
+  },
+};
+
+// Loading state
+export const LoadingState: Story = {
+  render: (args) => <DrawerExample {...args} />,
+  args: {
+    isOpen: true,
+    group: mockGroup,
+    onClose: fn(),
+    ouiaId: 'group-details-drawer-loading',
+  },
+  parameters: {
+    mockState: {
+      groupReducer: {
+        selectedGroup: {
+          members: { data: [], isLoading: true },
+          roles: { data: [], isLoading: true },
+          error: null,
+        },
+      },
+    },
+    docs: {
+      description: {
+        story: 'Drawer showing loading states in both Users and Roles tabs.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Should show loading spinners
+    await waitFor(async () => {
+      const spinners = canvas.getAllByLabelText(/loading/i);
+      expect(spinners.length).toBeGreaterThan(0);
+    });
+  },
+};
+
+// Empty state
+export const EmptyState: Story = {
+  render: (args) => <DrawerExample {...args} />,
+  args: {
+    isOpen: true,
+    group: mockGroup,
+    onClose: fn(),
+    ouiaId: 'group-details-drawer-empty',
+  },
+  parameters: {
+    mockState: {
+      groupReducer: {
+        selectedGroup: {
+          members: { data: [], isLoading: false },
+          roles: { data: [], isLoading: false },
+          error: null,
+        },
+      },
+    },
+    docs: {
+      description: {
+        story: 'Drawer showing empty states when group has no users or roles.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Should show empty state messages
+    await expect(canvas.findByText(/currently has no roles assigned/i)).resolves.toBeInTheDocument();
+
+    // Switch to Users tab to see empty users message
+    const usersTab = await canvas.findByRole('tab', { name: /users/i });
+    await userEvent.click(usersTab);
+
+    await expect(canvas.findByText(/currently has no users assigned/i)).resolves.toBeInTheDocument();
+  },
+};
+
+// Error state
+export const ErrorState: Story = {
+  render: (args) => <DrawerExample {...args} />,
+  args: {
+    isOpen: true,
+    group: mockGroup,
+    onClose: fn(),
+    ouiaId: 'group-details-drawer-error',
+  },
+  parameters: {
+    mockState: {
+      groupReducer: {
+        selectedGroup: {
+          members: { data: [], isLoading: false, error: 'Failed to load members' },
+          roles: { data: [], isLoading: false, error: 'Failed to load roles' },
+          error: 'Network error',
+        },
+      },
+    },
+    docs: {
+      description: {
+        story: 'Drawer showing error states when data fails to load.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Should show error messages
+    await expect(canvas.findByText('Unable to load roles')).resolves.toBeInTheDocument();
+
+    // Switch to Users tab to see error message
+    const usersTab = await canvas.findByRole('tab', { name: /users/i });
+    await userEvent.click(usersTab);
+
+    await expect(canvas.findByText('Unable to load users')).resolves.toBeInTheDocument();
+  },
+};

--- a/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.tsx
+++ b/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelContent,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  Spinner,
+  Tab,
+  Tabs,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, KeyIcon, UsersIcon } from '@patternfly/react-icons';
+import { DataView, DataViewTable } from '@patternfly/react-data-view';
+
+import { Group } from '../../../../redux/groups/reducer';
+import { fetchMembersForGroup, fetchRolesForGroup } from '../../../../redux/groups/actions';
+import { RBACStore } from '../../../../redux/store';
+import { extractErrorMessage } from '../../../../utilities/errorUtils';
+import { User } from '../../../../redux/users/reducer';
+import { Role } from '../../../../redux/roles/reducer';
+import messages from '../../../../Messages';
+
+interface GroupDetailsDrawerProps {
+  isOpen: boolean;
+  group?: Group;
+  onClose: () => void;
+  ouiaId?: string;
+  children: React.ReactNode;
+}
+
+export const GroupDetailsDrawer: React.FC<GroupDetailsDrawerProps> = ({ isOpen, group, onClose, ouiaId = 'group-details-drawer', children }) => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const [activeTab, setActiveTab] = useState<string | number>(0);
+
+  // Redux state for group data
+  const members = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.members?.data || []);
+  const membersLoading = useSelector((state: RBACStore) => (state.groupReducer?.selectedGroup?.members as any)?.isLoading || false);
+  const membersError = useSelector(
+    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.members as any)?.error,
+  );
+
+  const roles = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.data || []);
+  const rolesLoading = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.isLoading || false);
+  const rolesError = useSelector(
+    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.roles as any)?.error,
+  );
+
+  // Fetch data when group changes
+  useEffect(() => {
+    if (group) {
+      // Reset to first tab when opening drawer
+      setActiveTab(0);
+      // Fetch members and roles data
+      dispatch(fetchMembersForGroup(group.uuid, undefined, { limit: 1000 }));
+      dispatch(fetchRolesForGroup(group.uuid, { limit: 1000 }));
+    }
+  }, [dispatch, group]);
+
+  // Users tab columns
+  const GROUP_USERS_COLUMNS: string[] = [
+    intl.formatMessage(messages.username),
+    intl.formatMessage(messages.firstName),
+    intl.formatMessage(messages.lastName),
+  ];
+
+  // Roles tab columns
+  const GROUP_ROLES_COLUMNS: string[] = [intl.formatMessage(messages.roles)];
+
+  // Render users tab content
+  const renderUsersTab = useCallback(() => {
+    // Show loading state
+    if (membersLoading) {
+      return (
+        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
+          <Spinner size="lg" aria-label="Loading group members" />
+        </div>
+      );
+    }
+
+    // Show error state
+    if (membersError) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="Unable to load users" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
+            <EmptyStateBody>{extractErrorMessage(membersError)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    // Show empty state when no users
+    if (members.length === 0) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader
+              titleText={intl.formatMessage(messages.usersEmptyStateTitle)}
+              icon={<EmptyStateIcon icon={UsersIcon} />}
+              headingLevel="h4"
+            />
+            <EmptyStateBody>{intl.formatMessage(messages.groupNoUsersAssigned)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    const userRows = members.map((user: User) => ({
+      key: user.username,
+      row: [user.username, user.first_name, user.last_name],
+      props: {},
+    }));
+
+    return (
+      <div className="pf-v5-u-pt-md">
+        <DataView ouiaId={`${ouiaId}-users-view`}>
+          <DataViewTable
+            variant="compact"
+            aria-label="Group Users Table"
+            ouiaId={`${ouiaId}-users-table`}
+            columns={GROUP_USERS_COLUMNS}
+            rows={userRows}
+          />
+        </DataView>
+      </div>
+    );
+  }, [intl, members, membersError, membersLoading, ouiaId]);
+
+  // Render roles tab content
+  const renderRolesTab = useCallback(() => {
+    // Show loading state
+    if (rolesLoading) {
+      return (
+        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
+          <Spinner size="lg" aria-label="Loading roles" />
+        </div>
+      );
+    }
+
+    // Show error state
+    if (rolesError) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="Unable to load roles" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
+            <EmptyStateBody>{extractErrorMessage(rolesError)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    // Show empty state when no roles
+    if (roles.length === 0) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader
+              titleText={intl.formatMessage(messages.rolesEmptyStateTitle)}
+              icon={<EmptyStateIcon icon={KeyIcon} />}
+              headingLevel="h4"
+            />
+            <EmptyStateBody>{intl.formatMessage(messages.groupNoRolesAssigned)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    const roleRows = roles.map((role: Role) => ({
+      key: role.uuid,
+      row: [role.display_name],
+      props: {},
+    }));
+
+    return (
+      <div className="pf-v5-u-pt-md">
+        <DataView ouiaId={`${ouiaId}-roles-view`}>
+          <DataViewTable
+            variant="compact"
+            aria-label="Group Roles Table"
+            ouiaId={`${ouiaId}-roles-table`}
+            columns={GROUP_ROLES_COLUMNS}
+            rows={roleRows}
+          />
+        </DataView>
+      </div>
+    );
+  }, [intl, ouiaId, roles, rolesError, rolesLoading]);
+
+  return (
+    <Drawer isExpanded={isOpen}>
+      <DrawerContent
+        panelContent={
+          group ? (
+            <DrawerPanelContent>
+              <DrawerHead>
+                <Title headingLevel="h2" size="lg">
+                  {group.name}
+                </Title>
+                <DrawerActions>
+                  <DrawerCloseButton onClick={onClose} />
+                </DrawerActions>
+              </DrawerHead>
+              <Tabs activeKey={activeTab} onSelect={(_, tabIndex) => setActiveTab(tabIndex)} isFilled>
+                <Tab eventKey={0} title={intl.formatMessage(messages.roles)}>
+                  <div className="pf-v5-u-p-md">{activeTab === 0 && renderRolesTab()}</div>
+                </Tab>
+                <Tab eventKey={1} title={intl.formatMessage(messages.users)}>
+                  <div className="pf-v5-u-p-md">{activeTab === 1 && renderUsersTab()}</div>
+                </Tab>
+              </Tabs>
+            </DrawerPanelContent>
+          ) : null
+        }
+      >
+        <DrawerContentBody>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.stories.tsx
@@ -107,7 +107,8 @@ The RoleAssignmentsTable displays groups and their role assignments in a workspa
 - \`isLoading\`: Loading state boolean
 - \`page\`: Current page number
 - \`perPage\`: Number of items per page
-- \`onPaginationChange\`: Callback when pagination changes
+- \`onSetPage\`: Callback when page changes
+- \`onPerPageSelect\`: Callback when per page changes
 - \`sortBy\`: Current sort field
 - \`direction\`: Current sort direction
 - \`onSort\`: Callback when sorting changes
@@ -144,9 +145,13 @@ The table handles long descriptions with tooltips and shows creation/modificatio
       description: 'Number of items per page',
       control: { type: 'number' },
     },
-    onPaginationChange: {
-      description: 'Callback when pagination changes',
-      action: 'pagination-changed',
+    onSetPage: {
+      description: 'Callback when page changes',
+      action: 'page-changed',
+    },
+    onPerPageSelect: {
+      description: 'Callback when per page changes',
+      action: 'per-page-changed',
     },
     sortBy: {
       description: 'Current sort field',
@@ -190,7 +195,8 @@ export const Default: Story = {
     isLoading: false,
     page: 1,
     perPage: 20,
-    onPaginationChange: fn(),
+    onSetPage: fn(),
+    onPerPageSelect: fn(),
     sortBy: 'name',
     direction: 'asc',
     onSort: fn(),
@@ -245,7 +251,8 @@ export const LoadingState: Story = {
     isLoading: true,
     page: 1,
     perPage: 20,
-    onPaginationChange: fn(),
+    onSetPage: fn(),
+    onPerPageSelect: fn(),
     sortBy: 'name',
     direction: 'asc',
     onSort: fn(),
@@ -288,7 +295,8 @@ export const EmptyState: Story = {
     isLoading: false,
     page: 1,
     perPage: 20,
-    onPaginationChange: fn(),
+    onSetPage: fn(),
+    onPerPageSelect: fn(),
     sortBy: 'name',
     direction: 'asc',
     onSort: fn(),
@@ -319,7 +327,8 @@ export const PaginationTest: Story = {
     isLoading: false,
     page: 1,
     perPage: 2,
-    onPaginationChange: fn(),
+    onSetPage: fn(),
+    onPerPageSelect: fn(),
     sortBy: 'name',
     direction: 'asc',
     onSort: fn(),
@@ -357,6 +366,11 @@ export const PaginationTest: Story = {
 
     // Test pagination callback when clicking next
     await userEvent.click(nextButtons[0]);
-    await expect(args.onPaginationChange).toHaveBeenCalledWith(2, 2);
+
+    // Verify the callback was called and the second argument is the page number
+    await expect(args.onSetPage).toHaveBeenCalled();
+    const mockFn = args.onSetPage as any;
+    const lastCall = mockFn.mock.calls[mockFn.mock.calls.length - 1];
+    expect(lastCall[1]).toBe(2); // Second argument should be the page number
   },
 };

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { useIntl } from 'react-intl';
 import { DataViewState, DataViewTextFilter, DataViewTh } from '@patternfly/react-data-view';
@@ -7,38 +7,15 @@ import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
 import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
 import { DataViewTable } from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
 import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
-import {
-  Drawer,
-  DrawerActions,
-  DrawerCloseButton,
-  DrawerContent,
-  DrawerContentBody,
-  DrawerHead,
-  DrawerPanelContent,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateHeader,
-  EmptyStateIcon,
-  Pagination,
-  Spinner,
-  Tab,
-  Tabs,
-  Title,
-  Tooltip,
-} from '@patternfly/react-core';
-import { ExclamationCircleIcon, KeyIcon, SearchIcon, UsersIcon } from '@patternfly/react-icons';
+import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, Pagination, Tooltip } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { ThProps } from '@patternfly/react-table';
 import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
 import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
 
 import { Group } from '../../../../redux/groups/reducer';
-import { fetchMembersForGroup, fetchRolesForGroup } from '../../../../redux/groups/actions';
-import { RBACStore } from '../../../../redux/store';
-import { extractErrorMessage } from '../../../../utilities/errorUtils';
-import { useDispatch, useSelector } from 'react-redux';
-import { User } from '../../../../redux/users/reducer';
-import { Role } from '../../../../redux/roles/reducer';
 import messages from '../../../../Messages';
+import { GroupDetailsDrawer } from './GroupDetailsDrawer';
 
 const EmptyTable: React.FC<{ titleText: string }> = ({ titleText }) => (
   <EmptyState>
@@ -88,27 +65,12 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
   ouiaId = 'iam-role-assignments-table',
 }) => {
   const intl = useIntl();
-  const dispatch = useDispatch();
 
   // Local state for drawer only
   const [focusedGroup, setFocusedGroup] = useState<Group | undefined>();
-  const [activeDrawerTab, setActiveDrawerTab] = useState<string | number>(0);
 
   // Selection hook
   const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
-
-  // Redux state for focused group data
-  const members = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.members?.data || []);
-  const membersLoading = useSelector((state: RBACStore) => (state.groupReducer?.selectedGroup?.members as any)?.isLoading || false);
-  const membersError = useSelector(
-    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.members as any)?.error,
-  );
-
-  const roles = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.data || []);
-  const rolesLoading = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.isLoading || false);
-  const rolesError = useSelector(
-    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.roles as any)?.error,
-  );
 
   // Define columns - matching the required columns from the spec
   const columns = useMemo(() => {
@@ -131,17 +93,6 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
   const onCloseDrawer = useCallback(() => {
     setFocusedGroup(undefined);
   }, []);
-
-  // Fetch data when focused group changes
-  useEffect(() => {
-    if (focusedGroup) {
-      // Reset to first tab when opening drawer
-      setActiveDrawerTab(0);
-      // Fetch members and roles data
-      dispatch(fetchMembersForGroup(focusedGroup.uuid, undefined, { limit: 1000 }));
-      dispatch(fetchRolesForGroup(focusedGroup.uuid, { limit: 1000 }));
-    }
-  }, [dispatch, focusedGroup]);
 
   // Calculate sortable columns
   const sortByIndex = useMemo(() => {
@@ -168,7 +119,7 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
   // Transform groups into table rows
   const rows = useMemo(() => {
     const handleRowClick = (event: any, group: Group | undefined) => {
-      if (event.target.matches('td') || event.target.matches('tr')) {
+      if (event.currentTarget.matches('td') || event.currentTarget.matches('tr')) {
         onRowClick(group);
       }
     };
@@ -198,206 +149,54 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
 
   const activeState = isLoading ? DataViewState.loading : groups.length === 0 ? DataViewState.empty : undefined;
 
-  // Users tab columns
-  const GROUP_USERS_COLUMNS: string[] = [
-    intl.formatMessage(messages.username),
-    intl.formatMessage(messages.firstName),
-    intl.formatMessage(messages.lastName),
-  ];
-
-  // Roles tab columns
-  const GROUP_ROLES_COLUMNS: string[] = [intl.formatMessage(messages.roles)];
-
-  // Drawer render functions
-  const renderUsersTab = () => {
-    // Show loading state
-    if (membersLoading) {
-      return (
-        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
-          <Spinner size="lg" aria-label="Loading group members" />
-        </div>
-      );
-    }
-
-    // Show error state
-    if (membersError) {
-      return (
-        <div className="pf-v5-u-pt-md">
-          <EmptyState variant="sm">
-            <EmptyStateHeader titleText="Unable to load users" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
-            <EmptyStateBody>{extractErrorMessage(membersError)}</EmptyStateBody>
-          </EmptyState>
-        </div>
-      );
-    }
-
-    // Show empty state when no users
-    if (members.length === 0) {
-      return (
-        <div className="pf-v5-u-pt-md">
-          <EmptyState variant="sm">
-            <EmptyStateHeader
-              titleText={intl.formatMessage(messages.usersEmptyStateTitle)}
-              icon={<EmptyStateIcon icon={UsersIcon} />}
-              headingLevel="h4"
-            />
-            <EmptyStateBody>{intl.formatMessage(messages.groupNoUsersAssigned)}</EmptyStateBody>
-          </EmptyState>
-        </div>
-      );
-    }
-
-    const userRows = members.map((user: User) => ({
-      row: [user.username, user.first_name, user.last_name],
-    }));
-
-    return (
-      <div className="pf-v5-u-pt-md">
-        <DataView ouiaId={`${ouiaId}-users-view`}>
-          <DataViewTable
-            variant="compact"
-            aria-label="Group Users Table"
-            ouiaId={`${ouiaId}-users-table`}
-            columns={GROUP_USERS_COLUMNS}
-            rows={userRows}
-          />
-        </DataView>
-      </div>
-    );
-  };
-
-  const renderRolesTab = () => {
-    // Show loading state
-    if (rolesLoading) {
-      return (
-        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
-          <Spinner size="lg" aria-label="Loading roles" />
-        </div>
-      );
-    }
-
-    // Show error state
-    if (rolesError) {
-      return (
-        <div className="pf-v5-u-pt-md">
-          <EmptyState variant="sm">
-            <EmptyStateHeader titleText="Unable to load roles" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
-            <EmptyStateBody>{extractErrorMessage(rolesError)}</EmptyStateBody>
-          </EmptyState>
-        </div>
-      );
-    }
-
-    // Show empty state when no roles
-    if (roles.length === 0) {
-      return (
-        <div className="pf-v5-u-pt-md">
-          <EmptyState variant="sm">
-            <EmptyStateHeader
-              titleText={intl.formatMessage(messages.rolesEmptyStateTitle)}
-              icon={<EmptyStateIcon icon={KeyIcon} />}
-              headingLevel="h4"
-            />
-            <EmptyStateBody>{intl.formatMessage(messages.groupNoRolesAssigned)}</EmptyStateBody>
-          </EmptyState>
-        </div>
-      );
-    }
-
-    const roleRows = roles.map((role: Role) => ({
-      row: [role.display_name],
-    }));
-
-    return (
-      <div className="pf-v5-u-pt-md">
-        <DataView ouiaId={`${ouiaId}-roles-view`}>
-          <DataViewTable
-            variant="compact"
-            aria-label="Group Roles Table"
-            ouiaId={`${ouiaId}-roles-table`}
-            columns={GROUP_ROLES_COLUMNS}
-            rows={roleRows}
-          />
-        </DataView>
-      </div>
-    );
-  };
-
   return (
-    <Drawer isExpanded={!!focusedGroup}>
-      <DrawerContent
-        panelContent={
-          focusedGroup ? (
-            <DrawerPanelContent>
-              <DrawerHead>
-                <Title headingLevel="h2" size="lg">
-                  {focusedGroup.name}
-                </Title>
-                <DrawerActions>
-                  <DrawerCloseButton onClick={onCloseDrawer} />
-                </DrawerActions>
-              </DrawerHead>
-              <Tabs activeKey={activeDrawerTab} onSelect={(_, tabIndex) => setActiveDrawerTab(tabIndex)} isFilled>
-                <Tab eventKey={0} title={intl.formatMessage(messages.roles)}>
-                  <div className="pf-v5-u-p-md">{activeDrawerTab === 0 && renderRolesTab()}</div>
-                </Tab>
-                <Tab eventKey={1} title={intl.formatMessage(messages.users)}>
-                  <div className="pf-v5-u-p-md">{activeDrawerTab === 1 && renderUsersTab()}</div>
-                </Tab>
-              </Tabs>
-            </DrawerPanelContent>
-          ) : null
-        }
-      >
-        <DrawerContentBody>
-          <DataView activeState={activeState} selection={selection}>
-            <DataViewToolbar
-              bulkSelect={
-                <BulkSelect
-                  isDataPaginated
-                  pageCount={groups.length}
-                  selectedCount={selection.selected?.length || 0}
-                  totalCount={totalCount}
-                  onSelect={(value) => {
-                    if (value === BulkSelectValue.none) {
-                      selection.onSelect?.(false);
-                    } else if (value === BulkSelectValue.page) {
-                      selection.onSelect?.(true, rows);
-                    } else if (value === BulkSelectValue.nonePage) {
-                      selection.onSelect?.(false, rows);
-                    }
-                  }}
-                />
-              }
-              pagination={
-                <Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} isCompact />
-              }
-              filters={
-                <DataViewFilters onChange={(_e, values) => onSetFilters(values)} values={filters}>
-                  <DataViewTextFilter filterId="name" title="User group" placeholder="Filter by user group" />
-                </DataViewFilters>
-              }
-              clearAllFilters={clearAllFilters}
-            />
-            <DataViewTable
-              variant="compact"
-              aria-label="Role Assignments Table"
-              ouiaId={`${ouiaId}-table`}
-              columns={sortableColumns}
-              rows={rows}
-              headStates={{ loading: <SkeletonTableHead columns={columns.map((column) => column.label)} /> }}
-              bodyStates={{
-                loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
-                empty: <EmptyTable titleText={intl.formatMessage(messages.userGroupsEmptyStateTitle)} />,
+    <GroupDetailsDrawer isOpen={!!focusedGroup} group={focusedGroup} onClose={onCloseDrawer} ouiaId={ouiaId}>
+      <DataView activeState={activeState} selection={selection}>
+        <DataViewToolbar
+          bulkSelect={
+            <BulkSelect
+              isDataPaginated
+              pageCount={groups.length}
+              selectedCount={selection.selected?.length || 0}
+              totalCount={totalCount}
+              onSelect={(value) => {
+                if (value === BulkSelectValue.none) {
+                  selection.onSelect?.(false);
+                } else if (value === BulkSelectValue.page) {
+                  selection.onSelect?.(true, rows);
+                } else if (value === BulkSelectValue.nonePage) {
+                  selection.onSelect?.(false, rows);
+                }
               }}
             />
-            <DataViewToolbar
-              ouiaId={`${ouiaId}-footer-toolbar`}
-              pagination={<Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} />}
-            />
-          </DataView>
-        </DrawerContentBody>
-      </DrawerContent>
-    </Drawer>
+          }
+          pagination={
+            <Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} isCompact />
+          }
+          filters={
+            <DataViewFilters onChange={(_e, values) => onSetFilters(values)} values={filters}>
+              <DataViewTextFilter filterId="name" title="User group" placeholder="Filter by user group" />
+            </DataViewFilters>
+          }
+          clearAllFilters={clearAllFilters}
+        />
+        <DataViewTable
+          variant="compact"
+          aria-label="Role Assignments Table"
+          ouiaId={`${ouiaId}-table`}
+          columns={sortableColumns}
+          rows={rows}
+          headStates={{ loading: <SkeletonTableHead columns={columns.map((column) => column.label)} /> }}
+          bodyStates={{
+            loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
+            empty: <EmptyTable titleText={intl.formatMessage(messages.userGroupsEmptyStateTitle)} />,
+          }}
+        />
+        <DataViewToolbar
+          ouiaId={`${ouiaId}-footer-toolbar`}
+          pagination={<Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} />}
+        />
+      </DataView>
+    </GroupDetailsDrawer>
   );
 };

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
@@ -241,7 +241,7 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
               icon={<EmptyStateIcon icon={UsersIcon} />}
               headingLevel="h4"
             />
-            <EmptyStateBody>This group currently has no users assigned to it.</EmptyStateBody>
+            <EmptyStateBody>{intl.formatMessage(messages.groupNoUsersAssigned)}</EmptyStateBody>
           </EmptyState>
         </div>
       );
@@ -298,7 +298,7 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
               icon={<EmptyStateIcon icon={KeyIcon} />}
               headingLevel="h4"
             />
-            <EmptyStateBody>This group currently has no roles assigned to it.</EmptyStateBody>
+            <EmptyStateBody>{intl.formatMessage(messages.groupNoRolesAssigned)}</EmptyStateBody>
           </EmptyState>
         </div>
       );

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
@@ -54,7 +54,8 @@ interface RoleAssignmentsTableProps {
   isLoading: boolean;
   page: number;
   perPage: number;
-  onPaginationChange: (page: number, perPage: number) => void;
+  onSetPage: (event: React.MouseEvent | React.KeyboardEvent | MouseEvent, page: number) => void;
+  onPerPageSelect: (event: React.MouseEvent | React.KeyboardEvent | MouseEvent, perPage: number) => void;
 
   // Sorting props
   sortBy?: string;
@@ -76,7 +77,8 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
   isLoading,
   page,
   perPage,
-  onPaginationChange,
+  onSetPage,
+  onPerPageSelect,
   sortBy = 'name',
   direction = 'asc',
   onSort,
@@ -121,21 +123,6 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
     return baseColumns.map((col, index) => ({ ...col, index }));
   }, [intl]);
 
-  // Handle pagination
-  const onSetPage = useCallback(
-    (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, page: number) => {
-      onPaginationChange(page, perPage);
-    },
-    [onPaginationChange, perPage],
-  );
-
-  const onPerPageSelect = useCallback(
-    (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, perPage: number) => {
-      onPaginationChange(1, perPage);
-    },
-    [onPaginationChange],
-  );
-
   // Drawer handlers
   const onRowClick = useCallback((group: Group | undefined) => {
     setFocusedGroup(group);
@@ -158,8 +145,7 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
 
   // Calculate sortable columns
   const sortByIndex = useMemo(() => {
-    const columnIndex = columns.findIndex((column) => column.key === sortBy);
-    return columnIndex;
+    return columns.findIndex((column) => column.key === sortBy);
   }, [sortBy, columns]);
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
@@ -250,7 +236,11 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
       return (
         <div className="pf-v5-u-pt-md">
           <EmptyState variant="sm">
-            <EmptyStateHeader titleText="No users found" icon={<EmptyStateIcon icon={UsersIcon} />} headingLevel="h4" />
+            <EmptyStateHeader
+              titleText={intl.formatMessage(messages.usersEmptyStateTitle)}
+              icon={<EmptyStateIcon icon={UsersIcon} />}
+              headingLevel="h4"
+            />
             <EmptyStateBody>This group currently has no users assigned to it.</EmptyStateBody>
           </EmptyState>
         </div>
@@ -303,7 +293,11 @@ export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
       return (
         <div className="pf-v5-u-pt-md">
           <EmptyState variant="sm">
-            <EmptyStateHeader titleText="No roles found" icon={<EmptyStateIcon icon={KeyIcon} />} headingLevel="h4" />
+            <EmptyStateHeader
+              titleText={intl.formatMessage(messages.rolesEmptyStateTitle)}
+              icon={<EmptyStateIcon icon={KeyIcon} />}
+              headingLevel="h4"
+            />
             <EmptyStateBody>This group currently has no roles assigned to it.</EmptyStateBody>
           </EmptyState>
         </div>

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.tsx
@@ -1,177 +1,409 @@
-import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
-import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
-import { EmptyState, EmptyStateBody, EmptyStateHeader, EmptyStateIcon, Pagination, Tooltip } from '@patternfly/react-core';
-import { DataViewState } from '@patternfly/react-data-view';
-import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
-import { DataViewTable } from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
-import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
-import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
-import { SearchIcon } from '@patternfly/react-icons';
-import { formatDistanceToNow } from 'date-fns';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
-import { PER_PAGE_OPTIONS } from '../../../../helpers/pagination';
-import messages from '../../../../Messages';
-import { Group } from '../../../../redux/groups/reducer';
+import { formatDistanceToNow } from 'date-fns';
+import { useIntl } from 'react-intl';
+import { DataViewState, DataViewTextFilter, DataViewTh } from '@patternfly/react-data-view';
+import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
+import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
+import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
+import { DataViewTable } from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
+import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
+import {
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelContent,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  Pagination,
+  Spinner,
+  Tab,
+  Tabs,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, KeyIcon, SearchIcon, UsersIcon } from '@patternfly/react-icons';
+import { ThProps } from '@patternfly/react-table';
+import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
+import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
 
-const EmptyTable: React.FunctionComponent<{ titleText: string }> = ({ titleText }) => {
-  return (
-    <EmptyState>
-      <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<EmptyStateIcon icon={SearchIcon} />} />
-      <EmptyStateBody>
-        <FormattedMessage
-          {...messages['roleAssignmentsEmptyStateSubtitle']}
-          values={{
-            br: <br />,
-          }}
-        />
-      </EmptyStateBody>
-    </EmptyState>
-  );
-};
+import { Group } from '../../../../redux/groups/reducer';
+import { fetchMembersForGroup, fetchRolesForGroup } from '../../../../redux/groups/actions';
+import { RBACStore } from '../../../../redux/store';
+import { extractErrorMessage } from '../../../../utilities/errorUtils';
+import { useDispatch, useSelector } from 'react-redux';
+import { User } from '../../../../redux/users/reducer';
+import { Role } from '../../../../redux/roles/reducer';
+import messages from '../../../../Messages';
+
+const EmptyTable: React.FC<{ titleText: string }> = ({ titleText }) => (
+  <EmptyState>
+    <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<EmptyStateIcon icon={SearchIcon} />} />
+    <EmptyStateBody>No user groups match the filter criteria. Remove all filters or clear all to show results.</EmptyStateBody>
+  </EmptyState>
+);
 
 interface RoleAssignmentsTableProps {
+  // Data props
   groups: Group[];
   totalCount: number;
   isLoading: boolean;
   page: number;
   perPage: number;
   onPaginationChange: (page: number, perPage: number) => void;
-  defaultPerPage?: number;
-  useUrlParams?: boolean;
-  enableActions?: boolean;
+
+  // Sorting props
+  sortBy?: string;
+  direction?: 'asc' | 'desc';
+  onSort: (event: React.MouseEvent | React.KeyboardEvent, key: string, direction: 'asc' | 'desc') => void;
+
+  // Filtering props
+  filters: { name: string };
+  onSetFilters: (filters: Partial<{ name: string }>) => void;
+  clearAllFilters: () => void;
+
+  // UI configuration props
   ouiaId?: string;
-  onChange?: (selectedGroups: unknown[]) => void;
-  focusedGroup?: Group;
 }
 
-export const RoleAssignmentsTable: React.FunctionComponent<RoleAssignmentsTableProps> = ({
+export const RoleAssignmentsTable: React.FC<RoleAssignmentsTableProps> = ({
   groups,
   totalCount,
   isLoading,
   page,
   perPage,
   onPaginationChange,
+  sortBy = 'name',
+  direction = 'asc',
+  onSort,
+  filters,
+  onSetFilters,
+  clearAllFilters,
   ouiaId = 'iam-role-assignments-table',
-  onChange,
 }) => {
-  const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
   const intl = useIntl();
+  const dispatch = useDispatch();
 
-  const COLUMNS: string[] = [
-    intl.formatMessage(messages['userGroup']),
-    intl.formatMessage(messages['description']),
-    intl.formatMessage(messages['users']),
-    intl.formatMessage(messages['roles']),
-    intl.formatMessage(messages['accessOrigin']),
-    intl.formatMessage(messages['lastModified']),
-  ];
+  // Local state for drawer only
+  const [focusedGroup, setFocusedGroup] = useState<Group | undefined>();
+  const [activeDrawerTab, setActiveDrawerTab] = useState<string | number>(0);
 
-  // Handle pagination changes
+  // Selection hook
+  const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
+
+  // Redux state for focused group data
+  const members = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.members?.data || []);
+  const membersLoading = useSelector((state: RBACStore) => (state.groupReducer?.selectedGroup?.members as any)?.isLoading || false);
+  const membersError = useSelector(
+    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.members as any)?.error,
+  );
+
+  const roles = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.data || []);
+  const rolesLoading = useSelector((state: RBACStore) => state.groupReducer?.selectedGroup?.roles?.isLoading || false);
+  const rolesError = useSelector(
+    (state: RBACStore) => state.groupReducer?.selectedGroup?.error || (state.groupReducer?.selectedGroup?.roles as any)?.error,
+  );
+
+  // Define columns - matching the required columns from the spec
+  const columns = useMemo(() => {
+    const baseColumns = [
+      { label: intl.formatMessage(messages.userGroup), key: 'name', sort: true },
+      { label: intl.formatMessage(messages.description), key: 'description', sort: false },
+      { label: intl.formatMessage(messages.users), key: 'principalCount', sort: true },
+      { label: intl.formatMessage(messages.roles), key: 'roleCount', sort: true },
+      { label: intl.formatMessage(messages.lastModified), key: 'modified', sort: true },
+    ];
+
+    return baseColumns.map((col, index) => ({ ...col, index }));
+  }, [intl]);
+
+  // Handle pagination
   const onSetPage = useCallback(
-    (event: any, page: number) => {
+    (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, page: number) => {
       onPaginationChange(page, perPage);
     },
     [onPaginationChange, perPage],
   );
 
   const onPerPageSelect = useCallback(
-    (event: any, perPage: number) => {
-      onPaginationChange(1, perPage); // Reset to page 1 when changing page size
+    (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, perPage: number) => {
+      onPaginationChange(1, perPage);
     },
     [onPaginationChange],
   );
 
-  const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
-  const { selected, onSelect, isSelected } = selection;
+  // Drawer handlers
+  const onRowClick = useCallback((group: Group | undefined) => {
+    setFocusedGroup(group);
+  }, []);
 
+  const onCloseDrawer = useCallback(() => {
+    setFocusedGroup(undefined);
+  }, []);
+
+  // Fetch data when focused group changes
   useEffect(() => {
-    if (isLoading) {
-      setActiveState(DataViewState.loading);
-    } else {
-      totalCount === 0 ? setActiveState(DataViewState.empty) : setActiveState(undefined);
+    if (focusedGroup) {
+      // Reset to first tab when opening drawer
+      setActiveDrawerTab(0);
+      // Fetch members and roles data
+      dispatch(fetchMembersForGroup(focusedGroup.uuid, undefined, { limit: 1000 }));
+      dispatch(fetchRolesForGroup(focusedGroup.uuid, { limit: 1000 }));
     }
-  }, [totalCount, isLoading]);
+  }, [dispatch, focusedGroup]);
 
-  useEffect(() => {
-    onChange?.(selected);
-  }, [selected]);
+  // Calculate sortable columns
+  const sortByIndex = useMemo(() => {
+    const columnIndex = columns.findIndex((column) => column.key === sortBy);
+    return columnIndex;
+  }, [sortBy, columns]);
 
-  const handleBulkSelect = (value: BulkSelectValue) => {
-    if (value === BulkSelectValue.none) {
-      onSelect(false);
-    } else if (value === BulkSelectValue.page) {
-      onSelect(true, rows);
-    } else if (value === BulkSelectValue.nonePage) {
-      onSelect(false, rows);
+  const getSortParams = (columnIndex: number): ThProps['sort'] => ({
+    sortBy: {
+      index: sortByIndex,
+      direction,
+      defaultDirection: 'asc',
+    },
+    onSort: (_event, index, direction) => onSort(_event, columns[index].key, direction),
+    columnIndex,
+  });
+
+  const sortableColumns: DataViewTh[] = columns.map((column, index) => ({
+    cell: column.label,
+    props: {
+      ...(column.sort ? { sort: getSortParams(index) } : {}),
+    },
+  }));
+
+  // Transform groups into table rows
+  const rows = useMemo(() => {
+    const handleRowClick = (event: any, group: Group | undefined) => {
+      if (event.target.matches('td') || event.target.matches('tr')) {
+        onRowClick(group);
+      }
+    };
+
+    return groups.map((group: Group) => ({
+      id: group.uuid,
+      row: [
+        group.name,
+        group.description ? (
+          <Tooltip isContentLeftAligned content={group.description}>
+            <span>{group.description.length > 23 ? `${group.description.slice(0, 20)}...` : group.description}</span>
+          </Tooltip>
+        ) : (
+          <div className="pf-v5-u-color-400">{intl.formatMessage(messages['usersAndUserGroupsNoDescription'])}</div>
+        ),
+        group.principalCount,
+        group.roleCount,
+        group.modified ? formatDistanceToNow(new Date(group.modified), { addSuffix: true }) : '',
+      ],
+      props: {
+        isClickable: true,
+        onRowClick: (event: any) => handleRowClick(event, focusedGroup?.uuid === group.uuid ? undefined : group),
+        isRowSelected: false,
+      },
+    }));
+  }, [groups, focusedGroup, intl, onRowClick]);
+
+  const activeState = isLoading ? DataViewState.loading : groups.length === 0 ? DataViewState.empty : undefined;
+
+  // Users tab columns
+  const GROUP_USERS_COLUMNS: string[] = [
+    intl.formatMessage(messages.username),
+    intl.formatMessage(messages.firstName),
+    intl.formatMessage(messages.lastName),
+  ];
+
+  // Roles tab columns
+  const GROUP_ROLES_COLUMNS: string[] = [intl.formatMessage(messages.roles)];
+
+  // Drawer render functions
+  const renderUsersTab = () => {
+    // Show loading state
+    if (membersLoading) {
+      return (
+        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
+          <Spinner size="lg" aria-label="Loading group members" />
+        </div>
+      );
     }
+
+    // Show error state
+    if (membersError) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="Unable to load users" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
+            <EmptyStateBody>{extractErrorMessage(membersError)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    // Show empty state when no users
+    if (members.length === 0) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="No users found" icon={<EmptyStateIcon icon={UsersIcon} />} headingLevel="h4" />
+            <EmptyStateBody>This group currently has no users assigned to it.</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    const userRows = members.map((user: User) => ({
+      row: [user.username, user.first_name, user.last_name],
+    }));
+
+    return (
+      <div className="pf-v5-u-pt-md">
+        <DataView ouiaId={`${ouiaId}-users-view`}>
+          <DataViewTable
+            variant="compact"
+            aria-label="Group Users Table"
+            ouiaId={`${ouiaId}-users-table`}
+            columns={GROUP_USERS_COLUMNS}
+            rows={userRows}
+          />
+        </DataView>
+      </div>
+    );
   };
 
-  const rows = useMemo(
-    () =>
-      groups.map((group: Group) => ({
-        id: group.uuid,
-        row: [
-          group.name,
-          group.description ? (
-            <Tooltip isContentLeftAligned content={group.description}>
-              <span>{group.description.length > 23 ? group.description.slice(0, 20) + '...' : group.description}</span>
-            </Tooltip>
-          ) : (
-            <div className="pf-v5-u-color-400">{intl.formatMessage(messages['usersAndUserGroupsNoDescription'])}</div>
-          ),
-          group.principalCount,
-          group.roleCount,
-          '?', // not currently in API
-          group.modified ? formatDistanceToNow(new Date(group.modified), { addSuffix: true }) : '',
-        ],
-      })),
-    [groups],
-  );
-  const pageSelected = rows.length > 0 && rows.every(isSelected);
-  const pagePartiallySelected = !pageSelected && rows.some(isSelected);
+  const renderRolesTab = () => {
+    // Show loading state
+    if (rolesLoading) {
+      return (
+        <div className="pf-v5-u-pt-md pf-v5-u-text-align-center">
+          <Spinner size="lg" aria-label="Loading roles" />
+        </div>
+      );
+    }
 
-  const paginationComponent = (
-    <Pagination
-      perPageOptions={PER_PAGE_OPTIONS}
-      itemCount={totalCount}
-      page={page}
-      perPage={perPage}
-      onSetPage={onSetPage}
-      onPerPageSelect={onPerPageSelect}
-    />
-  );
+    // Show error state
+    if (rolesError) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="Unable to load roles" icon={<EmptyStateIcon icon={ExclamationCircleIcon} />} headingLevel="h4" />
+            <EmptyStateBody>{extractErrorMessage(rolesError)}</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    // Show empty state when no roles
+    if (roles.length === 0) {
+      return (
+        <div className="pf-v5-u-pt-md">
+          <EmptyState variant="sm">
+            <EmptyStateHeader titleText="No roles found" icon={<EmptyStateIcon icon={KeyIcon} />} headingLevel="h4" />
+            <EmptyStateBody>This group currently has no roles assigned to it.</EmptyStateBody>
+          </EmptyState>
+        </div>
+      );
+    }
+
+    const roleRows = roles.map((role: Role) => ({
+      row: [role.display_name],
+    }));
+
+    return (
+      <div className="pf-v5-u-pt-md">
+        <DataView ouiaId={`${ouiaId}-roles-view`}>
+          <DataViewTable
+            variant="compact"
+            aria-label="Group Roles Table"
+            ouiaId={`${ouiaId}-roles-table`}
+            columns={GROUP_ROLES_COLUMNS}
+            rows={roleRows}
+          />
+        </DataView>
+      </div>
+    );
+  };
 
   return (
-    <DataView ouiaId={ouiaId} selection={selection} activeState={activeState}>
-      <DataViewToolbar
-        ouiaId={`${ouiaId}-header-toolbar`}
-        bulkSelect={
-          <BulkSelect
-            isDataPaginated
-            pageCount={groups.length}
-            selectedCount={selected.length}
-            totalCount={totalCount}
-            pageSelected={pageSelected}
-            pagePartiallySelected={pagePartiallySelected}
-            onSelect={handleBulkSelect}
-          />
+    <Drawer isExpanded={!!focusedGroup}>
+      <DrawerContent
+        panelContent={
+          focusedGroup ? (
+            <DrawerPanelContent>
+              <DrawerHead>
+                <Title headingLevel="h2" size="lg">
+                  {focusedGroup.name}
+                </Title>
+                <DrawerActions>
+                  <DrawerCloseButton onClick={onCloseDrawer} />
+                </DrawerActions>
+              </DrawerHead>
+              <Tabs activeKey={activeDrawerTab} onSelect={(_, tabIndex) => setActiveDrawerTab(tabIndex)} isFilled>
+                <Tab eventKey={0} title={intl.formatMessage(messages.roles)}>
+                  <div className="pf-v5-u-p-md">{activeDrawerTab === 0 && renderRolesTab()}</div>
+                </Tab>
+                <Tab eventKey={1} title={intl.formatMessage(messages.users)}>
+                  <div className="pf-v5-u-p-md">{activeDrawerTab === 1 && renderUsersTab()}</div>
+                </Tab>
+              </Tabs>
+            </DrawerPanelContent>
+          ) : null
         }
-        pagination={React.cloneElement(paginationComponent, { isCompact: true })}
-      />
-      <DataViewTable
-        variant="compact"
-        aria-label="Role assignments table"
-        ouiaId={`${ouiaId}-table`}
-        columns={COLUMNS}
-        rows={rows}
-        headStates={{ loading: <SkeletonTableHead columns={COLUMNS} /> }}
-        bodyStates={{
-          loading: <SkeletonTableBody rowsCount={10} columnsCount={COLUMNS.length} />,
-          empty: <EmptyTable titleText={intl.formatMessage(messages.userGroupsEmptyStateTitle)} />,
-        }}
-      />
-      <DataViewToolbar ouiaId={`${ouiaId}-footer-toolbar`} pagination={paginationComponent} />
-    </DataView>
+      >
+        <DrawerContentBody>
+          <DataView activeState={activeState} selection={selection}>
+            <DataViewToolbar
+              bulkSelect={
+                <BulkSelect
+                  isDataPaginated
+                  pageCount={groups.length}
+                  selectedCount={selection.selected?.length || 0}
+                  totalCount={totalCount}
+                  onSelect={(value) => {
+                    if (value === BulkSelectValue.none) {
+                      selection.onSelect?.(false);
+                    } else if (value === BulkSelectValue.page) {
+                      selection.onSelect?.(true, rows);
+                    } else if (value === BulkSelectValue.nonePage) {
+                      selection.onSelect?.(false, rows);
+                    }
+                  }}
+                />
+              }
+              pagination={
+                <Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} isCompact />
+              }
+              filters={
+                <DataViewFilters onChange={(_e, values) => onSetFilters(values)} values={filters}>
+                  <DataViewTextFilter filterId="name" title="User group" placeholder="Filter by user group" />
+                </DataViewFilters>
+              }
+              clearAllFilters={clearAllFilters}
+            />
+            <DataViewTable
+              variant="compact"
+              aria-label="Role Assignments Table"
+              ouiaId={`${ouiaId}-table`}
+              columns={sortableColumns}
+              rows={rows}
+              headStates={{ loading: <SkeletonTableHead columns={columns.map((column) => column.label)} /> }}
+              bodyStates={{
+                loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
+                empty: <EmptyTable titleText={intl.formatMessage(messages.userGroupsEmptyStateTitle)} />,
+              }}
+            />
+            <DataViewToolbar
+              ouiaId={`${ouiaId}-footer-toolbar`}
+              pagination={<Pagination perPage={perPage} page={page} itemCount={totalCount} onSetPage={onSetPage} onPerPageSelect={onPerPageSelect} />}
+            />
+          </DataView>
+        </DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
   );
 };

--- a/src/features/workspaces/workspace-detail/components/index.ts
+++ b/src/features/workspaces/workspace-detail/components/index.ts
@@ -1,0 +1,7 @@
+export { GroupDetailsDrawer } from './GroupDetailsDrawer';
+export { RoleAssignmentsTable } from './RoleAssignmentsTable';
+
+// Re-export types that might be needed by consumers
+export type { Group } from '../../../../redux/groups/reducer';
+export type { User } from '../../../../redux/users/reducer';
+export type { Role } from '../../../../redux/roles/reducer';


### PR DESCRIPTION
For [RHCLOUD-41321](https://issues.redhat.com/browse/RHCLOUD-41321). Since the WS roles API isn't ready, we're just displaying all groups via a `fetchGroups` call. This table replaces the current table with added drawer capabilities to shows the roles and users associated with a user group.


https://github.com/user-attachments/assets/9b3588cd-b1cd-49c1-83a9-ff5f0b1e325a

## Summary by Sourcery

Introduce an enhanced RoleAssignmentsTable for workspace details with sorting, filtering, and interactive drawers showing group-specific roles and users; integrate Redux-based data fetching and update WorkspaceDetail and Storybook accordingly.

New Features:
- Add clickable rows in RoleAssignmentsTable that open a drawer with Users and Roles tabs
- Enable sorting and filtering of user groups directly within the RoleAssignmentsTable
- Fetch group members and roles via Redux actions when a drawer is opened

Enhancements:
- Replace the previous table implementation with a PatternFly DataView-based table supporting bulk selection, pagination, and filters
- Extend WorkspaceDetail to manage sort, direction, and filter state and pass them to the fetchGroups API call
- Update Storybook stories to provide a mocked Redux store, include new sorting and filtering controls, and adjust play tests to validate skeleton loads, headers, and interactions

Tests:
- Enhance Storybook play functions to verify skeleton states, header presence, and new table behaviors