### PR TITLE
feat: add disabled edit access button to WS details drawer

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -2858,4 +2858,9 @@ export default defineMessages({
     description: 'Grant access button text',
     defaultMessage: 'Grant access',
   },
+  editAccessForThisWorkspace: {
+    id: 'editAccessForThisWorkspace',
+    description: 'Edit access for this workspace button text',
+    defaultMessage: 'Edit access for this workspace',
+  },
 });

--- a/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.tsx
+++ b/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  Button,
   Drawer,
   DrawerActions,
   DrawerCloseButton,
@@ -253,6 +254,9 @@ export const GroupDetailsDrawer: React.FC<GroupDetailsDrawerProps> = ({
                   {group.name}
                 </Title>
                 <DrawerActions>
+                  <Button variant="secondary" isDisabled>
+                    {intl.formatMessage(messages.editAccessForThisWorkspace)}
+                  </Button>
                   <DrawerCloseButton onClick={onClose} />
                 </DrawerActions>
               </DrawerHead>


### PR DESCRIPTION
For [RHCLOUD-41942](https://issues.redhat.com/browse/RHCLOUD-41942). Since this milestone is read-only, this button is disabled by default for now. 

<img width="1512" height="794" alt="image" src="https://github.com/user-attachments/assets/7dff8686-dd59-425c-9ea4-10b9641e1016" />
