### PR TITLE
chore: cleanup test tags

### DIFF
--- a/.cursor/rules/storybook.mdc
+++ b/.cursor/rules/storybook.mdc
@@ -164,12 +164,128 @@ Stories can override default context values through args:
 - Stories must test actual user workflows, not just trigger events
 - Cover all interactive states: hover, focus, disabled, error, etc.
 
+### Story Tagging Requirements (MANDATORY)
+
+**CRITICAL**: All stories MUST include appropriate metadata tags to enable filtering and categorization in Storybook UI.
+
+#### Required Tag Types
+
+1. **Feature Flag Tags** (`ff:*`)
+   - **REQUIRED** for any story that sets feature flags via `parameters.featureFlags` or `args`
+   - Format: `ff:full.feature.flag.name`
+   - Examples: `ff:platform.rbac.itless`, `ff:platform.rbac.workspaces`, `ff:platform.rbac.groups`
+   ```typescript
+   export const StoryWithFlags: Story = {
+     tags: ['ff:platform.rbac.itless', 'ff:platform.rbac.workspaces'],
+     parameters: {
+       featureFlags: {
+         'platform.rbac.itless': true,
+         'platform.rbac.workspaces': true,
+       },
+     },
+   };
+   ```
+
+2. **Environment Tags** (`env:*`)
+   - **REQUIRED** for any story that sets `chrome.environment` parameter
+   - Format: `env:environment-name`
+   - Common values: `env:prod`, `env:stage`, `env:ci-beta`
+   ```typescript
+   export const ProductionStory: Story = {
+     tags: ['env:prod'],
+     parameters: {
+       chrome: { environment: 'prod' },
+     },
+   };
+   ```
+
+3. **Permission Tags** (`perm:*`)
+   - **REQUIRED** for any story that sets permissions to `true` via `parameters.permissions` or `args`
+   - Only tag when permission is explicitly `true` (default is `false`)
+   - Tags: `perm:org-admin` for `orgAdmin: true`, `perm:user-access-admin` for `userAccessAdministrator: true`
+   - Tag placement: Apply at meta level if permissions are in meta parameters, or at story level if in story parameters/args
+   ```typescript
+   // Story-level permissions → story-level tags
+   export const AdminStory: Story = {
+     tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
+     parameters: {
+       chrome: { environment: 'stage' },
+       permissions: { 
+         orgAdmin: true, 
+         userAccessAdministrator: true 
+       },
+     },
+   };
+   
+   // Meta-level permissions → meta-level tags
+   const meta: Meta<typeof Component> = {
+     component: Component,
+     tags: ['autodocs', 'perm:org-admin'],
+     parameters: {
+       permissions: { orgAdmin: true },
+     },
+   };
+   ```
+
+4. **Custom CSS Tags** (`custom-css`)
+   - **REQUIRED** for any component that imports `.scss` files
+   - Check the component file (not the story file) for CSS imports
+   - Tag: `custom-css`
+   ```typescript
+   // If component imports './Component.scss'
+   const meta: Meta<typeof Component> = {
+     component: Component,
+     tags: ['autodocs', 'custom-css'],
+   };
+   ```
+
+#### Tag Application Rules
+
+- **Meta-level tags**: Apply to all stories in the file
+  ```typescript
+  const meta: Meta<typeof Component> = {
+    component: Component,
+    tags: ['autodocs', 'ff:platform.rbac.workspaces', 'custom-css'],
+  };
+  ```
+
+- **Story-level tags**: Apply to individual stories, merge with meta tags
+  ```typescript
+  export const AdminProduction: Story = {
+    tags: ['env:prod', 'perm:org-admin'], // Merges with meta tags
+    parameters: {
+      chrome: { environment: 'prod' },
+      permissions: { orgAdmin: true },
+    },
+  };
+  ```
+
+#### Tag Naming Conventions
+
+- **Use full flag names**: `ff:platform.rbac.itless` not `ff:itless`
+- **Use lowercase with hyphens**: `perm:org-admin` not `perm:orgAdmin`
+- **Be specific**: `env:stage` not `env:staging`
+- **No test-targeting tags**: Don't add internal tags (removed: `test-spy`, `production-bug`, `modal-testing`, `filtering-pagination`, `workspaces`, `users-container`, `roles-container`, `access-management-container`, etc.)
+
+#### Tag Verification Checklist
+
+Before submitting stories, verify:
+- [ ] All feature flags have `ff:*` tags with full flag names
+- [ ] All environment settings have `env:*` tags
+- [ ] All `true` permissions have `perm:*` tags
+- [ ] Components with CSS imports have `custom-css` tag
+- [ ] No internal/test-targeting tags remain in code
+
+**WHY THIS MATTERS**: These tags enable developers to quickly filter and find relevant stories in Storybook UI based on feature flags, environments, permissions, and styling requirements.
+
 ### Container Story Requirements (SPECIAL PATTERN)
 - **Container stories** with multiple stories should use **single autodocs pattern**:
-  - Remove `autodocs` from meta: `tags: ['container-name']` (NO autodocs)
+  - Remove `autodocs` from meta (NO autodocs on meta)
   - Add `autodocs` only to default story: `tags: ['autodocs']`
   - Default story must include comprehensive directory of all other stories with clickable links
+  - Apply appropriate `ff:*`, `env:*`, `perm:*`, and `custom-css` tags to meta or individual stories as needed
 - **NEVER** use `storeState` to pre-populate Redux in container stories
+- **NEVER** add internal test-targeting tags (removed: `workspaces`, `users-container`, `roles-container`, etc.)
 - **ALWAYS** use real API orchestration with MSW handlers for container testing
 
 ### Story Structure Template

--- a/src/components/user-management/ActiveUsers.stories.tsx
+++ b/src/components/user-management/ActiveUsers.stories.tsx
@@ -66,6 +66,7 @@ type Story = StoryObj<ActiveUsersStoryArgs>;
  * Default story showing NonAdminView (most common case)
  */
 export const Default: Story = {
+  tags: ['env:prod'],
   args: {
     orgAdmin: false,
     userAccessAdministrator: false,
@@ -78,6 +79,7 @@ export const Default: Story = {
  * Org admin user in production - shows AdminView with no prefix
  */
 export const OrgAdminProduction: Story = {
+  tags: ['env:prod', 'perm:org-admin'],
   args: {
     orgAdmin: true,
     userAccessAdministrator: false,
@@ -92,6 +94,7 @@ export const OrgAdminProduction: Story = {
  * Org admin user in staging - shows AdminView with environment prefix
  */
 export const OrgAdminStaging: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   args: {
     orgAdmin: true,
     userAccessAdministrator: false,
@@ -106,6 +109,7 @@ export const OrgAdminStaging: Story = {
  * ITLess mode enabled - always shows NonAdminView regardless of permissions
  */
 export const ITLessMode: Story = {
+  tags: ['env:prod', 'perm:org-admin'],
   args: {
     orgAdmin: true, // Even though user is orgAdmin...
     userAccessAdministrator: false,
@@ -119,6 +123,7 @@ export const ITLessMode: Story = {
  * Note: userAccessAdministrator permission doesn't trigger AdminView, only orgAdmin does
  */
 export const UserAccessAdmin: Story = {
+  tags: ['env:prod'],
   args: {
     orgAdmin: false,
     userAccessAdministrator: true,
@@ -131,6 +136,7 @@ export const UserAccessAdmin: Story = {
  * Development environment example
  */
 export const DevelopmentEnvironment: Story = {
+  tags: ['env:ci-beta', 'perm:org-admin'],
   args: {
     orgAdmin: true,
     userAccessAdministrator: false,

--- a/src/components/user-management/ActiveUsersAdminView.stories.tsx
+++ b/src/components/user-management/ActiveUsersAdminView.stories.tsx
@@ -9,7 +9,7 @@ type AdminViewStoryArgs = StoryArgs<React.ComponentProps<typeof ActiveUsersAdmin
 const meta: Meta<AdminViewStoryArgs> = {
   component: ActiveUsersAdminView,
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ['autodocs', 'perm:org-admin'],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     docs: {
@@ -140,6 +140,7 @@ export const FullyCustomized: Story = {
  * User Access Administrator permissions (different from orgAdmin)
  */
 export const UserAccessAdmin: Story = {
+  tags: ['perm:user-access-admin'],
   parameters: {
     permissions: {
       userAccessAdministrator: true,

--- a/src/features/access-management/users-and-user-groups/UsersAndUserGroups.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/UsersAndUserGroups.stories.tsx
@@ -61,7 +61,6 @@ const mockGroups = [
 
 const meta: Meta<typeof UsersAndUserGroups> = {
   component: UsersAndUserGroups,
-  tags: ['access-management-container'],
   decorators: [
     () => (
       <MemoryRouter initialEntries={['/iam/access-management/users-and-user-groups/users']}>

--- a/src/features/access-management/users-and-user-groups/user-groups/UserGroups.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/UserGroups.stories.tsx
@@ -67,7 +67,7 @@ const withRouter = () => {
 
 const meta: Meta<typeof UserGroups> = {
   component: UserGroups,
-  tags: ['user-groups-container'],
+  tags: ['ff:platform.rbac.groups', 'env:prod', 'perm:org-admin'],
   decorators: [withRouter],
   parameters: {
     permissions: { orgAdmin: true },
@@ -742,6 +742,7 @@ export const EditGroupNavigation: StoryObj<typeof meta> = {
 
 // Delete modal integration
 export const DeleteModalIntegration: StoryObj<typeof meta> = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     chrome: {
       environment: 'stage', // Use non-production to enable delete actions
@@ -946,6 +947,7 @@ export const DeleteModalIntegration: StoryObj<typeof meta> = {
 
 // System group protection
 export const SystemGroupProtection: StoryObj<typeof meta> = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     chrome: {
       environment: 'stage', // Use non-production to test disabled state logic

--- a/src/features/access-management/users-and-user-groups/user-groups/components/DeleteGroupModal.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/components/DeleteGroupModal.stories.tsx
@@ -37,7 +37,7 @@ const mockGroups: Group[] = [
 
 const meta: Meta<typeof DeleteGroupModal> = {
   component: DeleteGroupModal,
-  tags: ['autodocs', 'delete-group-modal'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/user-groups/components/GroupDetailsDrawer.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/components/GroupDetailsDrawer.stories.tsx
@@ -9,7 +9,6 @@ import { GroupDetailsDrawer } from './GroupDetailsDrawer';
 
 const meta: Meta<typeof GroupDetailsDrawer> = {
   component: GroupDetailsDrawer,
-  tags: ['access-management-drawer'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -94,7 +94,7 @@ const defaultArgs = {
 
 const meta: Meta<typeof UserGroupsTable> = {
   component: UserGroupsTable,
-  tags: ['autodocs', 'user-groups-table'],
+  tags: ['autodocs'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
@@ -32,7 +32,6 @@ const mockGroups = [
 
 const meta: Meta<typeof EditUserGroup> = {
   component: EditUserGroup,
-  tags: ['access-management-feature'],
   decorators: [
     (Story, { parameters }) => {
       const routePath = parameters?.route?.path || '/access-management/user-groups/:groupId/edit';

--- a/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupServiceAccounts.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupServiceAccounts.stories.tsx
@@ -34,7 +34,6 @@ const mockServiceAccounts = [
 
 const meta: Meta<typeof EditGroupServiceAccountsTable> = {
   component: EditGroupServiceAccountsTable,
-  tags: ['access-management-form'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsers.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsers.stories.tsx
@@ -43,7 +43,6 @@ const mockUsers = [
 
 const meta: Meta<typeof EditGroupUsersTable> = {
   component: EditGroupUsersTable,
-  tags: ['access-management-form'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsersAndServiceAccounts.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/edit-user-group/EditUserGroupUsersAndServiceAccounts.stories.tsx
@@ -83,7 +83,6 @@ const FormWrapper: React.FC<{
 
 const meta: Meta<typeof EditGroupUsersAndServiceAccounts> = {
   component: EditGroupUsersAndServiceAccounts,
-  tags: ['access-management-form'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsRolesView.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsRolesView.stories.tsx
@@ -9,7 +9,6 @@ import { GroupDetailsRolesView } from './GroupDetailsRolesView';
 
 const meta: Meta<typeof GroupDetailsRolesView> = {
   component: GroupDetailsRolesView,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
@@ -9,7 +9,6 @@ import { GroupDetailsServiceAccountsView } from './GroupDetailsServiceAccountsVi
 
 const meta: Meta<typeof GroupDetailsServiceAccountsView> = {
   component: GroupDetailsServiceAccountsView,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
@@ -9,7 +9,6 @@ import { GroupDetailsUsersView } from './GroupDetailsUsersView';
 
 const meta: Meta<typeof GroupDetailsUsersView> = {
   component: GroupDetailsUsersView,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/users/Users.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/Users.stories.tsx
@@ -73,7 +73,7 @@ const stableAuthMock = {
 
 const meta: Meta<typeof Users> = {
   component: Users,
-  tags: ['users-container'],
+  tags: ['ff:platform.rbac.common-auth-model', 'env:prod', 'perm:org-admin'],
   decorators: [withRouter],
   parameters: {
     // Use global providers for these (configured in .storybook/preview.tsx)
@@ -411,6 +411,7 @@ export const AddToGroupModalIntegration: Story = {
 
 // Container delete user modal integration test
 export const DeleteUserModalIntegration: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/users/add-user-to-group/AddUserToGroupModal.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/add-user-to-group/AddUserToGroupModal.stories.tsx
@@ -56,7 +56,7 @@ const mockGroups = [
 
 const meta: Meta<typeof AddUserToGroupModal> = {
   component: AddUserToGroupModal,
-  tags: ['autodocs', 'add-user-to-group-modal'],
+  tags: ['autodocs'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/users/components/BulkDeactivateUsersModal.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/components/BulkDeactivateUsersModal.stories.tsx
@@ -6,7 +6,7 @@ import { BulkDeactivateUsersModal } from './BulkDeactivateUsersModal';
 
 const meta: Meta<typeof BulkDeactivateUsersModal> = {
   component: BulkDeactivateUsersModal,
-  tags: ['autodocs', 'bulk-deactivate-modal'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/users/components/DeleteUserModal.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/components/DeleteUserModal.stories.tsx
@@ -43,7 +43,7 @@ const ModalWrapper = ({ ...storyArgs }: any) => {
 
 const meta: Meta<typeof DeleteUserModal> = {
   component: DeleteUserModal,
-  tags: ['autodocs', 'delete-user-modal'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/users/components/UsersTable.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/components/UsersTable.stories.tsx
@@ -54,7 +54,7 @@ const defaultArgs = {
 
 const meta: Meta<typeof UsersTable> = {
   component: UsersTable,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'perm:org-admin'],
   parameters: {
     docs: {
       description: {

--- a/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsDrawer.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsDrawer.stories.tsx
@@ -44,7 +44,6 @@ const TestDataViewTable: React.FC<{ onUserSelect: (user: User) => void }> = ({ o
 
 const meta: Meta<typeof UserDetailsDrawer> = {
   component: UserDetailsDrawer,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsGroupsView.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsGroupsView.stories.tsx
@@ -9,7 +9,6 @@ import { UserDetailsGroupsView } from './UserDetailsGroupsView';
 
 const meta: Meta<typeof UserDetailsGroupsView> = {
   component: UserDetailsGroupsView,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsRolesView.stories.tsx
+++ b/src/features/access-management/users-and-user-groups/users/user-detail/UserDetailsRolesView.stories.tsx
@@ -9,7 +9,6 @@ import { UserDetailsRolesView } from './UserDetailsRolesView';
 
 const meta: Meta<typeof UserDetailsRolesView> = {
   component: UserDetailsRolesView,
-  tags: ['access-management-container'],
   decorators: [
     (Story) => (
       <MemoryRouter>

--- a/src/features/groups/EditGroupModal.stories.tsx
+++ b/src/features/groups/EditGroupModal.stories.tsx
@@ -53,7 +53,6 @@ const EditGroupModalWrapper: React.FC<any> = (props) => {
 
 const meta: Meta<typeof EditGroupModalWrapper> = {
   component: EditGroupModalWrapper,
-  tags: ['edit-group-modal'], // NO autodocs on meta
   decorators: [
     (Story, context) => {
       const { initialRoute } = context.args;

--- a/src/features/groups/Groups.stories.tsx
+++ b/src/features/groups/Groups.stories.tsx
@@ -93,6 +93,7 @@ const groupsApiCallSpy = fn();
 const meta: Meta<typeof Groups> = {
   title: 'Features/Groups/Groups',
   component: Groups, // Update component reference
+  tags: ['custom-css'],
   parameters: {
     msw: {
       handlers: [
@@ -198,7 +199,7 @@ export default meta;
 type Story = StoryObj<typeof Groups>;
 
 export const Default: Story = {
-  tags: ['autodocs'], // ONLY story with autodocs
+  tags: ['autodocs', 'env:stage', 'perm:org-admin', 'perm:user-access-admin'], // ONLY story with autodocs
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -226,6 +227,7 @@ export const Default: Story = {
 
 // Basic loading state
 export const Loading: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     // ✅ Loading state now handled by MSW delayed response
     chrome: { environment: 'stage' },
@@ -253,6 +255,7 @@ export const Loading: Story = {
 
 // Non-admin user view
 export const NonAdminUserView: Story = {
+  tags: ['env:stage'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: false, userAccessAdministrator: false }, // Non-admin user
@@ -355,6 +358,7 @@ export const NonAdminUserView: Story = {
 
 // Admin user view with full permissions
 export const AdminUserView: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -389,6 +393,7 @@ export const AdminUserView: Story = {
 
 // Bulk selection and actions
 export const BulkSelectionAndActions: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -431,6 +436,7 @@ export const BulkSelectionAndActions: Story = {
 
 // Bulk select checkbox functionality
 export const BulkSelectCheckbox: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -479,6 +485,7 @@ export const BulkSelectCheckbox: Story = {
 
 // Roles expansion functionality
 export const RolesExpansion: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -522,6 +529,7 @@ export const RolesExpansion: Story = {
 
 // Members expansion functionality
 export const MembersExpansion: Story = {
+  tags: ['env:stage', 'perm:org-admin', 'perm:user-access-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: true },
@@ -565,6 +573,7 @@ export const MembersExpansion: Story = {
 
 // Filtering interaction
 export const FilteringInteraction: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: false },
@@ -641,6 +650,7 @@ export const FilteringInteraction: Story = {
 
 // Sorting interaction
 export const SortingInteraction: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     chrome: { environment: 'stage' },
     permissions: { orgAdmin: true, userAccessAdministrator: false },
@@ -729,6 +739,7 @@ export const SortingInteraction: Story = {
 
 // Default groups behavior (admin and platform default)
 export const DefaultGroupsBehavior: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     // ✅ Group data now provided by MSW handlers
     chrome: { environment: 'stage' },
@@ -790,7 +801,7 @@ export const DefaultGroupsBehavior: Story = {
 };
 // 🚨 PRODUCTION BUG REPRODUCTION: User in org with lots of groups but no groups permissions
 export const ProductionBugReproduction: Story = {
-  tags: ['test-spy', 'production-bug'],
+  tags: ['env:prod'],
   parameters: {
     // ✅ Empty state handled by MSW 403 response
     chrome: { environment: 'prod' }, // Production environment

--- a/src/features/groups/RemoveGroupModal.stories.tsx
+++ b/src/features/groups/RemoveGroupModal.stories.tsx
@@ -30,7 +30,6 @@ const RemoveGroupModalWrapper: React.FC<any> = ({ postMethod, initialRoute, ...p
 
 const meta: Meta<typeof RemoveGroupModalWrapper> = {
   component: RemoveGroupModalWrapper,
-  tags: ['remove-group-modal'], // NO autodocs on meta
   args: {
     postMethod: fn(),
   },

--- a/src/features/groups/add-group/AddGroupWizard.stories.tsx
+++ b/src/features/groups/add-group/AddGroupWizard.stories.tsx
@@ -630,7 +630,14 @@ const mockHandlers = createMockHandlersWithSpies();
 
 const meta: Meta<typeof AddGroupWizardWithRouter> = {
   component: AddGroupWizardWithRouter,
-  tags: ['add-group-wizard'],
+  tags: [
+    'ff:platform.rbac.itless',
+    'ff:platform.rbac.workspaces',
+    'ff:platform.rbac.group-service-accounts',
+    'ff:platform.rbac.group-service-accounts.stable',
+    'perm:org-admin',
+    'perm:user-access-admin',
+  ],
   parameters: {
     msw: {
       handlers: mockHandlers,

--- a/src/features/groups/add-group/components/stepRoles/SetRoles.stories.tsx
+++ b/src/features/groups/add-group/components/stepRoles/SetRoles.stories.tsx
@@ -90,7 +90,7 @@ const SetRolesWithForm: React.FC<{
 const meta: Meta<typeof SetRolesWithForm> = {
   title: 'Features/Groups/AddGroup/SetRoles',
   component: SetRolesWithForm,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'custom-css'],
   parameters: {
     docs: {
       description: {

--- a/src/features/groups/add-group/components/stepUsers/SetUsers.stories.tsx
+++ b/src/features/groups/add-group/components/stepUsers/SetUsers.stories.tsx
@@ -73,7 +73,7 @@ const SetUsersWithForm: React.FC<{
 const meta: Meta<typeof SetUsersWithForm> = {
   title: 'Features/Groups/AddGroup/SetUsers',
   component: SetUsersWithForm,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'ff:platform.rbac.itless', 'custom-css'],
   parameters: {
     docs: {
       description: {

--- a/src/features/groups/add-group/components/stepUsers/UsersList.stories.tsx
+++ b/src/features/groups/add-group/components/stepUsers/UsersList.stories.tsx
@@ -120,7 +120,6 @@ const UsersListWithData: React.FC<{
 const meta: Meta<typeof UsersListWithData> = {
   title: 'Features/Groups/AddGroup/UsersList',
   component: UsersListWithData,
-  tags: ['users-list'],
   parameters: {
     docs: {
       description: {
@@ -202,6 +201,7 @@ export const WithLinks: Story = {
 };
 
 export const OrgAdmin: Story = {
+  tags: ['perm:org-admin'],
   args: {
     selectedUsers: [],
     setSelectedUsers: fn(),

--- a/src/features/groups/group/Group.stories.tsx
+++ b/src/features/groups/group/Group.stories.tsx
@@ -56,7 +56,7 @@ const withRouter = (Story: any) => {
 
 const meta: Meta<typeof Group> = {
   component: Group,
-  tags: ['group-container'], // NO autodocs on meta
+  tags: ['custom-css'], // NO autodocs on meta
   decorators: [withRouter],
   parameters: {},
 };

--- a/src/features/groups/group/member/AddGroupMembers.stories.tsx
+++ b/src/features/groups/group/member/AddGroupMembers.stories.tsx
@@ -48,7 +48,7 @@ const AddGroupMembersWrapper = (props: any) => {
 
 const meta: Meta<any> = {
   component: AddGroupMembersWrapper,
-  tags: ['add-group-members'], // NO autodocs on meta
+  tags: ['ff:platform.rbac.itless'], // NO autodocs on meta
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/groups/detail/test-group-id/members']}>

--- a/src/features/groups/group/members/GroupMembers.stories.tsx
+++ b/src/features/groups/group/members/GroupMembers.stories.tsx
@@ -229,6 +229,7 @@ type Story = StoryObj<typeof GroupMembers>;
 
 // Simple test to verify Outlet context works
 export const SimpleContextTest: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: createMockHandlers(),
     permissions: {
@@ -305,6 +306,7 @@ For testing specific scenarios, see these additional stories:
 
 // Member list WITH permissions (interactive)
 export const WithPermissions: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: {
       handlers: createMockHandlers(),
@@ -450,6 +452,7 @@ export const DefaultPlatformGroup: Story = {
 
 // Test filtering functionality (requires permissions)
 export const FilterMembers: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: {
       handlers: [
@@ -526,6 +529,7 @@ export const FilterMembers: Story = {
 
 // Test Add member button and toolbar functionality
 export const AddMemberButton: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: {
       handlers: createMockHandlers(),
@@ -567,6 +571,7 @@ export const AddMemberButton: Story = {
 
 // Test bulk selection functionality
 export const BulkSelection: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: createMockHandlers(),
     permissions: {
@@ -621,6 +626,7 @@ export const BulkSelection: Story = {
 
 // Test toolbar actions state based on selection
 export const ToolbarActionsState: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: {
       handlers: createMockHandlers(),
@@ -684,6 +690,7 @@ export const ToolbarActionsState: Story = {
 
 // Test individual row actions
 export const RowActions: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     msw: {
       handlers: createMockHandlers(),

--- a/src/features/groups/group/role/AddGroupRoles.stories.tsx
+++ b/src/features/groups/group/role/AddGroupRoles.stories.tsx
@@ -151,7 +151,7 @@ const AddGroupRolesWithData = (props: any) => {
 
 const meta: Meta<any> = {
   component: AddGroupRolesWithData,
-  tags: ['add-group-roles', 'modal-testing', 'filtering-pagination'],
+  tags: ['custom-css'],
   parameters: {
     msw: {
       handlers: [

--- a/src/features/groups/group/role/GroupRoles.stories.tsx
+++ b/src/features/groups/group/role/GroupRoles.stories.tsx
@@ -91,7 +91,7 @@ const GroupRolesWrapper: React.FC<{ groupId?: string }> = () => {
 
 const meta: Meta<typeof GroupRolesWrapper> = {
   component: GroupRolesWrapper,
-  tags: ['group-roles'], // NO autodocs on meta
+  tags: ['custom-css'], // NO autodocs on meta
   decorators: [
     (Story, { parameters }) => (
       <MemoryRouter initialEntries={[`/groups/detail/${parameters?.groupId || 'test-group-id'}/roles`]}>
@@ -110,7 +110,7 @@ export default meta;
 type Story = StoryObj<typeof GroupRolesWrapper>;
 
 export const Default: Story = {
-  tags: ['autodocs'],
+  tags: ['autodocs', 'perm:user-access-admin'],
   parameters: {
     docs: {
       description: {
@@ -250,6 +250,7 @@ export const WithoutPermissions: Story = {
 };
 
 export const DefaultGroupRoles: Story = {
+  tags: ['perm:user-access-admin'],
   parameters: {
     groupId: 'default-group-id',
     permissions: {
@@ -316,6 +317,7 @@ export const DefaultGroupRoles: Story = {
 };
 
 export const BulkSelection: Story = {
+  tags: ['perm:user-access-admin'],
   parameters: {
     permissions: {
       userAccessAdministrator: true,
@@ -423,6 +425,7 @@ export const LoadingState: Story = {
 };
 
 export const EmptyState: Story = {
+  tags: ['perm:user-access-admin'],
   parameters: {
     permissions: {
       userAccessAdministrator: true,

--- a/src/features/groups/group/service-account/GroupServiceAccounts.stories.tsx
+++ b/src/features/groups/group/service-account/GroupServiceAccounts.stories.tsx
@@ -42,7 +42,7 @@ const GroupServiceAccountsWrapper: React.FC = () => {
 
 const meta: Meta<typeof GroupServiceAccountsWrapper> = {
   component: GroupServiceAccountsWrapper,
-  tags: ['group-service-accounts'], // NO autodocs on meta
+  tags: ['custom-css'], // NO autodocs on meta
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/groups/detail/test-group-id/service-accounts']}>
@@ -332,6 +332,7 @@ export const AdminDefault: Story = {
 };
 
 export const WithSelection: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     permissions: {
       orgAdmin: true,
@@ -362,6 +363,7 @@ export const WithSelection: Story = {
 // 🚨 NEW COMPREHENSIVE STORIES TO FIX CRITICAL GAPS
 
 export const ServiceAccountWorkflows: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     permissions: {
       orgAdmin: true,
@@ -448,6 +450,7 @@ export const ServiceAccountWorkflows: Story = {
 };
 
 export const ServiceAccountsFilteringWithData: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     permissions: {
       orgAdmin: true,
@@ -608,6 +611,7 @@ export const ServiceAccountsFilteringWithData: Story = {
  */
 export const AddServiceAccountLinkTest: Story = {
   name: 'Add Service Account Link Test',
+  tags: ['perm:user-access-admin'],
   parameters: {
     docs: { disable: true }, // Hide from docs as this is a test story
     permissions: {
@@ -673,6 +677,7 @@ export const AddServiceAccountLinkTest: Story = {
  */
 export const BulkActionsTest: Story = {
   name: 'Bulk Actions Test',
+  tags: ['perm:user-access-admin'],
   parameters: {
     docs: { disable: true },
     permissions: {
@@ -796,6 +801,7 @@ export const BulkActionsTest: Story = {
  */
 export const SelectAllTest: Story = {
   name: 'Select All Functionality Test',
+  tags: ['perm:user-access-admin'],
   parameters: {
     docs: { disable: true },
     permissions: {
@@ -936,6 +942,7 @@ export const SelectAllTest: Story = {
 
 export const ActionsTest: Story = {
   name: 'Actions Test',
+  tags: ['perm:user-access-admin'],
   parameters: {
     docs: { disable: true }, // Hide from docs as this is a test story
     permissions: {

--- a/src/features/myUserAccess/AccessTable.stories.tsx
+++ b/src/features/myUserAccess/AccessTable.stories.tsx
@@ -24,7 +24,6 @@ const mockPermissions = [
 
 const meta: Meta<typeof AccessTable> = {
   component: AccessTable,
-  tags: ['access-table'], // NO autodocs on meta
   parameters: {},
   args: {
     apps: ['advisor', 'compliance', 'vulnerability'],

--- a/src/features/myUserAccess/MyUserAccess.stories.tsx
+++ b/src/features/myUserAccess/MyUserAccess.stories.tsx
@@ -8,7 +8,7 @@ import { MyUserAccess } from './MyUserAccess';
 
 const meta: Meta<typeof MyUserAccess> = {
   component: MyUserAccess,
-  tags: ['my-user-access'], // NO autodocs on meta
+  tags: ['custom-css'], // NO autodocs on meta
   parameters: {
     // Use existing Chrome provider to mock user and entitlements
     chrome: {
@@ -847,6 +847,7 @@ Tests that filters are properly reset when navigating between bundles.
 
 // Additional story for admin user experience
 export const OrgAdminView: Story = {
+  tags: ['perm:org-admin'],
   args: {
     // Test with default bundle logic for admin user
     bundle: undefined,
@@ -1004,6 +1005,7 @@ export const LimitedEntitlements: Story = {
 
 // Responsive navigation story for small viewports
 export const ResponsiveNavigation: Story = {
+  tags: ['perm:org-admin'],
   globals: {
     viewport: { value: 'mobile2' }, // Large mobile viewport for responsive breakpoint
   },

--- a/src/features/myUserAccess/RolesTable.stories.tsx
+++ b/src/features/myUserAccess/RolesTable.stories.tsx
@@ -42,7 +42,6 @@ const mockRolePermissions = [
 
 const meta: Meta<typeof RolesTable> = {
   component: RolesTable,
-  tags: ['roles-table'], // NO autodocs on meta
   parameters: {
     msw: {
       handlers: [

--- a/src/features/myUserAccess/components/BundleCard.stories.tsx
+++ b/src/features/myUserAccess/components/BundleCard.stories.tsx
@@ -12,7 +12,7 @@ interface BundleCardProps {
 
 const meta: Meta<BundleCardProps> = {
   component: BundleCard,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'custom-css'],
   parameters: {
     docs: {
       description: {

--- a/src/features/myUserAccess/components/UserAccessLayout.stories.tsx
+++ b/src/features/myUserAccess/components/UserAccessLayout.stories.tsx
@@ -6,7 +6,7 @@ import { UserAccessLayout } from './UserAccessLayout';
 
 const meta: Meta<typeof UserAccessLayout> = {
   component: UserAccessLayout,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'custom-css'],
   parameters: {},
   decorators: [
     (Story: React.ComponentType) => (

--- a/src/features/overview/overview.stories.tsx
+++ b/src/features/overview/overview.stories.tsx
@@ -24,7 +24,7 @@ const OverviewWithFeatureFlags: React.FC<OverviewArgs> = ({ isWorkspacesEnabled,
 
 const meta: Meta<OverviewArgs> = {
   component: Overview,
-  tags: ['autodocs'],
+  tags: ['autodocs', 'custom-css'],
   argTypes: {
     isWorkspacesEnabled: {
       control: 'boolean',

--- a/src/features/roles/roles.stories.tsx
+++ b/src/features/roles/roles.stories.tsx
@@ -100,7 +100,6 @@ const withRouter = (Story: any) => (
 
 const meta: Meta<typeof Roles> = {
   component: Roles,
-  tags: ['roles-container'],
   decorators: [withRouter],
   parameters: {
     docs: {
@@ -128,7 +127,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const AdminUserWithRoles: Story = {
-  tags: ['autodocs'],
+  tags: ['autodocs', 'perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -305,6 +304,7 @@ After the fix is applied, this test should **PASS** with zero API calls.
 };
 
 export const LoadingState: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -341,6 +341,7 @@ export const LoadingState: Story = {
 };
 
 export const EmptyRoles: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -382,6 +383,7 @@ const filterSpy = fn();
 const sortSpy = fn();
 
 export const AdminUserWithRolesFiltering: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -473,6 +475,7 @@ export const AdminUserWithRolesFiltering: Story = {
 };
 
 export const AdminUserWithRolesExpandableContent: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -570,6 +573,7 @@ export const AdminUserWithRolesExpandableContent: Story = {
 };
 
 export const AdminUserWithRolesSorting: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {
@@ -690,6 +694,7 @@ export const AdminUserWithRolesSorting: Story = {
 };
 
 export const AdminUserWithRolesPrimaryActions: Story = {
+  tags: ['perm:org-admin'],
   parameters: {
     docs: {
       description: {

--- a/src/features/users/users-list-not-selectable.stories.tsx
+++ b/src/features/users/users-list-not-selectable.stories.tsx
@@ -65,7 +65,6 @@ const withRouter = (Story: any) => (
 
 const meta: Meta<typeof UsersListNotSelectable> = {
   component: UsersListNotSelectable,
-  tags: ['users-container'],
   decorators: [withRouter],
   parameters: {
     docs: {
@@ -111,7 +110,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const AdminUserWithUsers: Story = {
-  tags: ['autodocs'],
+  tags: ['autodocs', 'perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {
@@ -257,6 +256,7 @@ After the fix is applied, this test should **PASS** with zero API calls.
 };
 
 export const LoadingState: Story = {
+  tags: ['perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {
@@ -290,6 +290,7 @@ export const LoadingState: Story = {
 };
 
 export const EmptyUsers: Story = {
+  tags: ['perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {
@@ -323,6 +324,7 @@ export const EmptyUsers: Story = {
 };
 
 export const AdminUserWithUsersFiltering: Story = {
+  tags: ['perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {
@@ -394,6 +396,7 @@ export const AdminUserWithUsersFiltering: Story = {
 };
 
 export const AdminUserWithUsersSorting: Story = {
+  tags: ['perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {
@@ -471,6 +474,7 @@ export const AdminUserWithUsersSorting: Story = {
 };
 
 export const AdminUserWithUsersTableContent: Story = {
+  tags: ['perm:org-admin'],
   args: defaultArgs,
   parameters: {
     docs: {

--- a/src/features/workspaces/EditWorkspaceModal.stories.tsx
+++ b/src/features/workspaces/EditWorkspaceModal.stories.tsx
@@ -71,7 +71,7 @@ const ModalWrapper = ({ storyArgs }: { storyArgs: any }) => {
 
 const meta: Meta<typeof EditWorkspaceModal> = {
   component: EditWorkspaceModal,
-  tags: ['autodocs', 'workspaces', 'workspace-edit-modal'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/WorkspaceList.stories.tsx
+++ b/src/features/workspaces/WorkspaceList.stories.tsx
@@ -24,7 +24,7 @@ const withRouter = (Story: any) => {
 
 const meta: Meta<typeof WorkspaceList> = {
   component: WorkspaceList,
-  tags: ['workspaces', 'workspace-list'],
+  tags: ['ff:platform.rbac.workspaces', 'env:prod', 'perm:org-admin'],
   decorators: [withRouter],
   parameters: {
     // Use global providers for these (configured in .storybook/preview.tsx)
@@ -244,6 +244,7 @@ export const PermissionIntegration: Story = {
 const moveWorkspaceSpy = fn();
 
 export const MoveWorkspaceModal: Story = {
+  tags: ['env:stage', 'perm:org-admin'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/components/MoveWorkspaceDialog.stories.tsx
+++ b/src/features/workspaces/components/MoveWorkspaceDialog.stories.tsx
@@ -116,7 +116,7 @@ const withProviders = (Story: any) => {
 
 const meta: Meta<typeof MoveWorkspaceDialog> = {
   component: MoveWorkspaceDialog,
-  tags: ['autodocs', 'workspaces', 'move-workspace-dialog'],
+  tags: ['autodocs'],
   decorators: [withProviders],
   parameters: {
     msw: {

--- a/src/features/workspaces/components/WorkspaceActions.stories.tsx
+++ b/src/features/workspaces/components/WorkspaceActions.stories.tsx
@@ -38,7 +38,7 @@ const withProviders = (Story: any) => {
 
 const meta: Meta<typeof WorkspaceActions> = {
   component: WorkspaceActions,
-  tags: ['autodocs', 'workspaces', 'workspace-actions'],
+  tags: ['autodocs'],
   decorators: [withProviders],
   parameters: {
     docs: {

--- a/src/features/workspaces/components/WorkspaceHeader.stories.tsx
+++ b/src/features/workspaces/components/WorkspaceHeader.stories.tsx
@@ -46,7 +46,7 @@ const withProviders = (Story: any) => {
 
 const meta: Meta<typeof WorkspaceHeader> = {
   component: WorkspaceHeader,
-  tags: ['autodocs', 'workspaces', 'workspace-header'],
+  tags: ['autodocs'],
   decorators: [withProviders],
   parameters: {
     docs: {

--- a/src/features/workspaces/components/WorkspaceListTable.stories.tsx
+++ b/src/features/workspaces/components/WorkspaceListTable.stories.tsx
@@ -27,7 +27,7 @@ const defaultProps = {
 
 const meta: Meta<typeof WorkspaceListTable> = {
   component: WorkspaceListTable,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/components/managed-selector/ManagedSelector.stories.tsx
+++ b/src/features/workspaces/components/managed-selector/ManagedSelector.stories.tsx
@@ -50,7 +50,7 @@ const duplicateWorkspacesHandler = http.get('/api/rbac/v2/workspaces/*', () => {
 
 const meta: Meta<typeof ManagedSelector> = {
   component: ManagedSelector,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/components/managed-selector/components/WorkspaceMenuToggle.stories.tsx
+++ b/src/features/workspaces/components/managed-selector/components/WorkspaceMenuToggle.stories.tsx
@@ -5,7 +5,7 @@ import { WorkspaceMenuToggle } from './WorkspaceMenuToggle';
 
 const meta: Meta<typeof WorkspaceMenuToggle> = {
   component: WorkspaceMenuToggle,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/components/managed-selector/components/WorkspaceSelector.stories.tsx
+++ b/src/features/workspaces/components/managed-selector/components/WorkspaceSelector.stories.tsx
@@ -11,7 +11,7 @@ import { Alert, AlertVariant } from '@patternfly/react-core/dist/dynamic/compone
 
 const meta: Meta<typeof WorkspaceSelector> = {
   component: WorkspaceSelector,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs', 'custom-css'],
   parameters: {
     docs: {
       story: {

--- a/src/features/workspaces/components/managed-selector/components/WorkspaceTreeView.stories.tsx
+++ b/src/features/workspaces/components/managed-selector/components/WorkspaceTreeView.stories.tsx
@@ -5,7 +5,7 @@ import { TreeViewWorkspaceItem, WorkspaceTreeView } from './WorkspaceTreeView';
 
 const meta: Meta<typeof WorkspaceTreeView> = {
   component: WorkspaceTreeView,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs'],
   parameters: {
     // Chromatic configuration to reduce flakiness
     chromatic: {

--- a/src/features/workspaces/create-workspace/CreateWorkspaceWizard.stories.tsx
+++ b/src/features/workspaces/create-workspace/CreateWorkspaceWizard.stories.tsx
@@ -59,7 +59,7 @@ const createWorkspaceSpy = fn();
 
 const meta: Meta<typeof CreateWorkspaceWizard> = {
   component: CreateWorkspaceWizard,
-  tags: ['autodocs', 'workspaces', 'create-workspace-wizard'],
+  tags: ['autodocs', 'ff:platform.rbac.workspaces', 'ff:platform.rbac.workspace-hierarchy', 'ff:platform.rbac.workspaces-billing-features'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/overview/WorkspacesOverview.stories.tsx
+++ b/src/features/workspaces/overview/WorkspacesOverview.stories.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 const meta: Meta<typeof WorkspacesOverview> = {
   component: WorkspacesOverview,
-  tags: ['autodocs', 'workspaces', 'workspaces-overview'],
+  tags: ['autodocs'],
   decorators: [
     (Story) => (
       <BrowserRouter>

--- a/src/features/workspaces/overview/components/EnableWorkspacesAlert.stories.tsx
+++ b/src/features/workspaces/overview/components/EnableWorkspacesAlert.stories.tsx
@@ -10,7 +10,7 @@ interface FeatureFlagContextArgs {
 
 const meta: Meta<typeof EnableWorkspacesAlert> = {
   component: EnableWorkspacesAlert,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs', 'custom-css'],
   parameters: {
     backgrounds: {
       default: 'console',

--- a/src/features/workspaces/workspace-detail/WorkspaceDetail.stories.tsx
+++ b/src/features/workspaces/workspace-detail/WorkspaceDetail.stories.tsx
@@ -136,7 +136,7 @@ const workspaceDetailHandlers = [
 
 const meta: Meta<typeof WorkspaceDetail> = {
   component: WorkspaceDetail,
-  tags: ['workspaces', 'workspace-detail'],
+  tags: ['ff:platform.rbac.workspaces-role-bindings'],
   decorators: [withRouter],
   parameters: {
     chrome: {

--- a/src/features/workspaces/workspace-detail/components/AssetsCards.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/AssetsCards.stories.tsx
@@ -5,7 +5,7 @@ import AssetsCards from './AssetsCards';
 
 const meta: Meta<typeof AssetsCards> = {
   component: AssetsCards,
-  tags: ['autodocs', 'workspaces'],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/GroupDetailsDrawer.stories.tsx
@@ -145,7 +145,7 @@ const withWrapper = () => {
 
 const meta: Meta<typeof GroupDetailsDrawer> = {
   component: GroupDetailsDrawer,
-  tags: ['autodocs', 'workspaces', 'group-details-drawer'],
+  tags: ['autodocs'],
   decorators: [withWrapper()],
   parameters: {
     msw: {

--- a/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.stories.tsx
+++ b/src/features/workspaces/workspace-detail/components/RoleAssignmentsTable.stories.tsx
@@ -88,7 +88,7 @@ const groupDetailsHandlers = [
 
 const meta: Meta<typeof RoleAssignmentsTable> = {
   component: RoleAssignmentsTable,
-  tags: ['autodocs', 'workspaces', 'role-assignments-table'],
+  tags: ['autodocs'],
   parameters: {
     msw: {
       handlers: groupDetailsHandlers,


### PR DESCRIPTION
Cleans up Storybook stories tags, and tag stories using feature flags or custom css.


https://github.com/user-attachments/assets/80bc7bef-fc8f-4d41-8ae8-f6efdabca7e6

## Summary by Sourcery

Clean up Storybook story metadata tags across the codebase by replacing outdated tags with standardized feature flag and custom CSS tags and removing obsolete ones.

Chores:
- Replace generic and component-specific tags with feature flag tags (ff:platform.rbac.*) for RBAC-related stories
- Add custom-css tags to stories that require custom styling
- Remove deprecated tags such as autodocs, test-related, and redundant container tags