### PR TITLE
fix(role-bindings): specify sources sub-fields in fields parameter

### DIFF
--- a/src/v2/data/queries/roles.ts
+++ b/src/v2/data/queries/roles.ts
@@ -187,7 +187,7 @@ export function useRoleAssignmentsQuery(
   return useQuery({
     queryKey: [...roleBindingsKeys.all, 'workspace-role-bindings', workspaceId, options?.limit, options?.cursor, options?.excludeSources],
     queryFn: async (): Promise<RoleBindingsListBySubject200Response> => {
-      const fields = 'last_modified,subject(id,group.name,group.description,group.user_count),roles(id,name),resource(id,name,type),sources';
+      const fields = 'last_modified,subject(id,group.name,group.description,group.user_count),roles(id,name),resource(id,name,type),sources(id,name,type)';
 
       const response = await rolesApi.roleBindingsListBySubject({
         resourceId: workspaceId,

--- a/src/v2/data/queries/roles.ts
+++ b/src/v2/data/queries/roles.ts
@@ -187,7 +187,8 @@ export function useRoleAssignmentsQuery(
   return useQuery({
     queryKey: [...roleBindingsKeys.all, 'workspace-role-bindings', workspaceId, options?.limit, options?.cursor, options?.excludeSources],
     queryFn: async (): Promise<RoleBindingsListBySubject200Response> => {
-      const fields = 'last_modified,subject(id,group.name,group.description,group.user_count),roles(id,name),resource(id,name,type),sources(id,name,type)';
+      const fields =
+        'last_modified,subject(id,group.name,group.description,group.user_count),roles(id,name),resource(id,name,type),sources(id,name,type)';
 
       const response = await rolesApi.roleBindingsListBySubject({
         resourceId: workspaceId,


### PR DESCRIPTION
## Summary
- The `fields` query parameter for `/role-bindings/by-subject/` specified `sources` as a bare field name, causing a 400 error from the API
- Changed to `sources(id,name,type)` to match the expected nested field format (same as `resource`, `roles`, `subject`)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run test:storybook` passes
- [ ] Verify on staging that workspace role bindings load without 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved role assignment data retrieval to request more detailed source information.

---

**Note:** This is a minor internal update with no direct impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->