### PR TITLE
fix(table-view): filter non-selectable rows in bulk select

### DIFF
--- a/src/shared/components/table-view/TableView.stories.tsx
+++ b/src/shared/components/table-view/TableView.stories.tsx
@@ -1150,7 +1150,13 @@ const BulkSelectIsRowSelectableTable: React.FC = () => {
       ariaLabel="Bulk select test table"
       ouiaId="BulkSelectTest"
       bulkActions={
-        tableState.selectedRows.length > 0 ? <span data-testid="selected-count">Selected: {tableState.selectedRows.length}</span> : undefined
+        tableState.selectedRows.length > 0 ? (
+          <>
+            <span data-testid="selected-count">Selected: {tableState.selectedRows.length}</span>
+            <span data-testid="selected-ids">{tableState.selectedRows.map((row) => row.id).join(',')}</span>
+            <span data-testid="selected-names">{tableState.selectedRows.map((row) => row.name).join(',')}</span>
+          </>
+        ) : undefined
       }
       {...tableState}
     />
@@ -1182,6 +1188,19 @@ export const BulkSelectRespectsIsRowSelectable: StoryObj<typeof BulkSelectIsRowS
       await waitFor(() => {
         expect(canvas.queryByTestId('selected-count')).toHaveTextContent('Selected: 3');
       });
+
+      // Verify the actual selectedRows contains only non-system rows (by ID and name)
+      const selectedIds = canvas.getByTestId('selected-ids');
+      expect(selectedIds).toHaveTextContent('1,3,5');
+      // Verify system role IDs are NOT in the selection
+      expect(selectedIds.textContent).not.toContain('2');
+      expect(selectedIds.textContent).not.toContain('4');
+
+      const selectedNames = canvas.getByTestId('selected-names');
+      expect(selectedNames).toHaveTextContent('Custom Role A,Custom Role C,Custom Role E');
+      // Verify system roles are NOT in the selection
+      expect(selectedNames.textContent).not.toContain('System Role B');
+      expect(selectedNames.textContent).not.toContain('System Role D');
 
       // All row checkboxes should be checked
       expect(checkboxes[1]).toBeChecked();

--- a/src/shared/components/table-view/TableView.stories.tsx
+++ b/src/shared/components/table-view/TableView.stories.tsx
@@ -1102,6 +1102,109 @@ export const SelectionWithBulkDelete: Story = {
 };
 
 /**
+ * Bulk select respects isRowSelectable.
+ * Uses a minimal static-data component to verify that handleBulkSelect
+ * filters out non-selectable rows before calling onSelectAll.
+ */
+
+interface SimpleItem {
+  id: string;
+  name: string;
+  system: boolean;
+}
+
+const bulkSelectItems: SimpleItem[] = [
+  { id: '1', name: 'Custom Role A', system: false },
+  { id: '2', name: 'System Role B', system: true },
+  { id: '3', name: 'Custom Role C', system: false },
+  { id: '4', name: 'System Role D', system: true },
+  { id: '5', name: 'Custom Role E', system: false },
+];
+
+const bulkSelectColumns = ['name'] as const;
+const bulkSelectColumnConfig: ColumnConfigMap<typeof bulkSelectColumns> = {
+  name: { label: 'Name' },
+};
+const bulkSelectCellRenderers: CellRendererMap<typeof bulkSelectColumns, SimpleItem> = {
+  name: (row) => row.name,
+};
+
+const BulkSelectIsRowSelectableTable: React.FC = () => {
+  const tableState = useTableState<typeof bulkSelectColumns, SimpleItem>({
+    columns: bulkSelectColumns,
+    getRowId: (row) => row.id,
+    isRowSelectable: (row) => !row.system,
+    initialPerPage: 10,
+  });
+
+  return (
+    <TableView
+      columns={bulkSelectColumns}
+      columnConfig={bulkSelectColumnConfig}
+      data={bulkSelectItems}
+      totalCount={bulkSelectItems.length}
+      getRowId={(row) => row.id}
+      cellRenderers={bulkSelectCellRenderers}
+      selectable
+      isRowSelectable={(row) => !row.system}
+      ariaLabel="Bulk select test table"
+      ouiaId="BulkSelectTest"
+      bulkActions={
+        tableState.selectedRows.length > 0 ? <span data-testid="selected-count">Selected: {tableState.selectedRows.length}</span> : undefined
+      }
+      {...tableState}
+    />
+  );
+};
+
+export const BulkSelectRespectsIsRowSelectable: StoryObj<typeof BulkSelectIsRowSelectableTable> = {
+  render: () => <BulkSelectIsRowSelectableTable />,
+  play: async ({ canvasElement, step }) => {
+    await step('Verify bulk select skips non-selectable rows', async () => {
+      const canvas = within(canvasElement);
+
+      // Wait for data to render
+      await waitFor(() => {
+        expect(canvas.queryByText('Custom Role A')).toBeInTheDocument();
+      });
+
+      // 5 rows total, 3 selectable (non-system), 2 non-selectable (system)
+      // Non-selectable rows render no checkbox → only 4 checkboxes: 1 bulk + 3 rows
+      const checkboxes = canvas.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(4); // 1 bulk select + 3 selectable rows
+
+      const bulkSelectCheckbox = checkboxes[0];
+
+      // Click bulk select to select all on page
+      await userEvent.click(bulkSelectCheckbox);
+
+      // Should show selected count = 3 (only non-system rows)
+      await waitFor(() => {
+        expect(canvas.queryByTestId('selected-count')).toHaveTextContent('Selected: 3');
+      });
+
+      // All row checkboxes should be checked
+      expect(checkboxes[1]).toBeChecked();
+      expect(checkboxes[2]).toBeChecked();
+      expect(checkboxes[3]).toBeChecked();
+
+      // Deselect all
+      await userEvent.click(bulkSelectCheckbox);
+
+      // Selected count should disappear
+      await waitFor(() => {
+        expect(canvas.queryByTestId('selected-count')).not.toBeInTheDocument();
+      });
+
+      // All row checkboxes should be unchecked
+      expect(checkboxes[1]).not.toBeChecked();
+      expect(checkboxes[2]).not.toBeChecked();
+      expect(checkboxes[3]).not.toBeChecked();
+    });
+  },
+};
+
+/**
  * Table without selection feature.
  */
 export const NoSelection: Story = {

--- a/src/shared/components/table-view/TableView.tsx
+++ b/src/shared/components/table-view/TableView.tsx
@@ -202,10 +202,11 @@ export function TableView<
 
   function handleBulkSelect(value: BulkSelectValue) {
     const currentRows = data || [];
+    const selectableRows = currentRows.filter(isRowSelectable);
     if (value === BulkSelectValue.none || value === BulkSelectValue.nonePage) {
-      onSelectAll?.(false, currentRows);
+      onSelectAll?.(false, selectableRows);
     } else if (value === BulkSelectValue.page || value === BulkSelectValue.all) {
-      onSelectAll?.(true, currentRows);
+      onSelectAll?.(true, selectableRows);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Bug**: `TableView.handleBulkSelect` passed all rows to `onSelectAll` without filtering by `isRowSelectable`, causing "Select all" to include non-selectable rows (e.g., system/default roles)
- **Fix**: Filter rows through `isRowSelectable` before passing to `onSelectAll` callback
- **Test**: Added `BulkSelectRespectsIsRowSelectable` Storybook interaction test with static data verifying only selectable rows are included in bulk selection

RHCLOUD-46661

## Test plan

- [x] All 1019 Storybook tests passing (174 suites)
- [x] All 210 unit tests passing (14 suites)
- [x] ESLint + Prettier + circular dependency checks passing
- [ ] Verify in staging: navigate to V2 Roles table, click "Select all" — system/default roles should not be selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk select now respects per-row selectability so only selectable rows are included in bulk operations and counts reflect actual selections.

* **Tests**
  * Added a test that verifies bulk-select only affects selectable rows, including checkbox states and selected count.

* **Examples**
  * Added an interactive story demonstrating and validating bulk-select behavior with non-selectable rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->