### PR TITLE
feat: update technology icon path

### DIFF
--- a/src/features/workspaces/workspace-detail/WorkspaceDetail.stories.tsx
+++ b/src/features/workspaces/workspace-detail/WorkspaceDetail.stories.tsx
@@ -179,12 +179,12 @@ const workspaceDetailHandlers = [
     });
   }),
   // Add handlers for static assets
-  http.get('/apps/frontend-assets/console-landing/insights.svg', () => {
+  http.get('/apps/frontend-assets/technology-icons/insights.svg', () => {
     return HttpResponse.text('<svg></svg>', {
       headers: { 'Content-Type': 'image/svg+xml' },
     });
   }),
-  http.get('/apps/frontend-assets/console-landing/openshift.svg', () => {
+  http.get('/apps/frontend-assets/technology-icons/openshift.svg', () => {
     return HttpResponse.text('<svg></svg>', {
       headers: { 'Content-Type': 'image/svg+xml' },
     });

--- a/src/features/workspaces/workspace-detail/components/AssetsCards.tsx
+++ b/src/features/workspaces/workspace-detail/components/AssetsCards.tsx
@@ -22,7 +22,7 @@ interface AssetsCardsProps {
 }
 
 const AssetsCards: React.FunctionComponent<AssetsCardsProps> = ({ workspaceName }: AssetsCardsProps) => {
-  const InsightsIcon = '/apps/frontend-assets/console-landing/insights.svg';
+  const InsightsIcon = '/apps/frontend-assets/technology-icons/insights.svg';
   const InsightsNavURL = `/insights/inventory?workspace=${workspaceName}`;
   const intl = useIntl();
   const AssetsCardsWidths = {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

[RHCLOUD-42183](https://issues.redhat.com/browse/RHCLOUD-42183)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Update static asset paths to point to the new technology-icons directory

Enhancements:
- Update HTTP mock handlers in workspace detail stories to use technology-icons paths for insights and openshift icons
- Update AssetsCards component to reference the insights icon from the technology-icons directory