### PR TITLE
test: tests for access management default landing

### DIFF
--- a/e2e/journeys/v2/navigation/overview.spec.ts
+++ b/e2e/journeys/v2/navigation/overview.spec.ts
@@ -1,13 +1,14 @@
 /**
  * Overview Page Tests
  *
- * Tests for the V2 Overview page content.
+ * Tests for the V2 Overview page content and default navigation.
  *
  * ═══════════════════════════════════════════════════════════════════════════════
  * DECISION TREE - Add your test here if:
  * ═══════════════════════════════════════════════════════════════════════════════
  * ✓ Testing overview page heading and content visibility
  * ✓ Testing Get Started card or other overview sections
+ * ✓ Testing that overview is the default page when navigating to /iam
  *
  * DO NOT add here if:
  * ✗ Testing navigation structure → navigation-structure.spec.ts
@@ -24,6 +25,7 @@ import { AUTH_V2_ORGADMIN, AUTH_V2_USERVIEWER, iamUrl, setupPage, v2 } from '../
 import { E2E_TIMEOUTS } from '../../../utils/timeouts';
 
 const overviewUrl = iamUrl(v2.overview.link());
+const iamBaseUrl = '/iam';
 
 test.describe('Overview', () => {
   test.describe('OrgAdmin', () => {
@@ -54,6 +56,45 @@ test.describe('Overview', () => {
       await expect(async () => {
         await page.goto(overviewUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
         await expect(page.getByText(/You do not have access to/i)).toBeVisible({ timeout: E2E_TIMEOUTS.DETAIL_CONTENT });
+      }).toPass({ timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD, intervals: [1_000, 2_000, 5_000] });
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Default Navigation Tests - Overview should be the landing page for /iam
+// ═══════════════════════════════════════════════════════════════════════════
+// These tests verify the correct behavior per the RBAC Overview page requirements.
+// They use test.fail() because of a known routing bug in src/v2/Routing.tsx:
+//   - The catch-all route currently redirects to /my-access instead of /overview
+//
+// Correct behavior:
+//   - Navigating to /iam (base URL) should redirect to /iam/overview
+//   - Overview page should be the default landing page for RBAC
+//
+// When the routing is fixed, these tests will start passing and test.fail()
+// will cause them to go red — that's the signal to remove the annotation.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Default Navigation', () => {
+  test.describe('OrgAdmin', () => {
+    test.use({ storageState: AUTH_V2_ORGADMIN });
+
+    test('Navigating to /iam redirects to overview page [OrgAdmin]', async ({ page }) => {
+      test.fail(true, 'Routing bug: catch-all route redirects to /my-access instead of /overview');
+      await setupPage(page);
+      await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
+      await page.waitForURL(/\/overview/, { timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD });
+      await expect(page.getByRole('heading', { name: /user access/i, level: 1 }).first()).toBeVisible({ timeout: E2E_TIMEOUTS.DETAIL_CONTENT });
+    });
+
+    test('Overview page is accessible as default landing page [OrgAdmin]', async ({ page }) => {
+      test.fail(true, 'Routing bug: catch-all route redirects to /my-access instead of /overview');
+      await setupPage(page);
+      await expect(async () => {
+        await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
+        const url = page.url();
+        expect(url).toContain('/overview');
       }).toPass({ timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD, intervals: [1_000, 2_000, 5_000] });
     });
   });

--- a/e2e/journeys/v2/navigation/overview.spec.ts
+++ b/e2e/journeys/v2/navigation/overview.spec.ts
@@ -20,7 +20,7 @@
  * @dependencies UTILS: setupPage
  */
 
-import { expect, test } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
 import { AUTH_V2_ORGADMIN, AUTH_V2_USERVIEWER, iamUrl, setupPage, v2 } from '../../../utils';
 import { E2E_TIMEOUTS } from '../../../utils/timeouts';
 
@@ -79,7 +79,7 @@ test.describe('Overview', () => {
 /**
  * Helper to navigate to /iam base URL and verify it redirects to overview
  */
-async function navigateToIamAndExpectOverview(page: any) {
+async function navigateToIamAndExpectOverview(page: Page) {
   await setupPage(page);
   await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
   await page.waitForURL(/\/overview/, { timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD });

--- a/e2e/journeys/v2/navigation/overview.spec.ts
+++ b/e2e/journeys/v2/navigation/overview.spec.ts
@@ -25,7 +25,7 @@ import { AUTH_V2_ORGADMIN, AUTH_V2_USERVIEWER, iamUrl, setupPage, v2 } from '../
 import { E2E_TIMEOUTS } from '../../../utils/timeouts';
 
 const overviewUrl = iamUrl(v2.overview.link());
-const iamBaseUrl = '/iam';
+const iamBaseUrl = iamUrl('');
 
 test.describe('Overview', () => {
   test.describe('OrgAdmin', () => {
@@ -76,26 +76,28 @@ test.describe('Overview', () => {
 // will cause them to go red — that's the signal to remove the annotation.
 // ═══════════════════════════════════════════════════════════════════════════
 
+/**
+ * Helper to navigate to /iam base URL and verify it redirects to overview
+ */
+async function navigateToIamAndExpectOverview(page: any) {
+  await setupPage(page);
+  await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
+  await page.waitForURL(/\/overview/, { timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD });
+  await expect(page.getByRole('heading', { name: /user access/i, level: 1 }).first()).toBeVisible({ timeout: E2E_TIMEOUTS.DETAIL_CONTENT });
+}
+
 test.describe('Default Navigation', () => {
   test.describe('OrgAdmin', () => {
     test.use({ storageState: AUTH_V2_ORGADMIN });
 
     test('Navigating to /iam redirects to overview page [OrgAdmin]', async ({ page }) => {
       test.fail(true, 'Routing bug: catch-all route redirects to /my-access instead of /overview');
-      await setupPage(page);
-      await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
-      await page.waitForURL(/\/overview/, { timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD });
-      await expect(page.getByRole('heading', { name: /user access/i, level: 1 }).first()).toBeVisible({ timeout: E2E_TIMEOUTS.DETAIL_CONTENT });
+      await navigateToIamAndExpectOverview(page);
     });
 
     test('Overview page is accessible as default landing page [OrgAdmin]', async ({ page }) => {
       test.fail(true, 'Routing bug: catch-all route redirects to /my-access instead of /overview');
-      await setupPage(page);
-      await expect(async () => {
-        await page.goto(iamBaseUrl, { timeout: E2E_TIMEOUTS.SLOW_DATA });
-        const url = page.url();
-        expect(url).toContain('/overview');
-      }).toPass({ timeout: E2E_TIMEOUTS.SETUP_PAGE_LOAD, intervals: [1_000, 2_000, 5_000] });
+      await navigateToIamAndExpectOverview(page);
     });
   });
 });


### PR DESCRIPTION
### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

These are to test the V2 overview page is navigable and the defaut access management destination, and that /iam directs to the overview page as well. I have a PR up in chrome to fix part of this but both of these tests are expected to fail currently.

[RHCLOUD-45059](https://issues.redhat.com/browse/RHCLOUD-45059)

---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-45059]: https://redhat.atlassian.net/browse/RHCLOUD-45059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage to validate default navigation from the IAM area to the Overview page and confirm Overview content (user access) is visible.
  * Added a test that intentionally fails to surface a known catch-all routing issue so it’s clearly highlighted during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->