### PR TITLE
feat(serviceaccountslist): convert service-accounts-list to use DataViewTable

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1723,6 +1723,11 @@ export default defineMessages({
     description: 'No service accounts message',
     defaultMessage: 'No service accounts found',
   },
+  groupServiceAccountEmptyStateBody: {
+    id: 'groupServiceAccountEmptyStateBody',
+    description: 'No service accounts for this group message',
+    defaultMessage: 'No service accounts found for this group.',
+  },
   contactServiceTeamForAccounts: {
     id: 'contactServiceTeamForAccounts',
     description: 'Contact service team to add accounts message',

--- a/src/features/groups/add-group/service-accounts-list.scss
+++ b/src/features/groups/add-group/service-accounts-list.scss
@@ -1,5 +1,13 @@
 .rbac-service-accounts-list {
+  
     .ins-c-conditional-filter {
         display: none;
+    }
+
+    .pf-v5-c-table {
+        th, td {
+            word-wrap: break-word;
+            overflow-wrap: anywhere;
+        }
     }
 }

--- a/src/features/groups/add-group/service-accounts-list.tsx
+++ b/src/features/groups/add-group/service-accounts-list.tsx
@@ -1,22 +1,31 @@
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import React, { Dispatch, Fragment, SetStateAction, useCallback, useEffect } from 'react';
-import { useIntl } from 'react-intl';
+import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { IntlShape, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
+import { useDataViewPagination, useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
+import { DataView, DataViewState } from '@patternfly/react-data-view/dist/dynamic/DataView';
+import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
+import { DataViewTable } from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
+import { DataViewTh, DataViewTr } from '@patternfly/react-data-view';
+import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
+import { EmptyState, EmptyStateBody, EmptyStateHeader, Pagination } from '@patternfly/react-core';
+import { SkeletonTable, SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
+import { TableVariant } from '@patternfly/react-table';
+import { SearchIcon } from '@patternfly/react-icons';
 import { LAST_PAGE } from '../../../redux/service-accounts/constants';
 import { ServiceAccount } from '../../../redux/service-accounts/types';
 import { getDateFormat } from '../../../helpers/stringUtilities';
 import messages from '../../../Messages';
-import { TableToolbarView } from '../../../components/tables/TableToolbarView';
 import { fetchServiceAccounts } from '../../../redux/service-accounts/actions';
 import { ServiceAccountsState } from '../../../redux/service-accounts/reducer';
 import { PaginationProps } from '../service-account/add-group-service-accounts';
+import { PER_PAGE_OPTIONS } from '../../../helpers/pagination';
 import './service-accounts-list.scss';
 
 interface ServiceAccountsListProps {
   selected: ServiceAccount[];
   setSelected: Dispatch<SetStateAction<ServiceAccount[]>>;
-  // optional group ID to check whether SA are assigned to selected group
   groupId?: string;
 }
 
@@ -28,35 +37,48 @@ const reducer = ({ serviceAccountReducer }: { serviceAccountReducer: ServiceAcco
   offset: serviceAccountReducer.offset,
 });
 
-const createRows = (data: ServiceAccount[], checkedRows: ServiceAccount[]) =>
-  data?.reduce(
-    (acc: any[], curr: ServiceAccount) => [
-      ...acc,
-      {
-        uuid: curr.uuid,
-        title: curr.name,
-        cells: [
-          curr.name,
-          curr.description,
-          curr.clientId,
-          curr.createdBy,
-          <Fragment key={`${curr.name}-modified`}>
-            <DateFormat date={curr.createdAt} type={getDateFormat(String(curr.createdAt))} />
-          </Fragment>,
-        ],
-        selected: Boolean(checkedRows && checkedRows.find((row: ServiceAccount) => row.uuid === curr.uuid)) || curr.assignedToSelectedGroup,
-        disableSelection: curr.assignedToSelectedGroup,
-      },
-    ],
-    [],
+const EmptyTable: React.FunctionComponent<{ titleText: string; bodyText: string }> = ({ titleText, bodyText }) => {
+  return (
+    <EmptyState>
+      <EmptyStateHeader titleText={titleText} headingLevel="h4" icon={<SearchIcon />} />
+      <EmptyStateBody>{bodyText}</EmptyStateBody>
+    </EmptyState>
   );
+};
 
 export const ServiceAccountsList: React.FunctionComponent<ServiceAccountsListProps> = ({ selected, setSelected, groupId }) => {
   const { auth, getEnvironmentDetails } = useChrome();
   const { serviceAccounts, status, limit, offset, isLoading } = useSelector(reducer);
+  const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
 
   const dispatch = useDispatch();
   const intl = useIntl();
+
+  const pagination = useDataViewPagination({ perPage: limit || 20 });
+  const { page, perPage, onSetPage, onPerPageSelect } = pagination;
+
+  const selection = useDataViewSelection({
+    matchOption: (a, b) => a.id === b.id,
+  });
+  const { selected: dataViewSelected, onSelect, isSelected } = selection;
+
+  useEffect(() => {
+    const selectedServiceAccounts = serviceAccounts.filter((serviceAccount) =>
+      dataViewSelected.some((selected) => selected.id === serviceAccount.uuid),
+    );
+    setSelected(selectedServiceAccounts);
+  }, [dataViewSelected, serviceAccounts, setSelected]);
+
+  useEffect(() => {
+    const dataViewItems = serviceAccounts.map((serviceAccount) => ({ id: serviceAccount.uuid }));
+    const selectedItems = dataViewItems.filter((item) => selected.some((serviceAccount) => serviceAccount.uuid === item.id));
+    if (selectedItems.length !== dataViewSelected.length || !selectedItems.every((item) => dataViewSelected.some((s) => s.id === item.id))) {
+      onSelect(false);
+      if (selectedItems.length > 0) {
+        onSelect(true, selectedItems);
+      }
+    }
+  }, [selected]);
 
   const fetchAccounts = useCallback(
     async (props?: PaginationProps) => {
@@ -64,69 +86,137 @@ export const ServiceAccountsList: React.FunctionComponent<ServiceAccountsListPro
       const token = await auth.getToken();
       dispatch(
         fetchServiceAccounts({
-          limit: props?.limit ?? limit,
-          offset: props?.offset ?? offset,
+          limit: props?.limit ?? perPage,
+          offset: props?.offset ?? (page - 1) * perPage,
           token,
           sso: env?.sso,
           groupId,
         }),
       );
     },
-    [limit, offset],
+    [perPage, page, groupId],
   );
 
   useEffect(() => {
-    fetchAccounts({ limit, offset: 0 });
-  }, []);
+    fetchAccounts({ limit: perPage, offset: (page - 1) * perPage });
+  }, [fetchAccounts]);
 
-  const columns = [
-    { title: intl.formatMessage(messages.name), orderBy: 'name' },
-    { title: intl.formatMessage(messages.description), orderBy: 'description' },
-    { title: intl.formatMessage(messages.clientId), orderBy: 'clientId' },
-    { title: intl.formatMessage(messages.owner), orderBy: 'owner' },
-    { title: intl.formatMessage(messages.timeCreated), orderBy: 'timeCreated' },
+  useEffect(() => {
+    if (isLoading) {
+      setActiveState(DataViewState.loading);
+    } else {
+      serviceAccounts.length === 0 ? setActiveState(DataViewState.empty) : setActiveState(undefined);
+    }
+  }, [serviceAccounts.length, isLoading]);
+
+  const COLUMN_HEADERS = [
+    { label: intl.formatMessage(messages.name), key: 'name', index: 0 },
+    { label: intl.formatMessage(messages.description), key: 'description', index: 1 },
+    { label: intl.formatMessage(messages.clientId), key: 'clientId', index: 2 },
+    { label: intl.formatMessage(messages.owner), key: 'owner', index: 3 },
+    { label: intl.formatMessage(messages.timeCreated), key: 'timeCreated', index: 4 },
   ];
 
+  const columns: DataViewTh[] = COLUMN_HEADERS.map((column) => ({
+    cell: column.label,
+    props: {},
+  }));
+
+  const rows: DataViewTr[] = useMemo(() => {
+    return serviceAccounts.map((serviceAccount: ServiceAccount) => ({
+      id: serviceAccount.uuid,
+      row: Object.values({
+        name: serviceAccount.name,
+        description: serviceAccount.description || '',
+        clientId: serviceAccount.clientId,
+        owner: serviceAccount.createdBy,
+        timeCreated: <DateFormat date={serviceAccount.createdAt} type={getDateFormat(String(serviceAccount.createdAt))} />,
+      }),
+      props: {
+        isRowSelected: selected.some((selectedServiceAccount) => selectedServiceAccount.uuid === serviceAccount.uuid),
+      },
+    }));
+  }, [serviceAccounts, selected]);
+
+  const handleBulkSelect = (value: BulkSelectValue) => {
+    const selectableRows = rows.filter((row) => {
+      const serviceAccount = serviceAccounts.find((serviceAccount) => serviceAccount.uuid === (row as any).id);
+      return !serviceAccount?.assignedToSelectedGroup;
+    });
+
+    value === BulkSelectValue.none && onSelect(false);
+    value === BulkSelectValue.all && onSelect(true, selectableRows);
+    value === BulkSelectValue.nonePage && onSelect(false, rows);
+    value === BulkSelectValue.page && onSelect(true, selectableRows);
+  };
+
+  const pageSelected = rows.length > 0 && rows.every(isSelected);
+  const pagePartiallySelected = !pageSelected && rows.some(isSelected);
+  const totalCount = status === LAST_PAGE ? offset + serviceAccounts.length : offset + serviceAccounts.length + 1;
+
+  const ouiaId = 'group-add-service-accounts';
+
   return (
-    <TableToolbarView
-      className="rbac-service-accounts-list"
-      columns={columns}
-      isSelectable
-      rows={createRows(serviceAccounts, selected)}
-      data={serviceAccounts}
-      fetchData={fetchAccounts}
-      isLoading={isLoading}
-      pagination={{
-        limit,
-        offset,
-        ...(status === LAST_PAGE ? { count: offset + serviceAccounts.length } : {}),
-      }}
-      paginationProps={{
-        toggleTemplate: () => (
-          <>
-            <b>
-              {offset + 1} - {offset + serviceAccounts.length}
-            </b>{' '}
-            of <b>{status === LAST_PAGE ? offset + serviceAccounts.length : 'many'}</b>
-          </>
-        ),
-        isCompact: true,
-      }}
-      checkedRows={selected}
-      setCheckedItems={setSelected}
-      titlePlural={intl.formatMessage(messages.serviceAccounts).toLowerCase()}
-      titleSingular={intl.formatMessage(messages.serviceAccount)}
-      emptyProps={{
-        title: intl.formatMessage(messages.noServiceAccountsFound),
-        description: [intl.formatMessage(messages.contactServiceTeamForAccounts), ''],
-      }}
-      tableId="group-add-accounts"
-      ouiaId="group-add-accounts"
-      toolbarButtons={() => []}
-      routes={() => null}
-      setFilterValue={() => {}}
-      filters={[]}
-    />
+    <div className="rbac-service-accounts-list">
+      <DataView ouiaId={ouiaId} selection={selection} activeState={activeState}>
+        <DataViewToolbar
+          ouiaId={`${ouiaId}-header-toolbar`}
+          bulkSelect={
+            <BulkSelect
+              isDataPaginated
+              pageCount={serviceAccounts.length}
+              totalCount={totalCount}
+              selectedCount={dataViewSelected.length}
+              pageSelected={pageSelected}
+              pagePartiallySelected={pagePartiallySelected}
+              onSelect={handleBulkSelect}
+            />
+          }
+          pagination={
+            <Pagination
+              perPageOptions={PER_PAGE_OPTIONS}
+              itemCount={totalCount}
+              page={page}
+              perPage={perPage}
+              onSetPage={onSetPage}
+              onPerPageSelect={onPerPageSelect}
+            />
+          }
+        />
+        {isLoading ? (
+          <SkeletonTable rowsCount={10} columns={columns} variant={TableVariant.compact} />
+        ) : (
+          <DataViewTable
+            columns={columns}
+            rows={rows}
+            ouiaId={`${ouiaId}-table`}
+            headStates={{ loading: <SkeletonTableHead columns={columns} /> }}
+            bodyStates={{
+              loading: <SkeletonTableBody rowsCount={10} columnsCount={columns.length} />,
+              empty: (
+                <EmptyTable
+                  titleText={intl.formatMessage(messages.noServiceAccountsFound)}
+                  bodyText={intl.formatMessage(messages.groupServiceAccountEmptyStateBody)}
+                />
+              ),
+            }}
+          />
+        )}
+        <DataViewToolbar
+          ouiaId={`${ouiaId}-footer-toolbar`}
+          pagination={
+            <Pagination
+              perPageOptions={PER_PAGE_OPTIONS}
+              itemCount={totalCount}
+              page={page}
+              perPage={perPage}
+              onSetPage={onSetPage}
+              onPerPageSelect={onPerPageSelect}
+            />
+          }
+        />
+      </DataView>
+    </div>
   );
 };
 

--- a/src/features/groups/add-group/service-accounts-list.tsx
+++ b/src/features/groups/add-group/service-accounts-list.tsx
@@ -1,7 +1,7 @@
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
-import { IntlShape, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { useDataViewPagination, useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
 import { DataView, DataViewState } from '@patternfly/react-data-view/dist/dynamic/DataView';

--- a/src/features/groups/add-group/service-accounts-list.tsx
+++ b/src/features/groups/add-group/service-accounts-list.tsx
@@ -187,6 +187,7 @@ export const ServiceAccountsList: React.FunctionComponent<ServiceAccountsListPro
           <SkeletonTable rowsCount={10} columns={columns} variant={TableVariant.compact} />
         ) : (
           <DataViewTable
+            variant="compact"
             columns={columns}
             rows={rows}
             ouiaId={`${ouiaId}-table`}

--- a/src/test/smart-components/group/service-account/__snapshots__/add-group-service-accounts.test.js.snap
+++ b/src/test/smart-components/group/service-account/__snapshots__/add-group-service-accounts.test.js.snap
@@ -123,53 +123,716 @@ exports[`<AddGroupServiceAccounts /> should render correctly empty 1`] = `
                 class="rbac-service-accounts-list"
               >
                 <div
-                  class="pf-v5-c-empty-state pf-m-sm"
+                  class="pf-v5-l-stack"
+                  data-ouia-component-id="group-add-service-accounts-stack"
                 >
                   <div
-                    class="pf-v5-c-empty-state__content"
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-0"
                   >
                     <div
-                      class="pf-v5-c-empty-state__header"
+                      class="pf-v5-c-toolbar"
+                      data-ouia-component-id="group-add-service-accounts-header-toolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-0"
                     >
                       <div
-                        class="pf-v5-c-empty-state__icon"
+                        class="pf-v5-c-toolbar__content"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
                         >
-                          <path
-                            d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
-                          />
-                        </svg>
+                          <div
+                            class="pf-v5-c-toolbar__item"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-bulk-select"
+                          >
+                            <div
+                              class="pf-v5-c-menu-toggle pf-m-split-button"
+                            >
+                              <label
+                                class="pf-v5-c-check pf-m-standalone"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="Select page"
+                                  class="pf-v5-c-check__input"
+                                  data-ouia-component-id="BulkSelect-checkbox"
+                                  data-ouia-component-type="PF5/MenuToggleCheckbox"
+                                  data-ouia-safe="true"
+                                  name="BulkSelect-checkbox"
+                                  type="checkbox"
+                                />
+                              </label>
+                              <button
+                                aria-expanded="false"
+                                aria-label="Bulk select toggle"
+                                class="pf-v5-c-menu-toggle__button"
+                                data-ouia-component-id="BulkSelect-toggle"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination"
+                              data-ouia-component-id="OUIA-Generated-Pagination-top-1"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
+                              >
+                                <b>
+                                  1
+                                   - 
+                                  1
+                                </b>
+                                 
+                                of
+                                 
+                                <b>
+                                  1
+                                </b>
+                                 
+                              </div>
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                id="options-menu-top-toggle"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <b>
+                                    1
+                                     - 
+                                    1
+                                  </b>
+                                   
+                                  of
+                                   
+                                  <b>
+                                    1
+                                  </b>
+                                   
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of
+                                     
+                                    1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                       <div
-                        class="pf-v5-c-empty-state__title"
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
                       >
-                        <h4
-                          class="pf-v5-c-empty-state__title-text"
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
+                        <div
+                          class="pf-v5-c-toolbar__item"
                         >
-                          No service accounts found
-                        </h4>
+                          <button
+                            aria-disabled="false"
+                            class="pf-v5-c-button pf-m-link pf-m-inline"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-clear-all-filters"
+                            data-ouia-component-type="PF5/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Clear filters
+                          </button>
+                        </div>
                       </div>
                     </div>
-                    <div
-                      class="pf-v5-c-empty-state__body pf-v5-u-mb-md"
+                  </div>
+                  <div
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-1"
+                  >
+                    <table
+                      aria-label="Data table"
+                      class="pf-v5-c-table pf-m-grid-md"
+                      data-ouia-component-id="group-add-service-accounts-table"
+                      data-ouia-component-type="PF5/Table"
+                      data-ouia-safe="true"
+                      role="grid"
                     >
-                      Contact your platform service team to add service accounts.
-                       
-                      <br />
-                       
-                      <br />
-                    </div>
+                      <thead
+                        class="pf-v5-c-table__thead"
+                        data-ouia-component-id="group-add-service-accounts-table-thead"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="group-add-service-accounts-table-tr-head"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <th
+                            class="pf-v5-c-table__th"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <span
+                              class="pf-v5-screen-reader"
+                            >
+                              Data selection table head cell
+                            </span>
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-0"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Name
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-1"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Description
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-2"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Client ID
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-3"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Owner
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-4"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Time created
+                          </th>
+                        </tr>
+                      </thead>
+                      <div
+                        class="pf-v5-c-empty-state"
+                      >
+                        <div
+                          class="pf-v5-c-empty-state__content"
+                        >
+                          <div
+                            class="pf-v5-c-empty-state__header"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 512 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                              />
+                            </svg>
+                            <div
+                              class="pf-v5-c-empty-state__title"
+                            >
+                              <h4
+                                class="pf-v5-c-empty-state__title-text"
+                              >
+                                No service accounts found
+                              </h4>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-empty-state__body"
+                          >
+                            No service accounts found for this group.
+                          </div>
+                        </div>
+                      </div>
+                    </table>
+                  </div>
+                  <div
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-2"
+                  >
                     <div
-                      class="pf-v5-c-empty-state__footer"
-                    />
+                      class="pf-v5-c-toolbar"
+                      data-ouia-component-id="group-add-service-accounts-footer-toolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-1"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
+                        >
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination"
+                            data-ouia-component-id="group-add-service-accounts-footer-toolbar-pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination"
+                              data-ouia-component-id="OUIA-Generated-Pagination-top-2"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
+                              >
+                                <b>
+                                  1
+                                   - 
+                                  1
+                                </b>
+                                 
+                                of
+                                 
+                                <b>
+                                  1
+                                </b>
+                                 
+                              </div>
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-2"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                id="options-menu-top-toggle"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <b>
+                                    1
+                                     - 
+                                    1
+                                  </b>
+                                   
+                                  of
+                                   
+                                  <b>
+                                    1
+                                  </b>
+                                   
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of
+                                     
+                                    1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
+                        <div
+                          class="pf-v5-c-toolbar__item"
+                        >
+                          <button
+                            aria-disabled="false"
+                            class="pf-v5-c-button pf-m-link pf-m-inline"
+                            data-ouia-component-id="group-add-service-accounts-footer-toolbar-clear-all-filters"
+                            data-ouia-component-type="PF5/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Clear filters
+                          </button>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -330,551 +993,742 @@ exports[`<AddGroupServiceAccounts /> should render correctly with data 1`] = `
                 class="rbac-service-accounts-list"
               >
                 <div
-                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                  data-ouia-component-id="PrimaryToolbar"
-                  data-ouia-component-type="PF5/Toolbar"
-                  data-ouia-safe="true"
-                  id="ins-primary-data-toolbar"
+                  class="pf-v5-l-stack"
+                  data-ouia-component-id="group-add-service-accounts-stack"
                 >
                   <div
-                    class="pf-v5-c-toolbar__content"
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-0"
                   >
                     <div
-                      class="pf-v5-c-toolbar__content-section"
+                      class="pf-v5-c-toolbar"
+                      data-ouia-component-id="group-add-service-accounts-header-toolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-2"
                     >
                       <div
-                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                        class="pf-v5-c-toolbar__content"
                       >
                         <div
-                          class="pf-v5-c-toolbar__item"
+                          class="pf-v5-c-toolbar__content-section"
                         >
-                          <button
-                            aria-expanded="false"
-                            class="pf-v5-c-menu-toggle"
-                            data-ouia-component-id="OUIA-Generated-MenuToggle-1"
-                            data-ouia-component-type="PF5/MenuToggle"
-                            data-ouia-safe="true"
-                            type="button"
+                          <div
+                            class="pf-v5-c-toolbar__item"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-bulk-select"
                           >
-                            <span
-                              class="pf-v5-c-menu-toggle__text"
+                            <div
+                              class="pf-v5-c-menu-toggle pf-m-split-button"
                             >
                               <label
                                 class="pf-v5-c-check pf-m-standalone"
                               >
                                 <input
                                   aria-invalid="false"
-                                  aria-label="Select all"
+                                  aria-label="Select page"
                                   class="pf-v5-c-check__input"
-                                  data-ouia-component-id="BulkSelectCheckbox"
+                                  data-ouia-component-id="BulkSelect-checkbox"
                                   data-ouia-component-type="PF5/MenuToggleCheckbox"
                                   data-ouia-safe="true"
-                                  name="group-add-accounts-toggle-checkbox"
+                                  name="BulkSelect-checkbox"
                                   type="checkbox"
                                 />
                               </label>
-                            </span>
-                            <span
-                              class="pf-v5-c-menu-toggle__controls"
-                            >
-                              <span
-                                class="pf-v5-c-menu-toggle__toggle-icon"
+                              <button
+                                aria-expanded="false"
+                                aria-label="Bulk select toggle"
+                                class="pf-v5-c-menu-toggle__button"
+                                data-ouia-component-id="BulkSelect-toggle"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                type="button"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </button>
-                        </div>
-                        <div
-                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
-                        >
-                          <div
-                            class="pf-v5-l-split ins-c-conditional-filter"
-                          >
-                            <div
-                              class="pf-v5-l-split__item pf-m-fill"
-                              data-ouia-component-id="ConditionalFilter"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="text input"
-                                  data-ouia-component-id="ConditionalFilter"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  id="filter-by-string"
-                                  placeholder="Filter by {key}"
-                                  type="text"
-                                  value=""
-                                  widget-type="InsightsInput"
-                                />
                                 <span
-                                  class="pf-v5-c-form-control__utilities"
+                                  class="pf-v5-c-menu-toggle__controls"
                                 >
                                   <span
-                                    class="pf-v5-c-form-control__icon"
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
                                   >
-                                    <span
-                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
                                     >
-                                      <span
-                                        class="pf-v5-c-icon__content"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
                                   </span>
                                 </span>
-                              </span>
+                              </button>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination"
+                              data-ouia-component-id="OUIA-Generated-Pagination-top-3"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
+                              >
+                                <b>
+                                  1
+                                   - 
+                                  2
+                                </b>
+                                 
+                                of
+                                 
+                                <b>
+                                  2
+                                </b>
+                                 
+                              </div>
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-3"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                id="options-menu-top-toggle"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <b>
+                                    1
+                                     - 
+                                    2
+                                  </b>
+                                   
+                                  of
+                                   
+                                  <b>
+                                    2
+                                  </b>
+                                   
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of
+                                     
+                                    1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
                             </div>
                           </div>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-compact"
-                          data-ouia-component-id="CompactPagination"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-top-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                          class="pf-v5-c-toolbar__group"
+                        />
+                        <div
+                          class="pf-v5-c-toolbar__item"
                         >
-                          <div
-                            class="pf-v5-c-pagination__total-items"
-                          >
-                            <b>
-                              1
-                               - 
-                              1
-                            </b>
-                             
-                            of 
-                            <b>
-                              many
-                            </b>
-                          </div>
                           <button
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                            data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
-                            data-ouia-component-type="PF5/MenuToggle"
+                            aria-disabled="false"
+                            class="pf-v5-c-button pf-m-link pf-m-inline"
+                            data-ouia-component-id="group-add-service-accounts-header-toolbar-clear-all-filters"
+                            data-ouia-component-type="PF5/Button"
                             data-ouia-safe="true"
-                            id="options-menu-top-toggle"
                             type="button"
                           >
-                            <span
-                              class="pf-v5-c-menu-toggle__text"
-                            >
-                              <b>
-                                1
-                                 - 
-                                1
-                              </b>
-                               
-                              of 
-                              <b>
-                                many
-                              </b>
-                            </span>
-                            <span
-                              class="pf-v5-c-menu-toggle__controls"
-                            >
-                              <span
-                                class="pf-v5-c-menu-toggle__toggle-icon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
+                            Clear filters
                           </button>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
-                          >
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="false"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-1"
+                  >
+                    <table
+                      aria-label="Data table"
+                      class="pf-v5-c-table pf-m-grid-md"
+                      data-ouia-component-id="group-add-service-accounts-table"
+                      data-ouia-component-type="PF5/Table"
+                      data-ouia-safe="true"
+                      role="grid"
+                    >
+                      <thead
+                        class="pf-v5-c-table__thead"
+                        data-ouia-component-id="group-add-service-accounts-table-thead"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="group-add-service-accounts-table-tr-head"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <th
+                            class="pf-v5-c-table__th"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <span
+                              class="pf-v5-screen-reader"
+                            >
+                              Data selection table head cell
+                            </span>
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-0"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Name
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-1"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Description
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-2"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Client ID
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-3"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Owner
+                          </th>
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-ouia-component-id="group-add-service-accounts-table-th-4"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            Time created
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="group-add-service-accounts-table-tr-0"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__check"
+                            tabindex="-1"
+                          >
+                            <label>
+                              <input
+                                aria-label="Select row 0"
+                                name="checkrow0"
+                                type="checkbox"
+                              />
+                            </label>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-ouia-component-id="group-add-service-accounts-table-td-0-0"
+                            tabindex="-1"
+                          >
+                            just-created
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-ouia-component-id="group-add-service-accounts-table-td-0-1"
+                            tabindex="-1"
+                          >
+                            just-created
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-ouia-component-id="group-add-service-accounts-table-td-0-2"
+                            tabindex="-1"
+                          >
+                            0f81d08d-74b2
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-ouia-component-id="group-add-service-accounts-table-td-0-3"
+                            tabindex="-1"
+                          >
+                            insights-qa
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-ouia-component-id="group-add-service-accounts-table-td-0-4"
+                            tabindex="-1"
+                          >
+                            <div
+                              style="display: contents;"
+                            >
+                              <span>
+                                56 years ago
+                              </span>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <div
+                    class="pf-v5-l-stack__item"
+                    data-ouia-component-id="group-add-service-accounts-stack-item-2"
                   >
                     <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-                <table
-                  aria-label="service accounts table"
-                  class="pf-v5-c-table pf-m-grid-md"
-                  data-ouia-component-id="group-add-accounts"
-                  data-ouia-component-type="PF5/Table"
-                  data-ouia-safe="true"
-                  role="grid"
-                >
-                  <thead
-                    class="pf-v5-c-table__thead"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-1"
-                      data-ouia-component-type="PF5/TableRow"
+                      class="pf-v5-c-toolbar"
+                      data-ouia-component-id="group-add-service-accounts-footer-toolbar"
+                      data-ouia-component-type="PF5/Toolbar"
                       data-ouia-safe="true"
+                      id="pf-random-id-3"
                     >
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="0"
-                        data-label=""
-                        tabindex="-1"
-                      />
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="1"
-                        data-label="Name"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Name
-                      </th>
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="2"
-                        data-label="Description"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Description
-                      </th>
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="3"
-                        data-label="Client ID"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Client ID
-                      </th>
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="4"
-                        data-label="Owner"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Owner
-                      </th>
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="5"
-                        data-label="Time created"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        Time created
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-2"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__check"
-                        data-key="0"
-                        tabindex="-1"
-                      >
-                        <label>
-                          <input
-                            aria-label="Select row 0"
-                            name="checkrow0"
-                            type="checkbox"
-                          />
-                        </label>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="1"
-                        data-label="Name"
-                        tabindex="-1"
-                      >
-                        just-created
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="2"
-                        data-label="Description"
-                        tabindex="-1"
-                      >
-                        just-created
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="3"
-                        data-label="Client ID"
-                        tabindex="-1"
-                      >
-                        0f81d08d-74b2
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="4"
-                        data-label="Owner"
-                        tabindex="-1"
-                      >
-                        insights-qa
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="5"
-                        data-label="Time created"
-                        tabindex="-1"
+                      <div
+                        class="pf-v5-c-toolbar__content"
                       >
                         <div
-                          style="display: contents;"
+                          class="pf-v5-c-toolbar__content-section"
                         >
-                          <span>
-                            56 years ago
-                          </span>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination"
+                            data-ouia-component-id="group-add-service-accounts-footer-toolbar-pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination"
+                              data-ouia-component-id="OUIA-Generated-Pagination-top-4"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
+                              >
+                                <b>
+                                  1
+                                   - 
+                                  2
+                                </b>
+                                 
+                                of
+                                 
+                                <b>
+                                  2
+                                </b>
+                                 
+                              </div>
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-4"
+                                data-ouia-component-type="PF5/MenuToggle"
+                                data-ouia-safe="true"
+                                id="options-menu-top-toggle"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <b>
+                                    1
+                                     - 
+                                    2
+                                  </b>
+                                   
+                                  of
+                                   
+                                  <b>
+                                    2
+                                  </b>
+                                   
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of
+                                     
+                                    1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
                         </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div
-                  class="pf-v5-c-toolbar ins-c-table__toolbar"
-                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                  data-ouia-component-type="RHI/TableToolbar"
-                  data-ouia-safe="true"
-                  id="pf-random-id-0"
-                >
-                  <div
-                    class="pf-v5-c-pagination pf-m-bottom pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
-                    data-ouia-component-type="PF5/Pagination"
-                    data-ouia-safe="true"
-                    id="options-menu-bottom-pagination"
-                    style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                  >
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-2"
-                      data-ouia-component-type="PF5/MenuToggle"
-                      data-ouia-safe="true"
-                      id="options-menu-bottom-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1
-                           - 
-                          1
-                        </b>
-                         
-                        of 
-                        <b>
-                          many
-                        </b>
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                    <nav
-                      aria-label="Pagination"
-                      class="pf-v5-c-pagination__nav"
-                    >
-                      <div
-                        class="pf-v5-c-pagination__nav-control"
-                      >
-                        <button
-                          aria-disabled="true"
-                          aria-label="Go to previous page"
-                          class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                          data-action="previous"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          disabled=""
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 256 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                            />
-                          </svg>
-                        </button>
                       </div>
                       <div
-                        class="pf-v5-c-pagination__nav-control"
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
                       >
-                        <button
-                          aria-disabled="false"
-                          aria-label="Go to next page"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-action="next"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          type="button"
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
+                        <div
+                          class="pf-v5-c-toolbar__item"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 256 512"
-                            width="1em"
+                          <button
+                            aria-disabled="false"
+                            class="pf-v5-c-button pf-m-link pf-m-inline"
+                            data-ouia-component-id="group-add-service-accounts-footer-toolbar-clear-all-filters"
+                            data-ouia-component-type="PF5/Button"
+                            data-ouia-safe="true"
+                            type="button"
                           >
-                            <path
-                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                            />
-                          </svg>
-                        </button>
+                            Clear filters
+                          </button>
+                        </div>
                       </div>
-                    </nav>
-                  </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/test/smart-components/group/service-account/__snapshots__/add-group-service-accounts.test.js.snap
+++ b/src/test/smart-components/group/service-account/__snapshots__/add-group-service-accounts.test.js.snap
@@ -455,7 +455,7 @@ exports[`<AddGroupServiceAccounts /> should render correctly empty 1`] = `
                   >
                     <table
                       aria-label="Data table"
-                      class="pf-v5-c-table pf-m-grid-md"
+                      class="pf-v5-c-table pf-m-grid-md pf-m-compact"
                       data-ouia-component-id="group-add-service-accounts-table"
                       data-ouia-component-type="PF5/Table"
                       data-ouia-safe="true"
@@ -1325,7 +1325,7 @@ exports[`<AddGroupServiceAccounts /> should render correctly with data 1`] = `
                   >
                     <table
                       aria-label="Data table"
-                      class="pf-v5-c-table pf-m-grid-md"
+                      class="pf-v5-c-table pf-m-grid-md pf-m-compact"
                       data-ouia-component-id="group-add-service-accounts-table"
                       data-ouia-component-type="PF5/Table"
                       data-ouia-safe="true"


### PR DESCRIPTION
### Description
There was an issue where if a name or description was too long, the group service-accounts-list table's pagination and data would be outside the modal. I just went ahead and converted the table to use DataView since this would cleanly fix the issue. 

[RHCLOUD-41951](https://issues.redhat.com/browse/RHCLOUD-41951)

---

### Screenshots
#### Before:
<img width="1130" height="766" alt="Screenshot From 2025-09-03 15-19-35" src="https://github.com/user-attachments/assets/c37c8234-8013-4442-a797-529e2c69e6f1" />


#### After:
<img width="1130" height="766" alt="Screenshot From 2025-09-03 15-20-32" src="https://github.com/user-attachments/assets/dc67f947-05d8-4710-9723-bd0f46b1c6a4" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Convert the service accounts list to use PatternFly DataView components, fixing overflow issues and improving pagination and selection handling

Bug Fixes:
- Fix service accounts table pagination and data overflowing outside the modal when names or descriptions are too long

Enhancements:
- Replace custom TableToolbarView with DataView, DataViewTable and DataViewToolbar for unified rendering
- Implement skeleton loading states and a custom empty state component for no data
- Integrate useDataViewPagination and useDataViewSelection hooks to manage pagination and selection
- Add SCSS rules to enable word-wrapping on long table cell content
- Add a new translation message for the group-specific empty state body