### PR TITLE
chore: replacing View Workspace list button with Select Workspace

### DIFF
--- a/src/features/workspaces/components/managed-selector/ManagedSelector.tsx
+++ b/src/features/workspaces/components/managed-selector/ManagedSelector.tsx
@@ -202,6 +202,7 @@ const ManagedSelectorInternal: React.FC<ManagedSelectorProps> = ({ onSelect, ini
       onSearchFilter={onSearchFilter}
       onSelectItem={onSelectTreeViewWorkspaceItem}
       onFetchData={fetchWorkspacesFromRBACBuildTree}
+      onButtonClick={() => setIsWorkspacesMenuExpanded(false)}
       renderMenuToggle={(props) => (
         <WorkspaceMenuToggle
           menuToggleRef={props.menuToggleRef}
@@ -222,7 +223,7 @@ const ManagedSelectorInternal: React.FC<ManagedSelectorProps> = ({ onSelect, ini
         />
       )}
       searchPlaceholder="Find a workspace by name"
-      buttonText="View workspace list"
+      buttonText="Select Workspace"
     />
   );
 };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Replacing the "View workspace list" button (which didn't do anything) with "Select Workspace". When clicked, this button will close the drop-down menu, keeping whichever workspace was selected as the "parent".

[RHCLOUD-41345](https://issues.redhat.com/browse/RHCLOUD-41345)

## Before:

<img width="1174" height="801" alt="image" src="https://github.com/user-attachments/assets/4ea69926-331b-42de-8029-c277af7be092" />


## After:
<img width="1174" height="801" alt="image" src="https://github.com/user-attachments/assets/578f3ee7-0d5a-46d6-a21f-0bac6e1c39f4" />


---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##

## Summary by Sourcery

Replace the non-functional "View workspace list" button with a "Select Workspace" button that closes the workspace selector menu on click

Enhancements:
- Update workspace selector toggle button text from "View workspace list" to "Select Workspace"
- Add onButtonClick handler to collapse the workspace dropdown when selecting a workspace