### PR TITLE
fix(groups): consistent date format with 3-month threshold

### DIFF
--- a/src/docs/TableView.mdx
+++ b/src/docs/TableView.mdx
@@ -57,7 +57,7 @@ export const MyFeatureTable: React.FC = () => {
       columnConfig={{
         name:    { label: 'Name', sortable: true },
         status:  { label: 'Status' },
-        created: { label: 'Created', sortable: true },
+        created: { label: 'Created', sortable: true, format: 'date' },
       }}
       data={data ?? []}
       totalCount={totalCount ?? 0}
@@ -82,7 +82,7 @@ export const MyFeatureTable: React.FC = () => {
       cellRenderers={{
         name:    (row) => <strong>{row.name}</strong>,
         status:  (row) => <StatusBadge status={row.status} />,
-        created: (row) => formatDate(row.created),
+        created: (row) => row.created,  // format: 'date' handles DateFormat wrapping
       }}
     />
   );

--- a/src/shared/components/table-view/components/TableViewRow.tsx
+++ b/src/shared/components/table-view/components/TableViewRow.tsx
@@ -11,7 +11,9 @@
 import React from 'react';
 import { Tbody, Td, Tr } from '@patternfly/react-table/dist/dynamic/components/Table';
 import { ExpandableRowContent } from '@patternfly/react-table/dist/dynamic/components/Table';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import type { CellRendererMap, ColumnConfigMap, ExpansionRendererMap } from '../types';
+import { getDateFormat } from '../../../helpers/stringUtilities';
 
 export interface TableViewRowProps<TColumns extends readonly string[], TRow, TCompound extends string> {
   /** Row data */
@@ -132,8 +134,17 @@ export function TableViewRow<TColumns extends readonly string[], TRow, TCompound
         const isCompound = compoundColumnSet.has(col);
         const canExpand = isCompound && isCellExpandable(row, col as TCompound);
         const cellExpanded = isCellExpanded(col);
-        const rawLabel = columnConfig[col as keyof typeof columnConfig]?.label;
+        const colConfig = columnConfig[col as keyof typeof columnConfig];
+        const rawLabel = colConfig?.label;
         const dataLabel = typeof rawLabel === 'string' ? rawLabel : col;
+
+        const cellContent = cellRenderers[col as keyof typeof cellRenderers](row);
+        const formattedContent =
+          colConfig?.format === 'date' && typeof cellContent === 'string' && cellContent ? (
+            <DateFormat date={cellContent} type={getDateFormat(cellContent)} />
+          ) : (
+            cellContent
+          );
 
         return (
           <Td
@@ -148,7 +159,7 @@ export function TableViewRow<TColumns extends readonly string[], TRow, TCompound
                 : undefined
             }
           >
-            {cellRenderers[col as keyof typeof cellRenderers](row)}
+            {formattedContent}
           </Td>
         );
       })}

--- a/src/shared/components/table-view/types.ts
+++ b/src/shared/components/table-view/types.ts
@@ -40,6 +40,15 @@ export interface ColumnConfig {
   isCompound?: boolean;
   /** Width percentage modifier — matches PatternFly Th width prop */
   width?: BaseCellProps['width'];
+  /**
+   * Column display format.
+   * - `'date'`: Automatically formats the cell renderer's return value as a date.
+   *   The cell renderer should return a date string (ISO 8601) or empty string.
+   *   Dates within 3 months show relative format ("2 days ago"), older dates show
+   *   full format ("15 Jun 2025"). Uses the shared `DateFormat` component and
+   *   `getDateFormat` utility for consistent date handling across the app.
+   */
+  format?: 'date';
 }
 
 /**

--- a/src/shared/helpers/stringUtilities.ts
+++ b/src/shared/helpers/stringUtilities.ts
@@ -1,7 +1,9 @@
+import { subMonths } from 'date-fns';
+
 export const firstUpperCase = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1);
 
 export const getDateFormat = (date: string): 'onlyDate' | 'relative' => {
-  const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  const threeMonthsAgo = subMonths(new Date(), 3);
   return Date.parse(date) < threeMonthsAgo.getTime() ? 'onlyDate' : 'relative';
 };
 

--- a/src/shared/helpers/stringUtilities.ts
+++ b/src/shared/helpers/stringUtilities.ts
@@ -1,8 +1,9 @@
 export const firstUpperCase = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1);
 
 export const getDateFormat = (date: string): 'onlyDate' | 'relative' => {
-  const monthAgo = new Date(Date.now());
-  return Date.parse(date) < monthAgo.setMonth(monthAgo.getMonth() - 1) ? 'onlyDate' : 'relative';
+  const threeMonthsAgo = new Date(Date.now());
+  threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+  return Date.parse(date) < threeMonthsAgo.getTime() ? 'onlyDate' : 'relative';
 };
 
 // This function is used to trim all leading and trailing spaces in a string and

--- a/src/shared/helpers/stringUtilities.ts
+++ b/src/shared/helpers/stringUtilities.ts
@@ -1,8 +1,7 @@
 export const firstUpperCase = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1);
 
 export const getDateFormat = (date: string): 'onlyDate' | 'relative' => {
-  const threeMonthsAgo = new Date(Date.now());
-  threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+  const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
   return Date.parse(date) < threeMonthsAgo.getTime() ? 'onlyDate' : 'relative';
 };
 

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -503,6 +503,13 @@ export const DateFormatSwitching: Story = {
       // Full date format: "15 Jun 2025"
       await expect(within(oldRow!).findByText(/\d{2}\s\w{3}\s\d{4}/)).resolves.toBeInTheDocument();
     });
+
+    await step('Verify empty date stays empty', async () => {
+      const canvas = within(canvasElement);
+      const noDateRow = (await canvas.findByText('No Date Group')).closest('tr');
+      await expect(within(noDateRow!).queryByText(/ago$/i)).not.toBeInTheDocument();
+      await expect(within(noDateRow!).queryByText(/\d{2}\s\w{3}\s\d{4}/)).not.toBeInTheDocument();
+    });
   },
 };
 

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -458,6 +458,54 @@ export const BulkSelection: Story = {
   },
 };
 
+// Date format switching: relative for recent (<3 months), full date for older
+export const DateFormatSwitching: Story = {
+  args: {
+    groups: [
+      {
+        ...createMockGroup('recent'),
+        name: 'Recently Modified',
+        modified: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), // 2 days ago
+      },
+      {
+        ...createMockGroup('old'),
+        name: 'Old Group',
+        modified: new Date('2025-06-15T12:00:00Z').toISOString(), // >3 months ago
+      },
+      {
+        ...createMockGroup('no-date'),
+        name: 'No Date Group',
+        modified: '',
+      },
+    ],
+    totalCount: 3,
+    enableActions: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Verifies that "Last Modified" dates use relative format ("2 days ago") for groups modified within the last 3 months and full date format ("15 Jun 2025") for older groups. Groups with no date show an empty cell.',
+      },
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify recent date shows relative format', async () => {
+      const canvas = within(canvasElement);
+      const recentRow = (await canvas.findByText('Recently Modified')).closest('tr');
+      // Relative format contains "ago" suffix
+      await expect(within(recentRow!).findByText(/ago$/)).resolves.toBeInTheDocument();
+    });
+
+    await step('Verify old date shows full date format', async () => {
+      const canvas = within(canvasElement);
+      const oldRow = (await canvas.findByText('Old Group')).closest('tr');
+      // Full date format: "15 Jun 2025"
+      await expect(within(oldRow!).findByText(/\d{2}\s\w{3}\s\d{4}/)).resolves.toBeInTheDocument();
+    });
+  },
+};
+
 // No actions mode
 export const NoActionsMode: Story = {
   args: {

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from 'react';
-import { format, formatDistanceToNow } from 'date-fns';
 import type { IntlShape } from 'react-intl';
 import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
 
 import type { CellRendererMap, ColumnConfigMap, FilterConfig } from '../../../../../../shared/components/table-view';
 import type { Group } from '../../../../../../v2/data/queries/groups';
-import { getDateFormat } from '../../../../../../shared/helpers/stringUtilities';
 import messages from '../../../../../../Messages';
 
 // NOTE: Per V2 designs, only name/description/users/lastModified are shown.
@@ -32,7 +30,7 @@ export function useUserGroupsTableConfig({ intl }: UseUserGroupsTableConfigOptio
       name: { label: intl.formatMessage(messages.name), sortable: true },
       description: { label: intl.formatMessage(messages.description) },
       principalCount: { label: intl.formatMessage(messages.users) },
-      modified: { label: intl.formatMessage(messages.lastModified), sortable: true },
+      modified: { label: intl.formatMessage(messages.lastModified), sortable: true, format: 'date' },
     }),
     [intl],
   );
@@ -49,11 +47,7 @@ export function useUserGroupsTableConfig({ intl }: UseUserGroupsTableConfigOptio
           <div className="pf-v6-u-color-400">{intl.formatMessage(messages['usersAndUserGroupsNoDescription'])}</div>
         ),
       principalCount: (group) => group.principalCount ?? 0,
-      modified: (group) => {
-        if (!group.modified) return '';
-        const date = new Date(group.modified);
-        return getDateFormat(group.modified) === 'onlyDate' ? format(date, 'dd MMM yyyy') : formatDistanceToNow(date, { addSuffix: true });
-      },
+      modified: (group) => group.modified ?? '',
     }),
     [intl],
   );

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/useUserGroupsTableConfig.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
-import { formatDistanceToNow } from 'date-fns';
+import { format, formatDistanceToNow } from 'date-fns';
 import type { IntlShape } from 'react-intl';
 import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
 
 import type { CellRendererMap, ColumnConfigMap, FilterConfig } from '../../../../../../shared/components/table-view';
 import type { Group } from '../../../../../../v2/data/queries/groups';
+import { getDateFormat } from '../../../../../../shared/helpers/stringUtilities';
 import messages from '../../../../../../Messages';
 
 // NOTE: Per V2 designs, only name/description/users/lastModified are shown.
@@ -48,7 +49,11 @@ export function useUserGroupsTableConfig({ intl }: UseUserGroupsTableConfigOptio
           <div className="pf-v6-u-color-400">{intl.formatMessage(messages['usersAndUserGroupsNoDescription'])}</div>
         ),
       principalCount: (group) => group.principalCount ?? 0,
-      modified: (group) => (group.modified ? formatDistanceToNow(new Date(group.modified), { addSuffix: true }) : ''),
+      modified: (group) => {
+        if (!group.modified) return '';
+        const date = new Date(group.modified);
+        return getDateFormat(group.modified) === 'onlyDate' ? format(date, 'dd MMM yyyy') : formatDistanceToNow(date, { addSuffix: true });
+      },
     }),
     [intl],
   );


### PR DESCRIPTION
## Summary

- Fixed inconsistent "Last Modified" date formatting in Groups table — dates older than 3 months now show full date format (`dd MMM yyyy`), recent dates show relative format ("2 days ago")
- Changed `getDateFormat` threshold from 1 month to 3 months per Karel Hala's specification
- Applied consistent formatting to V2 User Groups table (previously always showed relative time regardless of age)

Fixes RHCLOUD-31868

## Test plan

- [x] All 1019 Storybook tests pass
- [x] All 210 vitest tests pass
- [x] ESLint clean
- [x] Added `DateFormatSwitching` story verifying format transition
- [ ] Visual verification in staging: Groups table shows "2 days ago" for recent, "15 Jun 2025" for old entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Date formatting now treats recent activity (within ~3 months) as relative timestamps (e.g., "2 days ago"); older activity shows full dates (e.g., "15 Jun 2025"). Empty values render an empty date cell.
* **New Features**
  * Column-level date formatting applied so date cells are consistently formatted by the table.
* **Tests**
  * Added a story verifying recent, old, and empty "Last Modified" displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->