### PR TITLE
fix(roles): when navigating from my user access

### DIFF
--- a/src/features/roles/role-table-helpers.js
+++ b/src/features/roles/role-table-helpers.js
@@ -45,7 +45,7 @@ export const createRows = (data, selectedRows, intl, expanded, adminGroup) =>
                   ouiaId="role-in-groups-nested-table"
                   variant={TableVariant.compact}
                   cells={[intl.formatMessage(messages.groupName), intl.formatMessage(messages.description), ' ']}
-                  rows={groups.map((group) => ({
+                  rows={groups?.map((group) => ({
                     cells: [
                       { title: <AppLink to={pathnames['group-detail'].link.replace(':groupId', group.uuid)}>{group.name}</AppLink> },
                       group.description,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When user navigates to my user access and then to roles, the UI breaks because of incorrect access to object. This PR fixes it by checking first if groups exists and only after that render the table.

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1709" height="711" alt="Screenshot 2025-08-21 at 10 42 52" src="https://github.com/user-attachments/assets/15a12db7-6289-4221-9e18-b9e5498973f3" />


#### After:
<img width="1717" height="849" alt="Screenshot 2025-08-21 at 10 43 01" src="https://github.com/user-attachments/assets/6f78ddd3-2c1b-41cf-b312-de75f8e9c477" />


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Bug Fixes:
- Guard against undefined 'groups' in role-table-helpers by using optional chaining before rendering rows.