### PR TITLE
fix(role-bindings): add exclude_sources=indirect to bypass inherited lookup requirement

### DIFF
--- a/src/v2/data/queries/roleBindings.ts
+++ b/src/v2/data/queries/roleBindings.ts
@@ -68,6 +68,11 @@ export function useGroupRoleBindingsQuery(groupId: string, options?: { enabled?:
         resourceType: 'workspace',
         limit: 1000,
         fields: FIELDS,
+        options: {
+          params: {
+            exclude_sources: 'indirect',
+          },
+        },
       });
       return parseBindings(response.data?.data ?? []);
     },
@@ -93,6 +98,9 @@ export function useUserRoleBindingsQuery(userId: string | undefined, options?: {
           params: {
             granted_subject_type: 'user',
             granted_subject_id: userId!,
+            // Only exclude indirect bindings when no workspace context is given.
+            // When resourceId is present the API can resolve inherited bindings for that workspace.
+            ...(options?.resourceId ? {} : { exclude_sources: 'indirect' }),
           },
         },
       });


### PR DESCRIPTION
## Summary

- The role-bindings endpoint now performs inherited lookups by default as of RedHatInsights/insights-rbac#2605, requiring `resource_id` whenever `resource_type` is specified
- `useGroupRoleBindingsQuery` and `useUserRoleBindingsQuery` both specify `resource_type=workspace` without a `resource_id`, causing a 400 error on stage
- Add `exclude_sources=indirect` via the `options.params` passthrough to bypass the inherited lookup (and its `resource_id` requirement)

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — passes
- [x] `npm run test:storybook` — passes
- [ ] Manually verify group role bindings load on stage (group details page / My Access drawer)
- [ ] Manually verify user role bindings load on stage (user details drawer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role binding queries now exclude indirectly-sourced group bindings so permission lists are more accurate.
  * When requesting user role bindings for a specific resource, indirect/workspace-level bindings are included to ensure workspace-context permissions resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->