### PR TITLE
fix(roles): add meaningful OUIA IDs to wizard dropdowns

### DIFF
--- a/src/v1/features/roles/add-role/CostResources.tsx
+++ b/src/v1/features/roles/add-role/CostResources.tsx
@@ -225,7 +225,14 @@ const CostResources: React.FC<CostResourcesProps> = (props) => {
     const textInputRef = useRef<HTMLInputElement>(null);
 
     const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-      <MenuToggle ref={toggleRef} variant="typeahead" onClick={() => onToggle(permission)} isExpanded={isOpen} isFullWidth>
+      <MenuToggle
+        ref={toggleRef}
+        variant="typeahead"
+        onClick={() => onToggle(permission)}
+        isExpanded={isOpen}
+        isFullWidth
+        data-ouia-component-id={`cost-resource-toggle-${permission}`}
+      >
         <TextInputGroup isPlain>
           <TextInputGroupMain
             value={filterValue}
@@ -261,6 +268,7 @@ const CostResources: React.FC<CostResourcesProps> = (props) => {
             className="rbac-m-resource-type-select"
             maxMenuHeight="300px"
             isOpen={isOpen}
+            ouiaId={`cost-resource-select-${permission}`}
             onSelect={(_event, value) => {
               if (value === selectAllLabel) {
                 onSelect(value as string, true, permission);

--- a/src/v1/features/roles/add-role/InventoryGroupsRole.tsx
+++ b/src/v1/features/roles/add-role/InventoryGroupsRole.tsx
@@ -238,6 +238,7 @@ const InventoryGroupsRole: React.FC<InventoryGroupsRoleProps> = (props) => {
         innerRef={toggleRef as React.Ref<HTMLButtonElement>}
         isExpanded={state[permissionID]?.isOpen || false}
         isFullWidth
+        data-ouia-component-id={`inventory-group-toggle-${permissionID}`}
       >
         <TextInputGroup isPlain>
           <TextInputGroupMain
@@ -307,6 +308,7 @@ const InventoryGroupsRole: React.FC<InventoryGroupsRoleProps> = (props) => {
               toggle={(toggleRef) => toggle(toggleRef, permissionID)}
               isScrollable
               maxMenuHeight="300px"
+              ouiaId={`inventory-group-select-${permissionID}`}
             >
               <SelectList>
                 {isLoading ? (


### PR DESCRIPTION
## Summary

Resolves [RHCLOUD-28016](https://issues.redhat.com/browse/RHCLOUD-28016) — the group/resource definition dropdowns in the create role wizard had auto-generated OUIA IDs, making automated testing unreliable.

### Changes

- **InventoryGroupsRole.tsx** — Added `ouiaId` to the `Select` component and `data-ouia-component-id` to the `MenuToggle`, using the permission string for uniqueness (e.g. `inventory-group-select-inventory:hosts:read`)
- **CostResources.tsx** — Same pattern for cost-management resource selection dropdowns (e.g. `cost-resource-select-cost-management:aws.account:read`)

### Test plan

- [ ] Verify lint passes (`npm run lint`)
- [ ] Verify unit tests pass (`npm run test:web`)
- [ ] Open the create role wizard, add an inventory permission, and inspect the group definition dropdown — confirm `data-ouia-component-id` contains the permission string
- [ ] Repeat for cost-management permissions and verify resource definition dropdown OUIA IDs

[RHCLOUD-28016]: https://redhat.atlassian.net/browse/RHCLOUD-28016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced UI identification attributes for role management components to improve testing and identification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->