### PR TITLE
Fix for WS wizard pathing and close/submit

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1112,7 +1112,7 @@ export default defineMessages({
   createWorkspaceSuccessTitle: {
     id: 'createWorkspaceSuccessTitle',
     description: 'Create workspace success notification title',
-    defaultMessage: 'New {name} workspace have been successfully created',
+    defaultMessage: 'New {name} workspace has been successfully created',
   },
   createWorkspaceErrorTitle: {
     id: 'createWorkspaceErrorTitle',

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2818,4 +2818,9 @@ export default defineMessages({
     description: 'Message when group has no roles assigned',
     defaultMessage: 'This group currently has no roles assigned to it.',
   },
+  creatingWorkspaceCancel: {
+    id: 'creatingWorkspaceCancel',
+    description: 'Create workspace canceled notification description',
+    defaultMessage: 'Workspace creation was canceled by the user.',
+  },
 });

--- a/src/features/workspaces/components/WorkspaceListTable.tsx
+++ b/src/features/workspaces/components/WorkspaceListTable.tsx
@@ -308,7 +308,7 @@ export const WorkspaceListTable: React.FC<WorkspaceListTableProps> = ({
             }
             actions={
               <>
-                <Button variant="primary" onClick={() => navigate(pathnames['create-workspace'].path)}>
+                <Button variant="primary" onClick={() => navigate(pathnames['create-workspace'].link)}>
                   {intl.formatMessage(messages.createWorkspace)}
                 </Button>
                 {globalWs && (

--- a/src/features/workspaces/create-workspace/CreateWorkspaceWizard.tsx
+++ b/src/features/workspaces/create-workspace/CreateWorkspaceWizard.tsx
@@ -47,7 +47,7 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
       addNotification({
         variant: 'warning',
         title: intl.formatMessage(messages.createWorkspace),
-        description: 'Workspace creation has been canceled.',
+        description: intl.formatMessage(messages.creatingWorkspaceCancel),
       }),
     );
     navigate(pathnames.workspaces.link);

--- a/src/features/workspaces/create-workspace/CreateWorkspaceWizard.tsx
+++ b/src/features/workspaces/create-workspace/CreateWorkspaceWizard.tsx
@@ -5,15 +5,20 @@ import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';
 import { useFlag } from '@unleash/proxy-client-react';
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { createWorkspace } from '../../../redux/workspaces/actions';
+import { useIntl } from 'react-intl';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/';
+import useAppNavigate from '../../../hooks/useAppNavigate';
+import pathnames from '../../../utilities/pathnames';
+import messages from '../../../Messages';
+import { createWorkspace, fetchWorkspaces } from '../../../redux/workspaces/actions';
 import { ReviewStep as Review } from './components/Review';
 import { WORKSPACE_DESCRIPTION, WORKSPACE_NAME, WORKSPACE_PARENT, schemaBuilder } from './schema';
 import { SetDetails } from './components/SetDetails';
 import { SetEarMark } from './components/SetEarMark';
 
 export interface CreateWorkspaceWizardProps {
-  afterSubmit: () => void;
-  onCancel: () => void;
+  afterSubmit?: () => void;
+  onCancel?: () => void;
 }
 
 const FormTemplate = (props: FormTemplateCommonProps) => <Pf4FormTemplate {...props} showFormControls={false} />;
@@ -26,7 +31,27 @@ export const mapperExtension = {
 
 export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizardProps> = ({ afterSubmit, onCancel }) => {
   const dispatch = useDispatch();
+  const intl = useIntl();
+  const navigate = useAppNavigate();
   const enableFeatures = useFlag('platform.rbac.workspaces-billing-features');
+
+  // Default handlers for when component is used as a route element
+  const defaultAfterSubmit = () => {
+    // Refresh workspaces list to show the newly created workspace
+    dispatch(fetchWorkspaces());
+    navigate(pathnames.workspaces.link);
+  };
+
+  const defaultOnCancel = () => {
+    dispatch(
+      addNotification({
+        variant: 'warning',
+        title: intl.formatMessage(messages.createWorkspace),
+        description: 'Workspace creation has been canceled.',
+      }),
+    );
+    navigate(pathnames.workspaces.link);
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (_v: any, form: any) => {
@@ -38,7 +63,7 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
         parent_id: values[WORKSPACE_PARENT].id,
       }),
     );
-    afterSubmit();
+    (afterSubmit || defaultAfterSubmit)();
   };
 
   return (
@@ -47,7 +72,7 @@ export const CreateWorkspaceWizard: React.FunctionComponent<CreateWorkspaceWizar
       componentMapper={{ ...componentMapper, ...mapperExtension }}
       FormTemplate={FormTemplate}
       onSubmit={onSubmit}
-      onCancel={onCancel}
+      onCancel={onCancel || defaultOnCancel}
     />
   );
 };

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -128,7 +128,7 @@
     "createWorkspace": "Create workspace",
     "createWorkspaceErrorDescription": "The workspace was not created successfuly.",
     "createWorkspaceErrorTitle": "Failed creating {name} workspace",
-    "createWorkspaceSuccessTitle": "New {name} workspace have been successfully created",
+    "createWorkspaceSuccessTitle": "New {name} workspace has been successfully created",
     "creatingGroup": "Creating a group",
     "creatingRoleCanceled": "Creating role was canceled by the user",
     "deactivateUsersButton": "Deactivate users",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -127,7 +127,7 @@
   "createWorkspace": "Create workspace",
   "createWorkspaceErrorDescription": "The workspace was not created successfuly.",
   "createWorkspaceErrorTitle": "Failed creating {name} workspace",
-  "createWorkspaceSuccessTitle": "New {name} workspace have been successfully created",
+  "createWorkspaceSuccessTitle": "New {name} workspace has been successfully created",
   "creatingGroup": "Creating a group",
   "creatingRoleCanceled": "Creating role was canceled by the user",
   "deactivateUsersButton": "Deactivate users",


### PR DESCRIPTION
Create WS was pathing to the default user's table as it was trying to nav to `create-workspace` instead of `workspaces/create-workspace`. After getting that fixed, the wizard itself was throwing errors on close and submit.

https://github.com/user-attachments/assets/ca42652f-ca2d-4248-938c-cfe08170a819

## Summary by Sourcery

Fix workspace creation wizard routing and implement default submit and cancel handlers to prevent errors and improve user experience.

Bug Fixes:
- Correct navigation path for workspace creation in the workspace list table and wizard routing
- Provide default onCancel and afterSubmit handlers to avoid errors when closing or submitting the wizard

Enhancements:
- Refresh workspace list and navigate back to the workspaces page after successful creation
- Display a warning notification when the workspace creation wizard is canceled

Documentation:
- Fix grammar in the workspace creation success notification message