### PR TITLE
fix(groups): show all-users alert for custom default access groups

### DIFF
--- a/src/v1/features/groups/group/members/GroupMembers.stories.tsx
+++ b/src/v1/features/groups/group/members/GroupMembers.stories.tsx
@@ -329,7 +329,7 @@ export const DefaultPlatformGroup: Story = {
     await step('Verify platform default group card', async () => {
       expect(await canvas.findByText('All users in this organization are members of this group.')).toBeInTheDocument();
 
-      const table = canvas.queryByRole('table');
+      const table = canvas.queryByRole('grid');
       expect(table).not.toBeInTheDocument();
       const addButton = canvas.queryByRole('button', { name: /add member/i });
       expect(addButton).not.toBeInTheDocument();
@@ -667,7 +667,7 @@ export const ChangedDefaultPlatformGroup: Story = {
     await step('Verify changed platform default group shows all-users alert', async () => {
       expect(await canvas.findByText('All users in this organization are members of this group.')).toBeInTheDocument();
 
-      const table = canvas.queryByRole('table');
+      const table = canvas.queryByRole('grid');
       expect(table).not.toBeInTheDocument();
       const addButton = canvas.queryByRole('button', { name: /add member/i });
       expect(addButton).not.toBeInTheDocument();

--- a/src/v1/features/groups/group/members/GroupMembers.stories.tsx
+++ b/src/v1/features/groups/group/members/GroupMembers.stories.tsx
@@ -70,6 +70,14 @@ const mockDefaultPlatformGroup: GroupOut = {
   system: true,
 };
 
+const mockChangedDefaultPlatformGroup: GroupOut = {
+  ...mockGroup,
+  uuid: 'changed-platform-group-123',
+  name: 'Custom Default Access',
+  platform_default: true,
+  system: false,
+};
+
 // Track API calls for parameter verification
 const getMembersSpy = fn();
 const getGroupSpy = fn();
@@ -78,10 +86,11 @@ const membersByGroupId: Record<string, Principal[]> = {
   'group-123': mockMembers,
   'admin-group-123': [],
   'platform-group-123': [],
+  'changed-platform-group-123': [],
 };
 
 const createMockHandlers = () => [
-  ...groupsHandlers([mockGroup, mockDefaultAdminGroup, mockDefaultPlatformGroup], {
+  ...groupsHandlers([mockGroup, mockDefaultAdminGroup, mockDefaultPlatformGroup, mockChangedDefaultPlatformGroup], {
     onList: () => {},
   }),
   ...groupMembersHandlers(
@@ -637,6 +646,31 @@ Perfect for code review and UX validation.
       expect(modal).toBeInTheDocument();
       expect(within(modal).getByText(/Remove member\?/i)).toBeInTheDocument();
       expect(within(modal).getByText(new RegExp(mockMembers[0].username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'))).toBeInTheDocument();
+    });
+  },
+};
+
+// Custom (changed) platform default group - should still show "all users are members" alert
+export const ChangedDefaultPlatformGroup: Story = {
+  parameters: {
+    groupId: 'changed-platform-group-123',
+    msw: {
+      handlers: [
+        ...groupsHandlers([mockChangedDefaultPlatformGroup]),
+        ...groupMembersHandlers({ 'changed-platform-group-123': [] }, {}, { onListMembers: (groupId) => getMembersSpy({ groupId }) }),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify changed platform default group shows all-users alert', async () => {
+      expect(await canvas.findByText('All users in this organization are members of this group.')).toBeInTheDocument();
+
+      const table = canvas.queryByRole('table');
+      expect(table).not.toBeInTheDocument();
+      const addButton = canvas.queryByRole('button', { name: /add member/i });
+      expect(addButton).not.toBeInTheDocument();
     });
   },
 };

--- a/src/v1/features/groups/group/members/GroupMembers.tsx
+++ b/src/v1/features/groups/group/members/GroupMembers.tsx
@@ -64,8 +64,10 @@ const GroupMembers: React.FC<GroupMembersProps> = (props) => {
   const isChanged = platformDefault && !isSystemGroup;
   const group = groupData;
 
-  // Show default cards for default groups that haven't been modified
-  const showDefaultCard = (adminDefault || platformDefault) && isSystemGroup;
+  // Show default info for default groups
+  // A customized platform default group still implicitly includes all org members,
+  // so always show the alert for platform default groups (regardless of system status)
+  const showDefaultCard = (adminDefault && isSystemGroup) || platformDefault;
 
   // useTableState for all state management - provides apiParams for queries
   const tableState = useTableState<typeof columns, Member>({


### PR DESCRIPTION
## Summary
- Fixed custom (changed) platform default access groups showing an empty "no members" table instead of the "All users in this organization are members" alert
- Root cause: `showDefaultCard` only checked `isSystemGroup`, so customized default groups (`system: false, platform_default: true`) fell through to the members table, which returned empty since membership is implicit
- Added storybook test for the `ChangedDefaultPlatformGroup` scenario

RHCLOUD-43522

## Test plan
- [ ] Verify "All users in this organization are members" alert shows for unchanged default access groups (existing behavior preserved)
- [ ] Verify "All org admins are members" alert shows for admin default groups (existing behavior preserved)
- [ ] Verify same alert shows for customized/changed default access groups (bug fix)
- [ ] Verify regular non-default groups still show the members table normally
- [ ] Run `npm run test:storybook` — all 1026 tests pass including new `ChangedDefaultPlatformGroup` story

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected display logic so platform-default groups now show the default-members notification consistently; when that notification appears, the member list and related controls (including "Add member") are hidden.

* **Documentation**
  * Added a story demonstrating the changed platform-default group state, verifying the default-members alert and that the member grid and "Add member" control are not rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->