### PR TITLE
V2 defaultaccess issues

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1981,6 +1981,16 @@ export default defineMessages({
     description: 'Users inherited roles message',
     defaultMessage: 'This group contains the roles that all users in your organization inherit by default.',
   },
+  defaultGroupInfoAriaLabel: {
+    id: 'defaultGroupInfoAriaLabel',
+    description: 'Aria label for default group info popover button',
+    defaultMessage: 'Default group information',
+  },
+  adminDefaultGroupInfoAriaLabel: {
+    id: 'adminDefaultGroupInfoAriaLabel',
+    description: 'Aria label for admin default group info popover button',
+    defaultMessage: 'Admin default group information',
+  },
   invalidGroup: {
     id: 'invalidGroup',
     description: 'Invalid group message',
@@ -2741,6 +2751,61 @@ export default defineMessages({
     description: 'Restore Custom Default Access group description',
     defaultMessage:
       'Restoring <b>Default access</b> group will remove <b>Custom default access</b> group. <b>Custom default access</b> configurations cannot be recovered. Are you sure?',
+  },
+  restoreDefaultAccessSuccess: {
+    id: 'restoreDefaultAccessSuccess',
+    description: 'Success message when Default access group is restored',
+    defaultMessage: 'The Default access group has been restored to system defaults.',
+  },
+  restoreGroupError: {
+    id: 'restoreGroupError',
+    description: 'Error message when restoring group fails',
+    defaultMessage: 'There was an error restoring the Default access group.',
+  },
+  cannotEditAdminDefaultGroup: {
+    id: 'cannotEditAdminDefaultGroup',
+    description: 'Error message when trying to edit Default admin access group',
+    defaultMessage: 'Cannot edit Default admin access group',
+  },
+  cannotEditAdminDefaultGroupDescription: {
+    id: 'cannotEditAdminDefaultGroupDescription',
+    description: 'Description for error when trying to edit Default admin access group',
+    defaultMessage: 'The Default admin access group cannot be edited. This is a system-managed group.',
+  },
+  groupCreatedSuccess: {
+    id: 'groupCreatedSuccess',
+    description: 'Success message when group is created',
+    defaultMessage: 'Group created successfully',
+  },
+  groupCreatedDescription: {
+    id: 'groupCreatedDescription',
+    description: 'Description for group creation success',
+    defaultMessage: 'The group has been created.',
+  },
+  defaultAccessGroupCustomized: {
+    id: 'defaultAccessGroupCustomized',
+    description: 'Success message when Default access group is customized',
+    defaultMessage: 'Default access group customized',
+  },
+  defaultAccessGroupCustomizedDescription: {
+    id: 'defaultAccessGroupCustomizedDescription',
+    description: 'Description when Default access group is customized',
+    defaultMessage: 'The group has been customized and is no longer managed by the system.',
+  },
+  editDefaultAccessGroupWarningTitle: {
+    id: 'editDefaultAccessGroupWarningTitle',
+    description: 'Warning title when editing unmodified Default access group',
+    defaultMessage: 'You are editing the Default access group',
+  },
+  fieldEditableAfterCustomization: {
+    id: 'fieldEditableAfterCustomization',
+    description: 'Helper text explaining field will be editable after customization',
+    defaultMessage: 'This field will be editable after the group is customized by adding or removing members or service accounts.',
+  },
+  acknowledgeDefaultGroupCustomization: {
+    id: 'acknowledgeDefaultGroupCustomization',
+    description: 'Checkbox label to acknowledge customizing Default access group',
+    defaultMessage: 'I understand that saving will customize the Default access group.',
   },
   noGroups: {
     id: 'noGroups',

--- a/src/shared/data/queries/groups.ts
+++ b/src/shared/data/queries/groups.ts
@@ -711,8 +711,10 @@ export function useDeleteGroupMutation(options?: MutationOptions) {
         await groupsApi.deleteGroup({ uuid });
       },
       onSuccess: () => {
-        qc.invalidateQueries({ queryKey: groupsKeys.all });
-        notify('success', intl.formatMessage(messages.removeGroupSuccess));
+        if (!options?.deferSuccessSideEffects) {
+          qc.invalidateQueries({ queryKey: groupsKeys.all });
+          notify('success', intl.formatMessage(messages.removeGroupSuccess));
+        }
       },
       onError: () => {
         notify('danger', intl.formatMessage(messages.removeGroupError));

--- a/src/v2/data/queries/groupAssignments.ts
+++ b/src/v2/data/queries/groupAssignments.ts
@@ -12,6 +12,7 @@ import type { RoleBindingsGroupSubject, RoleBindingsRoleBindingBySubject } from 
 import messages from '../../../Messages';
 import { useRoleAssignmentsQuery } from './roles';
 import { useRoleBindingsQuery } from './workspaces';
+import { useSystemGroupQuery, useAdminGroupQuery } from '../../../shared/data/queries/groups';
 
 // =============================================================================
 // Raw API narrowing (rbac-client → typed binding)
@@ -56,26 +57,33 @@ export interface InheritedWorkspaceGroupRow extends WorkspaceGroupRow {
 // Private transformer (rbac-client type IN → UI model OUT)
 // =============================================================================
 
-/** V2 API does not expose platform_default/admin_default — detect by well-known names only */
-const DEFAULT_GROUP_NAMES = new Set(['default access', 'default admin access']);
-const ADMIN_DEFAULT_NAME = 'default admin access';
-
-function isDefaultGroupName(name: string): boolean {
-  return DEFAULT_GROUP_NAMES.has(name.toLowerCase());
+/**
+ * UUID-based detection for default groups.
+ * Checks subject.id against known default group UUIDs.
+ * This is more reliable than name-based detection, which breaks when
+ * "Default access" is customized and renamed to "Custom default access".
+ */
+interface DefaultGroupUUIDs {
+  systemGroupUuid?: string;
+  adminGroupUuid?: string;
 }
 
-function isAdminDefaultGroupName(name: string): boolean {
-  return name.toLowerCase() === ADMIN_DEFAULT_NAME;
-}
-
-function toWorkspaceGroupRow(binding: WorkspaceGroupBinding, labels: { allUsers: string; allOrgAdmins: string }): WorkspaceGroupRow {
+function toWorkspaceGroupRow(
+  binding: WorkspaceGroupBinding,
+  labels: { allUsers: string; allOrgAdmins: string },
+  defaultGroupUuids: DefaultGroupUUIDs = {},
+): WorkspaceGroupRow {
   const { subject } = binding;
+  const subjectId = subject?.id ?? '';
   const name = subject?.group?.name ?? '';
-  const isDefault = isDefaultGroupName(name);
-  const isAdmin = isAdminDefaultGroupName(name);
+
+  // UUID-based detection (preferred)
+  const isDefault = subjectId === defaultGroupUuids.systemGroupUuid || subjectId === defaultGroupUuids.adminGroupUuid;
+  const isAdmin = subjectId === defaultGroupUuids.adminGroupUuid;
+
   const roles: WorkspaceGroupRole[] = (binding.roles ?? []).map((r) => ({ id: r.id ?? '', name: r.name ?? '' }));
   return {
-    id: subject?.id ?? name,
+    id: subjectId || name,
     name,
     description: subject?.group?.description ?? '',
     userCount: isDefault ? (isAdmin ? labels.allOrgAdmins : labels.allUsers) : (subject?.group?.user_count ?? 0),
@@ -87,8 +95,12 @@ function toWorkspaceGroupRow(binding: WorkspaceGroupBinding, labels: { allUsers:
   };
 }
 
-function transformBindings(data: WorkspaceGroupBinding[], labels: { allUsers: string; allOrgAdmins: string }): WorkspaceGroupRow[] {
-  return data.map((b) => toWorkspaceGroupRow(b, labels)).filter((row) => row.roleCount > 0);
+function transformBindings(
+  data: WorkspaceGroupBinding[],
+  labels: { allUsers: string; allOrgAdmins: string },
+  defaultGroupUuids: DefaultGroupUUIDs = {},
+): WorkspaceGroupRow[] {
+  return data.map((b) => toWorkspaceGroupRow(b, labels, defaultGroupUuids)).filter((row) => row.roleCount > 0);
 }
 
 // =============================================================================
@@ -105,6 +117,10 @@ export function useWorkspaceGroups(workspaceId: string, options?: { enabled?: bo
   const intl = useIntl();
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
+  // Fetch default group UUIDs for reliable detection
+  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+
   const query = useRoleAssignmentsQuery(workspaceId, {
     enabled: options?.enabled ?? true,
     limit: ROLE_BINDINGS_LIMIT,
@@ -112,8 +128,14 @@ export function useWorkspaceGroups(workspaceId: string, options?: { enabled?: bo
   });
 
   const data = useMemo(
-    () => (query.data?.data ? transformBindings(query.data.data as WorkspaceGroupBinding[], labels) : []),
-    [query.data, labels.allUsers, labels.allOrgAdmins],
+    () =>
+      query.data?.data
+        ? transformBindings(query.data.data as WorkspaceGroupBinding[], labels, {
+            systemGroupUuid: systemGroup?.uuid,
+            adminGroupUuid: adminGroup?.uuid,
+          })
+        : [],
+    [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid],
   );
 
   return { data, isLoading: query.isLoading };
@@ -128,6 +150,10 @@ export function useWorkspaceInheritedGroups(workspaceId: string, options?: { ena
   const intl = useIntl();
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
+  // Fetch default group UUIDs for reliable detection
+  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+
   const query = useRoleAssignmentsQuery(workspaceId, {
     enabled: options?.enabled ?? true,
     limit: ROLE_BINDINGS_LIMIT,
@@ -137,10 +163,14 @@ export function useWorkspaceInheritedGroups(workspaceId: string, options?: { ena
   const data: InheritedWorkspaceGroupRow[] = useMemo(() => {
     if (!query.data?.data) return [];
     const bindings = query.data.data as WorkspaceGroupBinding[];
+    const defaultGroupUuids = {
+      systemGroupUuid: systemGroup?.uuid,
+      adminGroupUuid: adminGroup?.uuid,
+    };
     const seen = new Set<string>();
     return bindings
       .map((binding): InheritedWorkspaceGroupRow => {
-        const row = toWorkspaceGroupRow(binding, labels);
+        const row = toWorkspaceGroupRow(binding, labels, defaultGroupUuids);
         const source = binding.sources?.[0];
         return {
           ...row,
@@ -153,7 +183,7 @@ export function useWorkspaceInheritedGroups(workspaceId: string, options?: { ena
         seen.add(row.id);
         return true;
       });
-  }, [query.data, labels.allUsers, labels.allOrgAdmins]);
+  }, [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid]);
 
   return { data, isLoading: query.isLoading };
 }
@@ -166,6 +196,10 @@ export function useOrgGroups(organizationId: string, options?: { enabled?: boole
   const intl = useIntl();
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
+  // Fetch default group UUIDs for reliable detection
+  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+
   const query = useRoleBindingsQuery(
     {
       resourceId: `redhat/${organizationId}`,
@@ -177,8 +211,14 @@ export function useOrgGroups(organizationId: string, options?: { enabled?: boole
   );
 
   const data = useMemo(
-    () => (query.data?.data ? transformBindings(query.data.data as WorkspaceGroupBinding[], labels) : []),
-    [query.data, labels.allUsers, labels.allOrgAdmins],
+    () =>
+      query.data?.data
+        ? transformBindings(query.data.data as WorkspaceGroupBinding[], labels, {
+            systemGroupUuid: systemGroup?.uuid,
+            adminGroupUuid: adminGroup?.uuid,
+          })
+        : [],
+    [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid],
   );
 
   return { data, isLoading: query.isLoading };

--- a/src/v2/data/queries/groupAssignments.ts
+++ b/src/v2/data/queries/groupAssignments.ts
@@ -118,8 +118,8 @@ export function useWorkspaceGroups(workspaceId: string, options?: { enabled?: bo
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
   // Fetch default group UUIDs for reliable detection
-  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
-  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: systemGroup, isLoading: systemGroupLoading } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup, isLoading: adminGroupLoading } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
 
   const query = useRoleAssignmentsQuery(workspaceId, {
     enabled: options?.enabled ?? true,
@@ -138,7 +138,7 @@ export function useWorkspaceGroups(workspaceId: string, options?: { enabled?: bo
     [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid],
   );
 
-  return { data, isLoading: query.isLoading };
+  return { data, isLoading: query.isLoading || systemGroupLoading || adminGroupLoading };
 }
 
 /**
@@ -151,8 +151,8 @@ export function useWorkspaceInheritedGroups(workspaceId: string, options?: { ena
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
   // Fetch default group UUIDs for reliable detection
-  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
-  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: systemGroup, isLoading: systemGroupLoading } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup, isLoading: adminGroupLoading } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
 
   const query = useRoleAssignmentsQuery(workspaceId, {
     enabled: options?.enabled ?? true,
@@ -185,7 +185,7 @@ export function useWorkspaceInheritedGroups(workspaceId: string, options?: { ena
       });
   }, [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid]);
 
-  return { data, isLoading: query.isLoading };
+  return { data, isLoading: query.isLoading || systemGroupLoading || adminGroupLoading };
 }
 
 /**
@@ -197,8 +197,8 @@ export function useOrgGroups(organizationId: string, options?: { enabled?: boole
   const labels = { allUsers: intl.formatMessage(messages.allUsers), allOrgAdmins: intl.formatMessage(messages.allOrgAdmins) };
 
   // Fetch default group UUIDs for reliable detection
-  const { data: systemGroup } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
-  const { data: adminGroup } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: systemGroup, isLoading: systemGroupLoading } = useSystemGroupQuery({ enabled: options?.enabled ?? true });
+  const { data: adminGroup, isLoading: adminGroupLoading } = useAdminGroupQuery({ enabled: options?.enabled ?? true });
 
   const query = useRoleBindingsQuery(
     {
@@ -221,5 +221,5 @@ export function useOrgGroups(organizationId: string, options?: { enabled?: boole
     [query.data, labels.allUsers, labels.allOrgAdmins, systemGroup?.uuid, adminGroup?.uuid],
   );
 
-  return { data, isLoading: query.isLoading };
+  return { data, isLoading: query.isLoading || systemGroupLoading || adminGroupLoading };
 }

--- a/src/v2/data/queries/groupAssignments.ts
+++ b/src/v2/data/queries/groupAssignments.ts
@@ -12,7 +12,7 @@ import type { RoleBindingsGroupSubject, RoleBindingsRoleBindingBySubject } from 
 import messages from '../../../Messages';
 import { useRoleAssignmentsQuery } from './roles';
 import { useRoleBindingsQuery } from './workspaces';
-import { useSystemGroupQuery, useAdminGroupQuery } from '../../../shared/data/queries/groups';
+import { useAdminGroupQuery, useSystemGroupQuery } from '../../../shared/data/queries/groups';
 
 // =============================================================================
 // Raw API narrowing (rbac-client → typed binding)

--- a/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DefaultGroupChangedIcon } from './DefaultGroupChangedIcon';
+
+const meta = {
+  title: 'V2/Users and User Groups/Components/DefaultGroupChangedIcon',
+  component: DefaultGroupChangedIcon,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Displays a group name with an info icon for customized default groups. The popover explains that the group has been customized and is no longer system-managed.',
+      },
+    },
+  },
+} satisfies Meta<typeof DefaultGroupChangedIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Group name with info icon for a customized default group.
+ * Shows when platform_default=true AND system=false.
+ */
+export const CustomizedDefaultGroup: Story = {
+  args: {
+    name: 'Custom default access',
+  },
+};
+
+/**
+ * Example with longer group name
+ */
+export const LongGroupName: Story = {
+  args: {
+    name: 'Custom default access with a very long name that might wrap',
+  },
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { DefaultGroupChangedIcon } from './DefaultGroupChangedIcon';
 
 const meta = {
@@ -8,7 +8,8 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: 'Displays a group name with an info icon for customized default groups. The popover explains that the group has been customized and is no longer system-managed.',
+        component:
+          'Displays a group name with an info icon for customized default groups. The popover explains that the group has been customized and is no longer system-managed.',
       },
     },
   },

--- a/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultGroupChangedIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
+import { FormattedMessage } from 'react-intl';
+import messages from '../../../../Messages';
+
+interface DefaultGroupChangedIconProps {
+  name: string;
+}
+
+/**
+ * Displays a group name with an info icon and popover for customized default groups.
+ * The popover explains that the group has been customized from the Default access group
+ * and the system will no longer automatically update it.
+ */
+export const DefaultGroupChangedIcon: React.FC<DefaultGroupChangedIconProps> = ({ name }) => {
+  return (
+    <div style={{ display: 'inline-flex' }}>
+      <div style={{ alignSelf: 'center' }}>{name}</div>
+      <Popover
+        aria-label="default-group-icon"
+        bodyContent={
+          <FormattedMessage
+            {...messages.defaultAccessGroupNameChanged}
+            values={{
+              b: (text: React.ReactNode) => <b>{text}</b>,
+            }}
+          />
+        }
+      >
+        <Button
+          icon={<OutlinedQuestionCircleIcon className="rbac-default-group-info-icon" />}
+          variant="plain"
+          aria-label="More information about default group changes"
+        />
+      </Popover>
+    </div>
+  );
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DefaultInfoPopover } from './DefaultInfoPopover';
+
+const meta = {
+  title: 'V2/Users and User Groups/Components/DefaultInfoPopover',
+  component: DefaultInfoPopover,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Info popover displayed next to default group names in the table. Appears on hover (V2) instead of click (V1).',
+      },
+    },
+  },
+} satisfies Meta<typeof DefaultInfoPopover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Popover for platform_default group (Default access)
+ * Shows info about inherited roles for all users.
+ */
+export const PlatformDefaultGroup: Story = {
+  args: {
+    id: 'default-group-popover',
+    uuid: 'platform-default-uuid',
+    bodyContent: 'All users in this organization inherit roles assigned to this group.',
+  },
+};
+
+/**
+ * Popover for admin_default group (Default admin access)
+ * Shows info about inherited roles for org admins.
+ */
+export const AdminDefaultGroup: Story = {
+  args: {
+    id: 'default-admin-group-popover',
+    uuid: 'admin-default-uuid',
+    bodyContent: 'All org admins in this organization inherit roles assigned to this group.',
+  },
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { DefaultInfoPopover } from './DefaultInfoPopover';
 
 const meta = {

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: 'Info popover displayed next to default group names in the table. Appears on hover (V2) instead of click (V1).',
+        component: 'Keyboard-accessible info popover displayed next to default group names in the table. Opens on click or keyboard activation.',
       },
     },
   },
@@ -26,6 +26,7 @@ export const PlatformDefaultGroup: Story = {
     id: 'default-group-popover',
     uuid: 'platform-default-uuid',
     bodyContent: 'All users in this organization inherit roles assigned to this group.',
+    ariaLabel: 'Default group information',
   },
 };
 
@@ -38,5 +39,6 @@ export const AdminDefaultGroup: Story = {
     id: 'default-admin-group-popover',
     uuid: 'admin-default-uuid',
     bodyContent: 'All org admins in this organization inherit roles assigned to this group.',
+    ariaLabel: 'Admin default group information',
   },
 };

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
@@ -1,7 +1,6 @@
 import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
-import classNames from 'classnames';
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 
 interface DefaultInfoPopoverProps {
   id: string;
@@ -19,13 +18,7 @@ export const DefaultInfoPopover: React.FC<DefaultInfoPopoverProps> = ({ id, uuid
 
   return (
     <span ref={popoverRootRef} key={`${uuid}-popover`} id={id}>
-      <Popover
-        zIndex={110}
-        position="right"
-        bodyContent={bodyContent}
-        appendTo={popoverRootRef.current || undefined}
-        triggerAction="hover"
-      >
+      <Popover zIndex={110} position="right" bodyContent={bodyContent} appendTo={popoverRootRef.current || undefined} triggerAction="hover">
         <OutlinedQuestionCircleIcon className="pf-v6-c-question-circle-icon" />
       </Popover>
     </span>

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import React, { useRef } from 'react';
@@ -6,20 +7,23 @@ interface DefaultInfoPopoverProps {
   id: string;
   uuid: string;
   bodyContent: string;
+  ariaLabel: string;
 }
 
 /**
  * Info popover for default groups in the groups table.
  * Shows an info icon with explanatory text about inherited permissions.
- * Popover appears on hover (V2) instead of click (V1).
+ * Keyboard accessible with focus and click/enter support.
  */
-export const DefaultInfoPopover: React.FC<DefaultInfoPopoverProps> = ({ id, uuid, bodyContent }) => {
+export const DefaultInfoPopover: React.FC<DefaultInfoPopoverProps> = ({ id, uuid, bodyContent, ariaLabel }) => {
   const popoverRootRef = useRef<HTMLSpanElement>(null);
 
   return (
     <span ref={popoverRootRef} key={`${uuid}-popover`} id={id}>
-      <Popover zIndex={110} position="right" bodyContent={bodyContent} appendTo={popoverRootRef.current || undefined} triggerAction="hover">
-        <OutlinedQuestionCircleIcon className="pf-v6-c-question-circle-icon" />
+      <Popover zIndex={110} position="right" bodyContent={bodyContent} appendTo={popoverRootRef.current || undefined}>
+        <Button variant="plain" aria-label={ariaLabel}>
+          <OutlinedQuestionCircleIcon className="pf-v6-c-question-circle-icon" />
+        </Button>
       </Popover>
     </span>
   );

--- a/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultInfoPopover.tsx
@@ -1,0 +1,33 @@
+import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
+import classNames from 'classnames';
+import React, { useRef, useState } from 'react';
+
+interface DefaultInfoPopoverProps {
+  id: string;
+  uuid: string;
+  bodyContent: string;
+}
+
+/**
+ * Info popover for default groups in the groups table.
+ * Shows an info icon with explanatory text about inherited permissions.
+ * Popover appears on hover (V2) instead of click (V1).
+ */
+export const DefaultInfoPopover: React.FC<DefaultInfoPopoverProps> = ({ id, uuid, bodyContent }) => {
+  const popoverRootRef = useRef<HTMLSpanElement>(null);
+
+  return (
+    <span ref={popoverRootRef} key={`${uuid}-popover`} id={id}>
+      <Popover
+        zIndex={110}
+        position="right"
+        bodyContent={bodyContent}
+        appendTo={popoverRootRef.current || undefined}
+        triggerAction="hover"
+      >
+        <OutlinedQuestionCircleIcon className="pf-v6-c-question-circle-icon" />
+      </Popover>
+    </span>
+  );
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DefaultMembersAlert } from './DefaultMembersAlert';
+
+const meta = {
+  title: 'V2/Users and User Groups/Components/DefaultMembersAlert',
+  component: DefaultMembersAlert,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Alert shown in default groups to indicate all users/org admins are automatic members.',
+      },
+    },
+  },
+} satisfies Meta<typeof DefaultMembersAlert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Alert for platform_default group (Default access)
+ * Shows that all users are automatically members.
+ */
+export const PlatformDefaultGroup: Story = {
+  args: {
+    isAdminDefault: false,
+  },
+};
+
+/**
+ * Alert for admin_default group (Default admin access)
+ * Shows that all org admins are automatically members.
+ */
+export const AdminDefaultGroup: Story = {
+  args: {
+    isAdminDefault: true,
+  },
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { DefaultMembersAlert } from './DefaultMembersAlert';
 
 const meta = {

--- a/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.tsx
@@ -14,11 +14,5 @@ interface DefaultMembersAlertProps {
 export const DefaultMembersAlert: React.FC<DefaultMembersAlertProps> = ({ isAdminDefault }) => {
   const intl = useIntl();
 
-  return (
-    <Alert
-      variant="info"
-      isInline
-      title={intl.formatMessage(isAdminDefault ? messages.allOrgAdminsAreMembers : messages.allUsersAreMembers)}
-    />
-  );
+  return <Alert variant="info" isInline title={intl.formatMessage(isAdminDefault ? messages.allOrgAdminsAreMembers : messages.allUsersAreMembers)} />;
 };

--- a/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultMembersAlert.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { useIntl } from 'react-intl';
+import messages from '../../../../Messages';
+
+interface DefaultMembersAlertProps {
+  isAdminDefault: boolean;
+}
+
+/**
+ * Alert displayed for default groups indicating that all users (or all org admins)
+ * are automatically members of this group.
+ */
+export const DefaultMembersAlert: React.FC<DefaultMembersAlertProps> = ({ isAdminDefault }) => {
+  const intl = useIntl();
+
+  return (
+    <Alert
+      variant="info"
+      isInline
+      title={intl.formatMessage(isAdminDefault ? messages.allOrgAdminsAreMembers : messages.allUsersAreMembers)}
+    />
+  );
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DefaultServiceAccountsAlert } from './DefaultServiceAccountsAlert';
+
+const meta = {
+  title: 'V2/Users and User Groups/Components/DefaultServiceAccountsAlert',
+  component: DefaultServiceAccountsAlert,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Security compliance alert explaining that service accounts are not automatically included in default groups.',
+      },
+    },
+  },
+} satisfies Meta<typeof DefaultServiceAccountsAlert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Alert for platform_default group (Default access)
+ * Explains service accounts are not included in Default access group.
+ */
+export const PlatformDefaultGroup: Story = {
+  args: {
+    isPlatformDefault: true,
+  },
+};
+
+/**
+ * Alert for admin_default group (Default admin access)
+ * Explains service accounts are not included in Default admin access group.
+ */
+export const AdminDefaultGroup: Story = {
+  args: {
+    isPlatformDefault: false,
+  },
+};

--- a/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { DefaultServiceAccountsAlert } from './DefaultServiceAccountsAlert';
 
 const meta = {

--- a/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.tsx
+++ b/src/v2/features/users-and-user-groups/components/DefaultServiceAccountsAlert.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { useIntl } from 'react-intl';
+import messages from '../../../../Messages';
+
+interface DefaultServiceAccountsAlertProps {
+  isPlatformDefault: boolean;
+}
+
+/**
+ * Alert displayed for default groups explaining that service accounts are not
+ * automatically included in default access groups for security compliance.
+ */
+export const DefaultServiceAccountsAlert: React.FC<DefaultServiceAccountsAlertProps> = ({ isPlatformDefault }) => {
+  const intl = useIntl();
+
+  return (
+    <Alert
+      variant="info"
+      isInline
+      title={intl.formatMessage(isPlatformDefault ? messages.noAccountsInDefaultAccess : messages.noAccountsInDefaultAdminAccess)}
+    />
+  );
+};

--- a/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GroupResetWarningModal } from './GroupResetWarningModal';
+import { fn } from 'storybook/test';
+
+const meta = {
+  title: 'V2/Users and User Groups/Components/GroupResetWarningModal',
+  component: GroupResetWarningModal,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Warning modal shown when user attempts to restore a customized default group to system defaults.',
+      },
+    },
+  },
+  args: {
+    onClose: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof GroupResetWarningModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Modal shown when clicking "Restore to default" on a customized default group.
+ * Warns that restoring will delete customizations and recreate the system-managed version.
+ */
+export const Default: Story = {
+  args: {
+    isOpen: true,
+  },
+};
+
+/**
+ * Closed state (hidden)
+ */
+export const Closed: Story = {
+  args: {
+    isOpen: false,
+  },
+};

--- a/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.stories.tsx
+++ b/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { GroupResetWarningModal } from './GroupResetWarningModal';
 import { fn } from 'storybook/test';
 

--- a/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.tsx
+++ b/src/v2/features/users-and-user-groups/components/GroupResetWarningModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import WarningModal from '@patternfly/react-component-groups/dist/dynamic/WarningModal';
+import messages from '../../../../Messages';
+import { getModalContainer } from '../../../../shared/helpers/modal-container';
+
+interface GroupResetWarningModalProps {
+  /**
+   * Whether the modal is visible
+   */
+  isOpen: boolean;
+
+  /**
+   * Handler for closing the modal
+   */
+  onClose: () => void;
+
+  /**
+   * Handler for confirming the reset action
+   */
+  onConfirm: () => void;
+}
+
+/**
+ * Modal component for confirming default group reset actions.
+ * Warns users that restoring the Default access group will permanently delete
+ * the Custom default access group and all its configurations.
+ */
+export const GroupResetWarningModal: React.FC<GroupResetWarningModalProps> = ({ isOpen, onClose, onConfirm }) => {
+  const intl = useIntl();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <WarningModal
+      isOpen={isOpen}
+      title={intl.formatMessage(messages.restoreDefaultAccessQuestion)}
+      confirmButtonLabel={intl.formatMessage(messages.continue)}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      appendTo={getModalContainer()}
+    >
+      <FormattedMessage
+        {...messages.restoreDefaultAccessDescription}
+        values={{
+          b: (text: React.ReactNode) => <b>{text}</b>,
+        }}
+      />
+    </WarningModal>
+  );
+};

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
@@ -1,13 +1,8 @@
 import React, { Fragment, Suspense, useCallback, useEffect, useState } from 'react';
 import { Outlet, useSearchParams } from 'react-router-dom';
-import { useIntl } from 'react-intl';
 import { DataViewEventsProvider, EventTypes, useDataViewEventsContext } from '@patternfly/react-data-view';
-import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import { TabContent } from '@patternfly/react-core/dist/dynamic/components/Tabs';
-import UsersIcon from '@patternfly/react-icons/dist/js/icons/users-icon';
 import { useGroupsAccess } from '../../../../hooks/useRbacAccess';
-import messages from '../../../../../Messages';
 
 import { useDeleteGroupMutation } from '../../../../../v2/data/queries/groups';
 import useAppNavigate from '../../../../../shared/hooks/useAppNavigate';
@@ -28,7 +23,6 @@ interface UserGroupsProps {
 
 export const UserGroups: React.FC<UserGroupsProps> = ({ groupsRef, defaultPerPage = 20, ouiaId = 'iam-user-groups-table' }) => {
   const navigate = useAppNavigate();
-  const intl = useIntl();
   const [searchParams] = useSearchParams();
 
   // React Query mutation for deleting groups

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
@@ -129,27 +129,32 @@ export const UserGroups: React.FC<UserGroupsProps> = ({ groupsRef, defaultPerPag
   // Individual render functions for each tab
   const renderUsersTab = () => {
     if (!focusedGroup) return null;
-    if (focusedGroup.platform_default || focusedGroup.admin_default) {
-      const isAdmin = !!focusedGroup.admin_default;
-      return (
-        <div className="pf-v6-u-pt-md">
-          <EmptyState
-            variant="sm"
-            headingLevel="h4"
-            icon={UsersIcon}
-            titleText={intl.formatMessage(isAdmin ? messages.allOrgAdmins : messages.allUsers)}
-          >
-            <EmptyStateBody>{intl.formatMessage(isAdmin ? messages.allOrgAdminsAreMembers : messages.allUsersAreMembers)}</EmptyStateBody>
-          </EmptyState>
-        </div>
-      );
-    }
-    return <GroupDetailsUsersView groupId={focusedGroup.uuid} ouiaId={`${ouiaId}-users-view`} />;
+    const isDefaultGroup = !!(focusedGroup.platform_default || focusedGroup.admin_default);
+    const isAdminDefault = !!focusedGroup.admin_default;
+
+    return (
+      <GroupDetailsUsersView
+        groupId={focusedGroup.uuid}
+        ouiaId={`${ouiaId}-users-view`}
+        isDefaultGroup={isDefaultGroup}
+        isAdminDefault={isAdminDefault}
+      />
+    );
   };
 
   const renderServiceAccountsTab = () => {
     if (!focusedGroup) return null;
-    return <GroupDetailsServiceAccountsView groupId={focusedGroup.uuid} ouiaId={`${ouiaId}-service-accounts-view`} />;
+    const isDefaultGroup = !!(focusedGroup.platform_default || focusedGroup.admin_default);
+    const isPlatformDefault = !!focusedGroup.platform_default && !focusedGroup.admin_default;
+
+    return (
+      <GroupDetailsServiceAccountsView
+        groupId={focusedGroup.uuid}
+        ouiaId={`${ouiaId}-service-accounts-view`}
+        isDefaultGroup={isDefaultGroup}
+        isPlatformDefault={isPlatformDefault}
+      />
+    );
   };
 
   const renderRolesTab = () => {

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -722,7 +722,8 @@ export const DefaultGroupsWithPopovers: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Default groups (platform_default and admin_default) display info popovers next to their names explaining inherited roles. Popovers appear on hover.',
+        story:
+          'Default groups (platform_default and admin_default) display info popovers next to their names explaining inherited roles. Popovers appear on hover.',
       },
     },
   },

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -713,3 +713,31 @@ export const DefaultGroupsCounts: Story = {
     });
   },
 };
+
+/**
+ * Default groups with DefaultInfoPopover icons
+ * Shows info popovers next to default group names
+ */
+export const DefaultGroupsWithPopovers: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default groups (platform_default and admin_default) display info popovers next to their names explaining inherited roles. Popovers appear on hover.',
+      },
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify info popovers for default groups', async () => {
+      const canvas = within(canvasElement);
+      await expect(canvas.findByRole('grid')).resolves.toBeInTheDocument();
+
+      // Find the default groups
+      await expect(canvas.findByText(GROUP_SYSTEM_DEFAULT.name)).resolves.toBeInTheDocument();
+      await expect(canvas.findByText(GROUP_ADMIN_DEFAULT.name)).resolves.toBeInTheDocument();
+
+      // Verify info icons are present (question circle icons)
+      const questionIcons = canvas.getAllByRole('img', { hidden: true }).filter((icon) => icon.classList.contains('pf-v6-c-question-circle-icon'));
+      await expect(questionIcons.length).toBeGreaterThanOrEqual(2); // At least 2 for the default groups
+    });
+  },
+};

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
@@ -51,9 +51,10 @@ export function useUserGroupsTableConfig({ intl }: UseUserGroupsTableConfigOptio
               <>
                 {' '}
                 <DefaultInfoPopover
-                  id={`default${group.admin_default ? '-admin' : ''}-group-popover`}
+                  id={`default${group.admin_default ? '-admin' : ''}-group-popover-${group.uuid}`}
                   uuid={group.uuid}
                   bodyContent={intl.formatMessage(group.admin_default ? messages.orgAdminInheritedRoles : messages.usersInheritedRoles)}
+                  ariaLabel={intl.formatMessage(group.admin_default ? messages.adminDefaultGroupInfoAriaLabel : messages.defaultGroupInfoAriaLabel)}
                 />
               </>
             )}

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
@@ -6,6 +6,8 @@ import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip'
 import type { CellRendererMap, ColumnConfigMap, FilterConfig } from '../../../../../../shared/components/table-view';
 import type { Group } from '../../../../../../v2/data/queries/groups';
 import messages from '../../../../../../Messages';
+import { DefaultInfoPopover } from '../../../components/DefaultInfoPopover';
+import { DefaultGroupChangedIcon } from '../../../components/DefaultGroupChangedIcon';
 
 // NOTE: Per V2 designs, only name/description/users/lastModified are shown.
 // Roles, workspaces, and service accounts columns were removed from the table.
@@ -38,7 +40,26 @@ export function useUserGroupsTableConfig({ intl }: UseUserGroupsTableConfigOptio
 
   const cellRenderers: CellRendererMap<typeof columns, Group> = useMemo(
     () => ({
-      name: (group) => group.name,
+      name: (group) => {
+        const isDefaultGroup = group.platform_default || group.admin_default;
+        const isCustomizedDefault = group.platform_default && !group.system;
+
+        return (
+          <>
+            {isCustomizedDefault ? <DefaultGroupChangedIcon name={group.name} /> : group.name}
+            {isDefaultGroup && (
+              <>
+                {' '}
+                <DefaultInfoPopover
+                  id={`default${group.admin_default ? '-admin' : ''}-group-popover`}
+                  uuid={group.uuid}
+                  bodyContent={intl.formatMessage(group.admin_default ? messages.orgAdminInheritedRoles : messages.usersInheritedRoles)}
+                />
+              </>
+            )}
+          </>
+        );
+      },
       description: (group) =>
         group.description ? (
           <Tooltip isContentLeftAligned content={group.description}>

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
@@ -614,9 +614,9 @@ export const EditUnmodifiedDefaultGroup: Story = {
 **Unmodified Default Group**: Editing the unmodified "Default access" group (platform_default=true, system=true).
 
 Shows:
-- Danger alert warning about customization
+- Warning alert explaining customization consequences
 - Acknowledgment checkbox required before save
-- Name and description fields are editable but changes won't be saved
+- Name and description fields are disabled with helper text explaining they'll be editable after customization
 - Only member/service account changes trigger backend cloning
         `,
       },
@@ -649,10 +649,15 @@ Shows:
       const canvas = within(canvasElement);
 
       // Wait for form to load
-      await expect(canvas.findByDisplayValue('Default access')).resolves.toBeInTheDocument();
+      const nameField = await canvas.findByDisplayValue('Default access');
+      await expect(nameField).toBeInTheDocument();
 
       // Should show danger alert
       await expect(canvas.findByText(/you are editing the default access group/i)).resolves.toBeInTheDocument();
+
+      // Name and description fields should be disabled
+      await expect(nameField).toBeDisabled();
+      await expect(canvas.findByText(/this field will be editable after the group is customized/i)).resolves.toBeInTheDocument();
 
       // Should show acknowledgment checkbox
       const checkbox = await canvas.findByRole('checkbox', { name: /i understand that saving will customize/i });

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.stories.tsx
@@ -594,3 +594,154 @@ export const ValidationErrors: Story = {
     });
   },
 };
+
+/**
+ * Editing an unmodified platform_default group (system=true)
+ * Shows danger alert, requires checkbox acknowledgment, disables name/description updates
+ */
+export const EditUnmodifiedDefaultGroup: Story = {
+  args: {
+    createNewGroup: false,
+  },
+  parameters: {
+    route: {
+      path: '/access-management/user-groups/:groupId/edit',
+      initialEntries: ['/access-management/user-groups/default-access/edit'],
+    },
+    docs: {
+      description: {
+        story: `
+**Unmodified Default Group**: Editing the unmodified "Default access" group (platform_default=true, system=true).
+
+Shows:
+- Danger alert warning about customization
+- Acknowledgment checkbox required before save
+- Name and description fields are editable but changes won't be saved
+- Only member/service account changes trigger backend cloning
+        `,
+      },
+    },
+    msw: {
+      handlers: [
+        ...groupsHandlers([
+          ...mockGroups,
+          {
+            uuid: 'default-access',
+            name: 'Default access',
+            description: 'All users inherit roles from this group',
+            principalCount: 'All users',
+            roleCount: 5,
+            system: true,
+            platform_default: true,
+            admin_default: false,
+            created: '2024-01-01T00:00:00Z',
+            modified: '2024-01-01T00:00:00Z',
+          },
+        ]),
+        ...usersHandlers(editUsers),
+        ...serviceAccountsHandlers(editServiceAccountsForList),
+        ...createGroupMembersHandlers({ 'default-access': [] }, { 'default-access': [] }),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify default group safeguards', async () => {
+      const canvas = within(canvasElement);
+
+      // Wait for form to load
+      await expect(canvas.findByDisplayValue('Default access')).resolves.toBeInTheDocument();
+
+      // Should show danger alert
+      await expect(canvas.findByText(/you are editing the default access group/i)).resolves.toBeInTheDocument();
+
+      // Should show acknowledgment checkbox
+      const checkbox = await canvas.findByRole('checkbox', { name: /i understand that saving will customize/i });
+      await expect(checkbox).toBeInTheDocument();
+      await expect(checkbox).not.toBeChecked();
+
+      // Submit button should be disabled until checkbox is checked
+      const buttons = await canvas.findAllByRole('button');
+      const submitButton = buttons.find((button) => button.textContent?.includes('Submit'));
+      await expect(submitButton).toBeDisabled();
+
+      // Check the acknowledgment checkbox
+      await userEvent.click(checkbox);
+      await expect(checkbox).toBeChecked();
+
+      // Submit should now be enabled (assuming form has changes)
+      // Note: may still be disabled if form is pristine
+    });
+  },
+};
+
+/**
+ * Editing a customized platform_default group (system=false)
+ * Shows info alert with restore button, allows normal editing
+ */
+export const EditCustomizedDefaultGroup: Story = {
+  args: {
+    createNewGroup: false,
+  },
+  parameters: {
+    route: {
+      path: '/access-management/user-groups/:groupId/edit',
+      initialEntries: ['/access-management/user-groups/custom-default-access/edit'],
+    },
+    docs: {
+      description: {
+        story: `
+**Customized Default Group**: Editing a customized default group (platform_default=true, system=false).
+
+Shows:
+- Info alert about customization
+- "Restore to default" button in alert
+- Normal editing allowed (no checkbox required)
+- GroupResetWarningModal when restore is clicked
+        `,
+      },
+    },
+    msw: {
+      handlers: [
+        ...groupsHandlers([
+          ...mockGroups,
+          {
+            uuid: 'custom-default-access',
+            name: 'Custom default access',
+            description: 'Customized default access group',
+            principalCount: 10,
+            roleCount: 5,
+            system: false,
+            platform_default: true,
+            admin_default: false,
+            created: '2024-01-01T00:00:00Z',
+            modified: '2024-02-01T00:00:00Z',
+          },
+        ]),
+        ...usersHandlers(editUsers),
+        ...serviceAccountsHandlers(editServiceAccountsForList),
+        ...createGroupMembersHandlers({ 'custom-default-access': [editUsers[0]] }, { 'custom-default-access': [] }),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify customized group UI', async () => {
+      const canvas = within(canvasElement);
+
+      // Wait for form to load
+      await expect(canvas.findByDisplayValue('Custom default access')).resolves.toBeInTheDocument();
+
+      // Should show info alert (not danger)
+      await expect(canvas.findByText(/this group has been customized/i)).resolves.toBeInTheDocument();
+
+      // Should show restore button
+      const restoreButton = await canvas.findByRole('button', { name: /restore to default/i });
+      await expect(restoreButton).toBeInTheDocument();
+
+      // Click restore button to open modal
+      await userEvent.click(restoreButton);
+
+      // Should show warning modal
+      await expect(canvas.findByText(/restore default access group\?/i)).resolves.toBeInTheDocument();
+    });
+  },
+};

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -458,7 +458,13 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
           <>
             {/* Alert for unmodified platform_default group */}
             {isUnmodifiedPlatformDefault && (
-              <Alert variant="warning" isInline isExpandable={false} title={intl.formatMessage(Messages.editDefaultAccessGroupWarningTitle)} className="pf-v6-u-mb-md">
+              <Alert
+                variant="warning"
+                isInline
+                isExpandable={false}
+                title={intl.formatMessage(Messages.editDefaultAccessGroupWarningTitle)}
+                className="pf-v6-u-mb-md"
+              >
                 <p>
                   Once saved, the system will no longer manage this group automatically and it will be renamed to{' '}
                   <strong>Custom default access</strong>.

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -7,6 +7,7 @@ import { Form } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import Messages from '../../../../../../Messages';
 import { FormRenderer, componentTypes, useFormApi, validatorTypes } from '@data-driven-forms/react-form-renderer';
@@ -14,6 +15,7 @@ import componentMapper from '@data-driven-forms/pf4-component-mapper/component-m
 import type FormTemplateCommonProps from '@data-driven-forms/common/form-template';
 import {
   type Group,
+  groupsKeys,
   useAddMembersToGroupMutation,
   useAddServiceAccountsToGroupMutation,
   useCreateGroupMutation,
@@ -51,6 +53,65 @@ interface EditUserGroupFormValues {
   };
 }
 
+/**
+ * Props for CustomFormTemplate component
+ */
+interface CustomFormTemplateProps extends FormTemplateCommonProps {
+  isUnmodifiedPlatformDefault: boolean;
+  checkFormHasChanges: (values: Record<string, unknown>) => boolean;
+}
+
+/**
+ * Custom form template that includes acknowledgement checkbox for unmodified default groups.
+ * Extracted as a named component to ensure React Hook rules are followed correctly.
+ */
+function CustomFormTemplate(props: CustomFormTemplateProps) {
+  const { formFields, isUnmodifiedPlatformDefault, checkFormHasChanges } = props;
+  const intl = useIntl();
+
+  // Local state for checkbox - only re-renders this component, not the entire page
+  const [defaultGroupAcknowledged, setDefaultGroupAcknowledged] = useState(false);
+
+  // Use the DDF useFormApi hook to access form state
+  const { getState, handleSubmit, onCancel } = useFormApi();
+  const formState = getState();
+  const values = formState?.values || {};
+  const isFormInvalid = formState?.invalid ?? false;
+
+  // Check if form has actual changes (calculated directly, not in useEffect)
+  const hasFormChanges = checkFormHasChanges(values);
+
+  // For platform_default groups: disabled if no changes OR invalid OR checkbox not checked
+  // For other groups: disabled if no changes OR invalid
+  const shouldDisable = isUnmodifiedPlatformDefault
+    ? !hasFormChanges || isFormInvalid || !defaultGroupAcknowledged
+    : !hasFormChanges || isFormInvalid;
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      {formFields as React.ReactNode}
+      {isUnmodifiedPlatformDefault && (
+        <div className="pf-v6-u-mb-md">
+          <Checkbox
+            id="default-group-acknowledgement"
+            label={intl.formatMessage(Messages.acknowledgeDefaultGroupCustomization)}
+            isChecked={defaultGroupAcknowledged}
+            onChange={(_event, checked) => setDefaultGroupAcknowledged(checked)}
+          />
+        </div>
+      )}
+      <ActionGroup>
+        <Button variant="primary" type="submit" isDisabled={shouldDisable}>
+          Submit
+        </Button>
+        <Button variant="link" onClick={onCancel}>
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+}
+
 export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ createNewGroup }) => {
   const intl = useIntl();
   const addNotification = useAddNotification();
@@ -69,11 +130,11 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     serviceAccounts?: string[];
   } | null>(null);
 
-  // State for default group safeguard
-  const [defaultGroupAcknowledged, setDefaultGroupAcknowledged] = useState(false);
-
   // State for restore modal
   const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
+
+  // Query client for manual cache invalidation
+  const queryClient = useQueryClient();
 
   // Use React Query for data fetching
   const { data: allGroupsData, isLoading: isGroupsLoading } = useGroupsQuery({ limit: 1000, offset: 0, orderBy: 'name' }, { enabled: true });
@@ -88,7 +149,8 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   // Use React Query mutations
   const createGroupMutation = useCreateGroupMutation();
   const updateGroupMutation = useUpdateGroupMutation();
-  const deleteGroupMutation = useDeleteGroupMutation();
+  // Suppress default notification for delete - we handle it manually in handleRestoreConfirm
+  const deleteGroupMutation = useDeleteGroupMutation({ deferSuccessSideEffects: true });
   const addMembersMutation = useAddMembersToGroupMutation();
   const removeMembersMutation = useRemoveMembersFromGroupMutation();
   const addServiceAccountsMutation = useAddServiceAccountsToGroupMutation();
@@ -117,16 +179,17 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   );
 
   // Hard block: Redirect away if trying to edit admin_default group
-  useEffect(() => {
-    if (group?.admin_default && !createNewGroup) {
-      addNotification({
-        variant: 'warning',
-        title: 'Cannot edit Default admin access group',
-        description: 'The Default admin access group cannot be edited. This is a system-managed group.',
-      });
-      navigate(pathnames['user-groups'].link());
-    }
-  }, [group?.admin_default, createNewGroup, addNotification, navigate]);
+  // Handle this synchronously during render to avoid flash of content
+  const [hasShownAdminDefaultError, setHasShownAdminDefaultError] = React.useState(false);
+  if (group?.admin_default && !createNewGroup && !hasShownAdminDefaultError) {
+    setHasShownAdminDefaultError(true);
+    addNotification({
+      variant: 'warning',
+      title: intl.formatMessage(Messages.cannotEditAdminDefaultGroup),
+      description: intl.formatMessage(Messages.cannotEditAdminDefaultGroupDescription),
+    });
+    navigate(pathnames['user-groups'].link());
+  }
 
   // Update form data when group data changes
   useEffect(() => {
@@ -188,12 +251,16 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
           ],
           initialValue: initialFormData?.name,
           isRequired: true,
+          isDisabled: isUnmodifiedPlatformDefault,
+          helperText: isUnmodifiedPlatformDefault ? intl.formatMessage(Messages.fieldEditableAfterCustomization) : undefined,
         },
         {
           name: 'description',
           label: intl.formatMessage(Messages.description),
           component: componentTypes.TEXTAREA,
           initialValue: initialFormData?.description,
+          isDisabled: isUnmodifiedPlatformDefault,
+          helperText: isUnmodifiedPlatformDefault ? intl.formatMessage(Messages.fieldEditableAfterCustomization) : undefined,
         },
         {
           name: 'users-and-service-accounts',
@@ -248,51 +315,12 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     [initialFormData],
   );
 
-  // Custom FormTemplate that includes the acknowledgement checkbox above the submit button
-  const CustomFormTemplate = useCallback(
-    (props: FormTemplateCommonProps) => {
-      const { formFields } = props;
-
-      // Use the DDF useFormApi hook to access form state
-      const { getState, handleSubmit, onCancel } = useFormApi();
-      const formState = getState();
-      const values = formState?.values || {};
-      const isFormInvalid = formState?.invalid ?? false;
-
-      // Check if form has actual changes (calculated directly, not in useEffect)
-      const hasFormChanges = checkFormHasChanges(values);
-
-      // For platform_default groups: disabled if no changes OR invalid OR checkbox not checked
-      // For other groups: disabled if no changes OR invalid
-      const shouldDisable = isUnmodifiedPlatformDefault
-        ? !hasFormChanges || isFormInvalid || !defaultGroupAcknowledged
-        : !hasFormChanges || isFormInvalid;
-
-      return (
-        <Form onSubmit={handleSubmit}>
-          {formFields as React.ReactNode}
-          {isUnmodifiedPlatformDefault && (
-            <div className="pf-v6-u-mb-md">
-              <Checkbox
-                id="default-group-acknowledgement"
-                label="I understand that saving will customize the Default access group."
-                isChecked={defaultGroupAcknowledged}
-                onChange={(_event, checked) => setDefaultGroupAcknowledged(checked)}
-              />
-            </div>
-          )}
-          <ActionGroup>
-            <Button variant="primary" type="submit" isDisabled={shouldDisable}>
-              Submit
-            </Button>
-            <Button variant="link" onClick={onCancel}>
-              Cancel
-            </Button>
-          </ActionGroup>
-        </Form>
-      );
-    },
-    [isUnmodifiedPlatformDefault, defaultGroupAcknowledged, checkFormHasChanges],
+  // Wrapper component that passes additional props to CustomFormTemplate
+  const FormTemplateWithProps = useCallback(
+    (props: FormTemplateCommonProps) => (
+      <CustomFormTemplate {...props} isUnmodifiedPlatformDefault={!!isUnmodifiedPlatformDefault} checkFormHasChanges={checkFormHasChanges} />
+    ),
+    [isUnmodifiedPlatformDefault, checkFormHasChanges],
   );
 
   const handleSubmit = async (values: EditUserGroupFormValues) => {
@@ -305,8 +333,8 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
         targetGroupId = newGroup?.uuid;
         addNotification({
           variant: 'success',
-          title: 'Group created successfully',
-          description: 'The group has been created.',
+          title: intl.formatMessage(Messages.groupCreatedSuccess),
+          description: intl.formatMessage(Messages.groupCreatedDescription),
         });
       } else if (groupId && (values.name !== group?.name || values.description !== group?.description)) {
         // Skip name/description update for unmodified default groups (system=true)
@@ -374,8 +402,8 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
       if (isUnmodifiedPlatformDefault && !createNewGroup) {
         addNotification({
           variant: 'success',
-          title: 'Default access group customized',
-          description: 'The group has been customized and is no longer managed by the system.',
+          title: intl.formatMessage(Messages.defaultAccessGroupCustomized),
+          description: intl.formatMessage(Messages.defaultAccessGroupCustomizedDescription),
         });
       }
 
@@ -396,10 +424,14 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     try {
       await deleteGroupMutation.mutateAsync(groupId);
 
+      // Manually invalidate cache (since we deferred automatic side effects)
+      queryClient.invalidateQueries({ queryKey: groupsKeys.all });
+
+      // Show custom notification for restore operation
       addNotification({
         variant: 'success',
         title: intl.formatMessage(Messages.restoreToDefault),
-        description: 'The Default access group has been restored to system defaults.',
+        description: intl.formatMessage(Messages.restoreDefaultAccessSuccess),
       });
 
       setIsRestoreModalOpen(false);
@@ -408,8 +440,8 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
       console.error('Failed to restore group:', error);
       addNotification({
         variant: 'danger',
-        title: 'Error restoring group',
-        description: 'There was an error restoring the Default access group.',
+        title: intl.formatMessage(Messages.restoreGroupError),
+        description: intl.formatMessage(Messages.restoreGroupError),
       });
     }
   };
@@ -418,7 +450,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     <React.Fragment>
       <PageHeader title={pageTitle} breadcrumbs={<RbacBreadcrumbs breadcrumbs={breadcrumbsList} />} />
       <PageSection hasBodyWrapper data-ouia-component-id="edit-user-group-form" className="pf-v6-u-m-lg-on-lg" isWidthLimited>
-        {isLoading || !initialFormData ? (
+        {isLoading || !initialFormData || (group?.admin_default && !createNewGroup) ? (
           <div style={{ textAlign: 'center' }}>
             <Spinner />
           </div>
@@ -426,7 +458,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
           <>
             {/* Alert for unmodified platform_default group */}
             {isUnmodifiedPlatformDefault && (
-              <Alert variant="danger" isInline isExpandable={false} title="You are editing the Default access group" className="pf-v6-u-mb-md">
+              <Alert variant="warning" isInline isExpandable={false} title={intl.formatMessage(Messages.editDefaultAccessGroupWarningTitle)} className="pf-v6-u-mb-md">
                 <p>
                   Once saved, the system will no longer manage this group automatically and it will be renamed to{' '}
                   <strong>Custom default access</strong>.
@@ -459,7 +491,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
               }}
               onSubmit={handleSubmit}
               onCancel={returnToPreviousPage}
-              FormTemplate={CustomFormTemplate}
+              FormTemplate={FormTemplateWithProps}
             />
           </>
         )}

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -1,19 +1,24 @@
 import PageHeader from '@patternfly/react-component-groups/dist/esm/PageHeader';
-import { PageSection } from '@patternfly/react-core';
-
+import { ActionGroup, PageSection } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Checkbox } from '@patternfly/react-core/dist/dynamic/components/Checkbox';
+import { Form } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import Messages from '../../../../../../Messages';
-import { FormRenderer, componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { FormRenderer, componentTypes, validatorTypes, useFormApi } from '@data-driven-forms/react-form-renderer';
 import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
-import { FormTemplate } from '@data-driven-forms/pf4-component-mapper';
+import { FormTemplate as Pf4FormTemplate } from '@data-driven-forms/pf4-component-mapper';
+import type FormTemplateCommonProps from '@data-driven-forms/common/form-template';
 import {
   type Group,
   useAddMembersToGroupMutation,
   useAddServiceAccountsToGroupMutation,
   useCreateGroupMutation,
+  useDeleteGroupMutation,
   useGroupMembersQuery,
   useGroupQuery,
   useGroupServiceAccountsQuery,
@@ -28,6 +33,7 @@ import { EditGroupUsersAndServiceAccounts } from './EditUserGroupUsersAndService
 import { RbacBreadcrumbs } from '../../../../../../shared/components/navigation/Breadcrumbs';
 import pathnames from '../../../../../utilities/pathnames';
 import useAppNavigate from '../../../../../../shared/hooks/useAppNavigate';
+import { GroupResetWarningModal } from '../../../components/GroupResetWarningModal';
 
 interface EditUserGroupProps {
   createNewGroup?: boolean;
@@ -64,6 +70,12 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     serviceAccounts?: string[];
   } | null>(null);
 
+  // State for default group safeguard
+  const [defaultGroupAcknowledged, setDefaultGroupAcknowledged] = useState(false);
+
+  // State for restore modal
+  const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
+
   // Use React Query for data fetching
   const { data: allGroupsData, isLoading: isGroupsLoading } = useGroupsQuery({ limit: 1000, offset: 0, orderBy: 'name' }, { enabled: true });
   const { data: groupData, isLoading: isGroupLoading } = useGroupQuery(groupId || '', { enabled: !!groupId && !createNewGroup });
@@ -77,6 +89,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   // Use React Query mutations
   const createGroupMutation = useCreateGroupMutation();
   const updateGroupMutation = useUpdateGroupMutation();
+  const deleteGroupMutation = useDeleteGroupMutation();
   const addMembersMutation = useAddMembersToGroupMutation();
   const removeMembersMutation = useRemoveMembersFromGroupMutation();
   const addServiceAccountsMutation = useAddServiceAccountsToGroupMutation();
@@ -103,6 +116,18 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
     ],
     [intl, pageTitle],
   );
+
+  // Hard block: Redirect away if trying to edit admin_default group
+  useEffect(() => {
+    if (group?.admin_default && !createNewGroup) {
+      addNotification({
+        variant: 'warning',
+        title: 'Cannot edit Default admin access group',
+        description: 'The Default admin access group cannot be edited. This is a system-managed group.',
+      });
+      navigate(pathnames['user-groups'].link());
+    }
+  }, [group?.admin_default, createNewGroup, addNotification, navigate]);
 
   // Update form data when group data changes
   useEffect(() => {
@@ -136,6 +161,10 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
       });
     }
   }, [group?.uuid, group?.name, group?.description, groupUsers.length, groupServiceAccounts.length, createNewGroup, initialFormData]);
+
+  // Determine if this is a default group and its state
+  const isUnmodifiedPlatformDefault = group?.platform_default && group?.system && !createNewGroup;
+  const isCustomizedPlatformDefault = group?.platform_default && !group?.system && !createNewGroup;
 
   const schema = useMemo(
     () => ({
@@ -186,12 +215,85 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
         },
       ],
     }),
-    [initialFormData, allGroups, groupId, intl],
+    [initialFormData, allGroups, groupId, intl, isUnmodifiedPlatformDefault],
   );
 
   const returnToPreviousPage = useCallback(() => {
     navigate(pathnames['user-groups'].link());
   }, [navigate]);
+
+  // Helper function to check if form values have changed from initial data
+  const checkFormHasChanges = useCallback((values: Record<string, unknown>) => {
+    if (!initialFormData) {
+      return false;
+    }
+
+    const nameChanged = values.name !== initialFormData.name;
+    const descriptionChanged = values.description !== initialFormData.description;
+
+    // For users and service accounts, compare the 'updated' arrays
+    const usersAndSA = values['users-and-service-accounts'] as { users?: { updated?: string[] }; serviceAccounts?: { updated?: string[] } } | undefined;
+    const currentUsers = usersAndSA?.users?.updated || [];
+    const currentServiceAccounts = usersAndSA?.serviceAccounts?.updated || [];
+    const initialUsers = initialFormData.users || [];
+    const initialServiceAccounts = initialFormData.serviceAccounts || [];
+
+    const usersChanged = JSON.stringify([...currentUsers].sort()) !== JSON.stringify([...initialUsers].sort());
+    const serviceAccountsChanged = JSON.stringify([...currentServiceAccounts].sort()) !== JSON.stringify([...initialServiceAccounts].sort());
+
+    return nameChanged || descriptionChanged || usersChanged || serviceAccountsChanged;
+  }, [initialFormData]);
+
+  // Custom FormTemplate that includes the acknowledgement checkbox above the submit button
+  const CustomFormTemplate = useCallback(
+    (props: FormTemplateCommonProps) => {
+      const { formFields } = props;
+
+      // Use the DDF useFormApi hook to access form state
+      const { getState, handleSubmit, onCancel } = useFormApi();
+      const formState = getState();
+      const values = formState?.values || {};
+      const isFormInvalid = formState?.invalid ?? false;
+
+      // Check if form has actual changes (calculated directly, not in useEffect)
+      const hasFormChanges = checkFormHasChanges(values);
+
+      // For platform_default groups: disabled if no changes OR invalid OR checkbox not checked
+      // For other groups: disabled if no changes OR invalid
+      const shouldDisable = isUnmodifiedPlatformDefault
+        ? !hasFormChanges || isFormInvalid || !defaultGroupAcknowledged
+        : !hasFormChanges || isFormInvalid;
+
+      return (
+        <Form onSubmit={handleSubmit}>
+          {formFields as React.ReactNode}
+          {isUnmodifiedPlatformDefault && (
+            <div className="pf-v6-u-mb-md">
+              <Checkbox
+                id="default-group-acknowledgement"
+                label="I understand that saving will customize the Default access group."
+                isChecked={defaultGroupAcknowledged}
+                onChange={(_event, checked) => setDefaultGroupAcknowledged(checked)}
+              />
+            </div>
+          )}
+          <ActionGroup>
+            <Button
+              variant="primary"
+              type="submit"
+              isDisabled={shouldDisable}
+            >
+              Submit
+            </Button>
+            <Button variant="link" onClick={onCancel}>
+              Cancel
+            </Button>
+          </ActionGroup>
+        </Form>
+      );
+    },
+    [isUnmodifiedPlatformDefault, defaultGroupAcknowledged, checkFormHasChanges],
+  );
 
   const handleSubmit = async (values: EditUserGroupFormValues) => {
     try {
@@ -207,12 +309,16 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
           description: 'The group has been created.',
         });
       } else if (groupId && (values.name !== group?.name || values.description !== group?.description)) {
-        await updateGroupMutation.mutateAsync({ uuid: groupId, name: values.name, description: values.description });
-        addNotification({
-          variant: 'success',
-          title: intl.formatMessage(Messages.editGroupSuccessTitle),
-          description: intl.formatMessage(Messages.editGroupSuccessDescription),
-        });
+        // Skip name/description update for unmodified default groups (system=true)
+        // The backend will clone the group when we modify members/service accounts below
+        if (!isUnmodifiedPlatformDefault) {
+          await updateGroupMutation.mutateAsync({ uuid: groupId, name: values.name, description: values.description });
+          addNotification({
+            variant: 'success',
+            title: intl.formatMessage(Messages.editGroupSuccessTitle),
+            description: intl.formatMessage(Messages.editGroupSuccessDescription),
+          });
+        }
       }
 
       // Handle user and service account changes
@@ -264,6 +370,15 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
         }
       }
 
+      // Show success notification for unmodified default groups after customization
+      if (isUnmodifiedPlatformDefault && !createNewGroup) {
+        addNotification({
+          variant: 'success',
+          title: 'Default access group customized',
+          description: 'The group has been customized and is no longer managed by the system.',
+        });
+      }
+
       returnToPreviousPage();
     } catch (error) {
       console.error('Failed to save group:', error);
@@ -271,6 +386,30 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
         variant: 'danger',
         title: createNewGroup ? 'Error creating group' : intl.formatMessage(Messages.editGroupErrorTitle),
         description: createNewGroup ? 'There was an error creating the group.' : intl.formatMessage(Messages.editGroupErrorDescription),
+      });
+    }
+  };
+
+  const handleRestoreConfirm = async () => {
+    if (!groupId) return;
+
+    try {
+      await deleteGroupMutation.mutateAsync(groupId);
+
+      addNotification({
+        variant: 'success',
+        title: intl.formatMessage(Messages.restoreToDefault),
+        description: 'The Default access group has been restored to system defaults.',
+      });
+
+      setIsRestoreModalOpen(false);
+      navigate(pathnames['user-groups'].link());
+    } catch (error) {
+      console.error('Failed to restore group:', error);
+      addNotification({
+        variant: 'danger',
+        title: 'Error restoring group',
+        description: 'There was an error restoring the Default access group.',
       });
     }
   };
@@ -284,21 +423,59 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
             <Spinner />
           </div>
         ) : (
-          <FormRenderer
-            schema={schema}
-            componentMapper={{
-              ...componentMapper,
-              'users-and-service-accounts': EditGroupUsersAndServiceAccounts,
-            }}
-            onSubmit={handleSubmit}
-            onCancel={returnToPreviousPage}
-            FormTemplate={FormTemplate}
-            FormTemplateProps={{
-              disableSubmit: ['pristine', 'invalid'],
-            }}
-          />
+          <>
+            {/* Alert for unmodified platform_default group */}
+            {isUnmodifiedPlatformDefault && (
+              <Alert
+                variant="danger"
+                isInline
+                isExpandable={false}
+                title="You are editing the Default access group"
+                className="pf-v6-u-mb-md"
+              >
+                <p>
+                  Once saved, the system will no longer manage this group automatically and it will be renamed to <strong>Custom default access</strong>.
+                </p>
+              </Alert>
+            )}
+
+            {/* Alert for customized platform_default group */}
+            {isCustomizedPlatformDefault && (
+              <Alert
+                variant="info"
+                isInline
+                title="This group has been customized"
+                className="pf-v6-u-mb-md"
+                actionLinks={
+                  <Button variant="link" isInline onClick={() => setIsRestoreModalOpen(true)}>
+                    {intl.formatMessage(Messages.restoreToDefault)}
+                  </Button>
+                }
+              >
+                <p>This group has been customized from the Default access group. Changes here will not be reverted automatically.</p>
+              </Alert>
+            )}
+
+            <FormRenderer
+              schema={schema}
+              componentMapper={{
+                ...componentMapper,
+                'users-and-service-accounts': EditGroupUsersAndServiceAccounts,
+              }}
+              onSubmit={handleSubmit}
+              onCancel={returnToPreviousPage}
+              FormTemplate={CustomFormTemplate}
+            />
+          </>
         )}
       </PageSection>
+
+      {/* Restore warning modal */}
+      <GroupResetWarningModal
+        isOpen={isRestoreModalOpen}
+        onClose={() => setIsRestoreModalOpen(false)}
+        onConfirm={handleRestoreConfirm}
+      />
     </React.Fragment>
   );
 };

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/edit-user-group/EditUserGroup.tsx
@@ -9,9 +9,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import Messages from '../../../../../../Messages';
-import { FormRenderer, componentTypes, validatorTypes, useFormApi } from '@data-driven-forms/react-form-renderer';
+import { FormRenderer, componentTypes, useFormApi, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
-import { FormTemplate as Pf4FormTemplate } from '@data-driven-forms/pf4-component-mapper';
 import type FormTemplateCommonProps from '@data-driven-forms/common/form-template';
 import {
   type Group,
@@ -223,26 +222,31 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
   }, [navigate]);
 
   // Helper function to check if form values have changed from initial data
-  const checkFormHasChanges = useCallback((values: Record<string, unknown>) => {
-    if (!initialFormData) {
-      return false;
-    }
+  const checkFormHasChanges = useCallback(
+    (values: Record<string, unknown>) => {
+      if (!initialFormData) {
+        return false;
+      }
 
-    const nameChanged = values.name !== initialFormData.name;
-    const descriptionChanged = values.description !== initialFormData.description;
+      const nameChanged = values.name !== initialFormData.name;
+      const descriptionChanged = values.description !== initialFormData.description;
 
-    // For users and service accounts, compare the 'updated' arrays
-    const usersAndSA = values['users-and-service-accounts'] as { users?: { updated?: string[] }; serviceAccounts?: { updated?: string[] } } | undefined;
-    const currentUsers = usersAndSA?.users?.updated || [];
-    const currentServiceAccounts = usersAndSA?.serviceAccounts?.updated || [];
-    const initialUsers = initialFormData.users || [];
-    const initialServiceAccounts = initialFormData.serviceAccounts || [];
+      // For users and service accounts, compare the 'updated' arrays
+      const usersAndSA = values['users-and-service-accounts'] as
+        | { users?: { updated?: string[] }; serviceAccounts?: { updated?: string[] } }
+        | undefined;
+      const currentUsers = usersAndSA?.users?.updated || [];
+      const currentServiceAccounts = usersAndSA?.serviceAccounts?.updated || [];
+      const initialUsers = initialFormData.users || [];
+      const initialServiceAccounts = initialFormData.serviceAccounts || [];
 
-    const usersChanged = JSON.stringify([...currentUsers].sort()) !== JSON.stringify([...initialUsers].sort());
-    const serviceAccountsChanged = JSON.stringify([...currentServiceAccounts].sort()) !== JSON.stringify([...initialServiceAccounts].sort());
+      const usersChanged = JSON.stringify([...currentUsers].sort()) !== JSON.stringify([...initialUsers].sort());
+      const serviceAccountsChanged = JSON.stringify([...currentServiceAccounts].sort()) !== JSON.stringify([...initialServiceAccounts].sort());
 
-    return nameChanged || descriptionChanged || usersChanged || serviceAccountsChanged;
-  }, [initialFormData]);
+      return nameChanged || descriptionChanged || usersChanged || serviceAccountsChanged;
+    },
+    [initialFormData],
+  );
 
   // Custom FormTemplate that includes the acknowledgement checkbox above the submit button
   const CustomFormTemplate = useCallback(
@@ -278,11 +282,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
             </div>
           )}
           <ActionGroup>
-            <Button
-              variant="primary"
-              type="submit"
-              isDisabled={shouldDisable}
-            >
+            <Button variant="primary" type="submit" isDisabled={shouldDisable}>
               Submit
             </Button>
             <Button variant="link" onClick={onCancel}>
@@ -426,15 +426,10 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
           <>
             {/* Alert for unmodified platform_default group */}
             {isUnmodifiedPlatformDefault && (
-              <Alert
-                variant="danger"
-                isInline
-                isExpandable={false}
-                title="You are editing the Default access group"
-                className="pf-v6-u-mb-md"
-              >
+              <Alert variant="danger" isInline isExpandable={false} title="You are editing the Default access group" className="pf-v6-u-mb-md">
                 <p>
-                  Once saved, the system will no longer manage this group automatically and it will be renamed to <strong>Custom default access</strong>.
+                  Once saved, the system will no longer manage this group automatically and it will be renamed to{' '}
+                  <strong>Custom default access</strong>.
                 </p>
               </Alert>
             )}
@@ -471,11 +466,7 @@ export const EditUserGroup: React.FunctionComponent<EditUserGroupProps> = ({ cre
       </PageSection>
 
       {/* Restore warning modal */}
-      <GroupResetWarningModal
-        isOpen={isRestoreModalOpen}
-        onClose={() => setIsRestoreModalOpen(false)}
-        onConfirm={handleRestoreConfirm}
-      />
+      <GroupResetWarningModal isOpen={isRestoreModalOpen} onClose={() => setIsRestoreModalOpen(false)} onConfirm={handleRestoreConfirm} />
     </React.Fragment>
   );
 };

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
@@ -250,3 +250,97 @@ export const NetworkFailure: Story = {
     });
   },
 };
+
+/**
+ * Platform default group with DefaultServiceAccountsAlert
+ * Shows security compliance alert
+ */
+export const DefaultPlatformGroup: Story = {
+  args: {
+    groupId: 'default-platform-group',
+    ouiaId: 'group-service-accounts-view-default',
+    isDefaultGroup: true,
+    isPlatformDefault: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Platform default group shows DefaultServiceAccountsAlert explaining service accounts are not included in Default access group.',
+      },
+    },
+    msw: {
+      handlers: [
+        ...createGroupMembersHandlers(
+          {},
+          {
+            'default-platform-group': [
+              {
+                username: 'service-account-12345',
+                type: 'service-account' as const,
+                clientId: 'service-account-12345',
+              },
+            ],
+          }
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify DefaultServiceAccountsAlert for platform default group', async () => {
+      // Should show alert about service accounts not being included
+      await expect(canvas.findByText(/service accounts are not included in the default access group/i)).resolves.toBeInTheDocument();
+
+      // Should still show the service accounts table
+      await expect(canvas.findByRole('grid')).resolves.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Admin default group with DefaultServiceAccountsAlert
+ * Shows security compliance alert
+ */
+export const DefaultAdminGroup: Story = {
+  args: {
+    groupId: 'default-admin-group',
+    ouiaId: 'group-service-accounts-view-admin-default',
+    isDefaultGroup: true,
+    isPlatformDefault: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Admin default group shows DefaultServiceAccountsAlert explaining service accounts are not included in Default admin access group.',
+      },
+    },
+    msw: {
+      handlers: [
+        ...createGroupMembersHandlers(
+          {},
+          {
+            'default-admin-group': [
+              {
+                username: 'service-account-67890',
+                type: 'service-account' as const,
+                clientId: 'service-account-67890',
+              },
+            ],
+          }
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify DefaultServiceAccountsAlert for admin default group', async () => {
+      // Should show alert about service accounts not being included
+      await expect(canvas.findByText(/service accounts are not included in the default admin access group/i)).resolves.toBeInTheDocument();
+
+      // Should still show the service accounts table
+      await expect(canvas.findByRole('grid')).resolves.toBeInTheDocument();
+    });
+  },
+};

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.stories.tsx
@@ -280,7 +280,7 @@ export const DefaultPlatformGroup: Story = {
                 clientId: 'service-account-12345',
               },
             ],
-          }
+          },
         ),
       ],
     },
@@ -327,7 +327,7 @@ export const DefaultAdminGroup: Story = {
                 clientId: 'service-account-67890',
               },
             ],
-          }
+          },
         ),
       ],
     },

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.tsx
@@ -10,10 +10,15 @@ import { type ServiceAccount, useGroupServiceAccountsQuery } from '../../../../.
 import { extractErrorMessage } from '../../../../../../shared/utilities/errorUtils';
 import { TableView, useTableState } from '../../../../../../shared/components/table-view';
 import type { CellRendererMap, ColumnConfigMap } from '../../../../../../shared/components/table-view/types';
+import { DefaultServiceAccountsAlert } from '../../../components/DefaultServiceAccountsAlert';
 
 interface GroupDetailsServiceAccountsViewProps {
   groupId: string;
   ouiaId: string;
+  /** If true, shows security compliance alert about service accounts */
+  isDefaultGroup?: boolean;
+  /** If false, this is the admin default group; otherwise platform default */
+  isPlatformDefault?: boolean;
 }
 
 interface ServiceAccountData {
@@ -25,7 +30,7 @@ interface ServiceAccountData {
 
 const columns = ['name', 'clientId', 'owner'] as const;
 
-const GroupDetailsServiceAccountsView: React.FunctionComponent<GroupDetailsServiceAccountsViewProps> = ({ groupId, ouiaId }) => {
+const GroupDetailsServiceAccountsView: React.FunctionComponent<GroupDetailsServiceAccountsViewProps> = ({ groupId, ouiaId, isDefaultGroup, isPlatformDefault }) => {
   const intl = useIntl();
 
   const columnConfig: ColumnConfigMap<typeof columns> = useMemo(
@@ -90,6 +95,7 @@ const GroupDetailsServiceAccountsView: React.FunctionComponent<GroupDetailsServi
 
   return (
     <div className="pf-v6-u-pt-md">
+      {isDefaultGroup && <DefaultServiceAccountsAlert isPlatformDefault={!!isPlatformDefault} />}
       <TableView<typeof columns, ServiceAccountData>
         columns={columns}
         columnConfig={columnConfig}

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsServiceAccountsView.tsx
@@ -30,7 +30,12 @@ interface ServiceAccountData {
 
 const columns = ['name', 'clientId', 'owner'] as const;
 
-const GroupDetailsServiceAccountsView: React.FunctionComponent<GroupDetailsServiceAccountsViewProps> = ({ groupId, ouiaId, isDefaultGroup, isPlatformDefault }) => {
+const GroupDetailsServiceAccountsView: React.FunctionComponent<GroupDetailsServiceAccountsViewProps> = ({
+  groupId,
+  ouiaId,
+  isDefaultGroup,
+  isPlatformDefault,
+}) => {
   const intl = useIntl();
 
   const columnConfig: ColumnConfigMap<typeof columns> = useMemo(

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
@@ -260,21 +260,19 @@ export const DefaultPlatformGroup: Story = {
     },
     msw: {
       handlers: [
-        ...createGroupMembersHandlers(
-          {
-            'default-platform-group': [
-              {
-                username: 'john.doe',
-                email: 'john.doe@example.com',
-                first_name: 'John',
-                last_name: 'Doe',
-                is_active: true,
-                is_org_admin: false,
-                external_source_id: '1',
-              },
-            ],
-          }
-        ),
+        ...createGroupMembersHandlers({
+          'default-platform-group': [
+            {
+              username: 'john.doe',
+              email: 'john.doe@example.com',
+              first_name: 'John',
+              last_name: 'Doe',
+              is_active: true,
+              is_org_admin: false,
+              external_source_id: '1',
+            },
+          ],
+        }),
       ],
     },
   },
@@ -310,21 +308,19 @@ export const DefaultAdminGroup: Story = {
     },
     msw: {
       handlers: [
-        ...createGroupMembersHandlers(
-          {
-            'default-admin-group': [
-              {
-                username: 'admin.user',
-                email: 'admin.user@example.com',
-                first_name: 'Admin',
-                last_name: 'User',
-                is_active: true,
-                is_org_admin: true,
-                external_source_id: '2',
-              },
-            ],
-          }
-        ),
+        ...createGroupMembersHandlers({
+          'default-admin-group': [
+            {
+              username: 'admin.user',
+              email: 'admin.user@example.com',
+              first_name: 'Admin',
+              last_name: 'User',
+              is_active: true,
+              is_org_admin: true,
+              external_source_id: '2',
+            },
+          ],
+        }),
       ],
     },
   },

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
@@ -240,3 +240,103 @@ export const NetworkFailure: Story = {
     });
   },
 };
+
+/**
+ * Default group with DefaultMembersAlert
+ * Shows alert for platform_default group
+ */
+export const DefaultPlatformGroup: Story = {
+  args: {
+    groupId: 'default-platform-group',
+    ouiaId: 'group-users-view-default',
+    isDefaultGroup: true,
+    isAdminDefault: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Platform default group shows DefaultMembersAlert explaining that all users are automatically members.',
+      },
+    },
+    msw: {
+      handlers: [
+        ...createGroupMembersHandlers(
+          {
+            'default-platform-group': [
+              {
+                username: 'john.doe',
+                email: 'john.doe@example.com',
+                first_name: 'John',
+                last_name: 'Doe',
+                is_active: true,
+                is_org_admin: false,
+                external_source_id: '1',
+              },
+            ],
+          }
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify DefaultMembersAlert for platform default group', async () => {
+      // Should show alert about all users being members
+      await expect(canvas.findByText(/all users in this organization/i)).resolves.toBeInTheDocument();
+
+      // Should still show the users table
+      await expect(canvas.findByRole('grid')).resolves.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Admin default group with DefaultMembersAlert
+ * Shows alert for admin_default group
+ */
+export const DefaultAdminGroup: Story = {
+  args: {
+    groupId: 'default-admin-group',
+    ouiaId: 'group-users-view-admin-default',
+    isDefaultGroup: true,
+    isAdminDefault: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Admin default group shows DefaultMembersAlert explaining that all org admins are automatically members.',
+      },
+    },
+    msw: {
+      handlers: [
+        ...createGroupMembersHandlers(
+          {
+            'default-admin-group': [
+              {
+                username: 'admin.user',
+                email: 'admin.user@example.com',
+                first_name: 'Admin',
+                last_name: 'User',
+                is_active: true,
+                is_org_admin: true,
+                external_source_id: '2',
+              },
+            ],
+          }
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify DefaultMembersAlert for admin default group', async () => {
+      // Should show alert about all org admins being members
+      await expect(canvas.findByText(/all org admins in this organization/i)).resolves.toBeInTheDocument();
+
+      // Should still show the users table
+      await expect(canvas.findByRole('grid')).resolves.toBeInTheDocument();
+    });
+  },
+};

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.stories.tsx
@@ -260,19 +260,22 @@ export const DefaultPlatformGroup: Story = {
     },
     msw: {
       handlers: [
-        ...createGroupMembersHandlers({
-          'default-platform-group': [
-            {
-              username: 'john.doe',
-              email: 'john.doe@example.com',
-              first_name: 'John',
-              last_name: 'Doe',
-              is_active: true,
-              is_org_admin: false,
-              external_source_id: '1',
-            },
-          ],
-        }),
+        ...createGroupMembersHandlers(
+          {
+            'default-platform-group': [
+              {
+                username: 'john.doe',
+                email: 'john.doe@example.com',
+                first_name: 'John',
+                last_name: 'Doe',
+                is_active: true,
+                is_org_admin: false,
+                external_source_id: '1',
+              },
+            ],
+          },
+          {},
+        ),
       ],
     },
   },
@@ -308,19 +311,22 @@ export const DefaultAdminGroup: Story = {
     },
     msw: {
       handlers: [
-        ...createGroupMembersHandlers({
-          'default-admin-group': [
-            {
-              username: 'admin.user',
-              email: 'admin.user@example.com',
-              first_name: 'Admin',
-              last_name: 'User',
-              is_active: true,
-              is_org_admin: true,
-              external_source_id: '2',
-            },
-          ],
-        }),
+        ...createGroupMembersHandlers(
+          {
+            'default-admin-group': [
+              {
+                username: 'admin.user',
+                email: 'admin.user@example.com',
+                first_name: 'Admin',
+                last_name: 'User',
+                is_active: true,
+                is_org_admin: true,
+                external_source_id: '2',
+              },
+            ],
+          },
+          {},
+        ),
       ],
     },
   },

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/user-group-detail/GroupDetailsUsersView.tsx
@@ -10,10 +10,15 @@ import { useGroupMembersQuery } from '../../../../../../v2/data/queries/groups';
 import { extractErrorMessage } from '../../../../../../shared/utilities/errorUtils';
 import { TableView, useTableState } from '../../../../../../shared/components/table-view';
 import type { CellRendererMap, ColumnConfigMap } from '../../../../../../shared/components/table-view/types';
+import { DefaultMembersAlert } from '../../../components/DefaultMembersAlert';
 
 interface GroupDetailsUsersViewProps {
   groupId: string;
   ouiaId: string;
+  /** If true, shows alert indicating all users are automatic members */
+  isDefaultGroup?: boolean;
+  /** If true, shows "all org admins" message; otherwise "all users" */
+  isAdminDefault?: boolean;
 }
 
 interface MemberData {
@@ -24,7 +29,7 @@ interface MemberData {
 
 const columns = ['username', 'firstName', 'lastName'] as const;
 
-const GroupDetailsUsersView: React.FunctionComponent<GroupDetailsUsersViewProps> = ({ groupId, ouiaId }) => {
+const GroupDetailsUsersView: React.FunctionComponent<GroupDetailsUsersViewProps> = ({ groupId, ouiaId, isDefaultGroup, isAdminDefault }) => {
   const intl = useIntl();
 
   const columnConfig: ColumnConfigMap<typeof columns> = useMemo(
@@ -86,6 +91,7 @@ const GroupDetailsUsersView: React.FunctionComponent<GroupDetailsUsersViewProps>
 
   return (
     <div className="pf-v6-u-pt-md">
+      {isDefaultGroup && <DefaultMembersAlert isAdminDefault={!!isAdminDefault} />}
       <TableView<typeof columns, MemberData>
         columns={columns}
         columnConfig={columnConfig}


### PR DESCRIPTION
### What and why

#### New Safeguards & UI Components

- Default Members Alert - Informs users that all users/org admins are automatically members of default groups

- Service Accounts Alert - Security compliance notice explaining service accounts are excluded from default groups

- Info Popover - Icons in the groups table explaining inherited roles for all default groups

- Reset Warning Modal - Confirmation dialog when attempting to restore a customized default group to system defaults

#### Edit Flow Enhancements

- Danger alert with acknowledgment checkbox prevents accidental customization of unmodified default groups

- Info alert with "Restore to default" button for already-customized groups

- Success notification after default group customization completes

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual indicators and info popovers for platform/admin default groups
  * Alerts for default-group member and service-account behavior
  * Warning modal and restore flow for resetting customized default groups
* **Bug Fixes / UX**
  * Stronger safeguards when editing default groups (disabled fields, acknowledgement, and contextual actions)
* **Documentation / Stories**
  * Storybook coverage added for all new components and default-group scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->