### PR TITLE
fix(groups): prevent editing Default access groups in v2

### DIFF
--- a/e2e/journeys/v2/user-groups/user-group-detail.spec.ts
+++ b/e2e/journeys/v2/user-groups/user-group-detail.spec.ts
@@ -119,6 +119,28 @@ test.describe('User Group Detail', () => {
       await expect(groupsPage.editPageNameInput).toHaveValue(new RegExp(SEEDED_GROUP_NAME!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     });
 
+    test(`Drawer Edit button is not visible for Default access group [OrgAdmin]`, async ({ page }) => {
+      const groupsPage = new UserGroupsPage(page);
+      await groupsPage.goto();
+
+      await groupsPage.openDrawer('Default access');
+      await expect(groupsPage.drawer.getByRole('heading', { name: 'Default access' })).toBeVisible();
+      await expect(groupsPage.drawerEditButton).not.toBeVisible();
+
+      await groupsPage.closeDrawerViaButton();
+    });
+
+    test(`Drawer Edit button is not visible for Default admin access group [OrgAdmin]`, async ({ page }) => {
+      const groupsPage = new UserGroupsPage(page);
+      await groupsPage.goto();
+
+      await groupsPage.openDrawer('Default admin access');
+      await expect(groupsPage.drawer.getByRole('heading', { name: 'Default admin access' })).toBeVisible();
+      await expect(groupsPage.drawerEditButton).not.toBeVisible();
+
+      await groupsPage.closeDrawerViaButton();
+    });
+
     test(`Drawer close button works [OrgAdmin]`, async ({ page }) => {
       test.skip(!SEEDED_GROUP_NAME, 'No seed data — run npm run e2e:seed:v2');
       const groupsPage = new UserGroupsPage(page);

--- a/e2e/journeys/v2/user-groups/user-group-management.spec.ts
+++ b/e2e/journeys/v2/user-groups/user-group-management.spec.ts
@@ -161,23 +161,31 @@ test.describe('User Group Management', () => {
       await expect(groupsPage.createButton).toBeVisible();
     });
 
-    test('Default access group delete is disabled [OrgAdmin]', async ({ page }) => {
+    test('Default access group has no Edit action and Delete is disabled [OrgAdmin]', async ({ page }) => {
       const groupsPage = new UserGroupsPage(page);
       await groupsPage.goto();
 
       await page.getByRole('button', { name: 'Actions for group Default access' }).click();
-      // PatternFly uses HTML `disabled` attribute (not aria-disabled) on the menu button
+      // Edit action should not be present at all
+      await expect(page.getByRole('menuitem', { name: /edit user group/i })).not.toBeVisible({
+        timeout: E2E_TIMEOUTS.MENU_ANIMATION,
+      });
+      // Delete action should be present but disabled
       await expect(page.getByRole('menuitem', { name: /delete user group/i })).toBeDisabled({
         timeout: E2E_TIMEOUTS.MENU_ANIMATION,
       });
     });
 
-    test('Default admin access group delete is disabled [OrgAdmin]', async ({ page }) => {
+    test('Default admin access group has no Edit action and Delete is disabled [OrgAdmin]', async ({ page }) => {
       const groupsPage = new UserGroupsPage(page);
       await groupsPage.goto();
 
       await page.getByRole('button', { name: 'Actions for group Default admin access' }).click();
-      // PatternFly uses HTML `disabled` attribute (not aria-disabled) on the menu button
+      // Edit action should not be present at all
+      await expect(page.getByRole('menuitem', { name: /edit user group/i })).not.toBeVisible({
+        timeout: E2E_TIMEOUTS.MENU_ANIMATION,
+      });
+      // Delete action should be present but disabled
       await expect(page.getByRole('menuitem', { name: /delete user group/i })).toBeDisabled({
         timeout: E2E_TIMEOUTS.MENU_ANIMATION,
       });

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.stories.tsx
@@ -625,16 +625,13 @@ export const SystemGroupProtection: StoryObj<typeof meta> = {
       const systemKebabButton = await canvas.findByLabelText(`Actions for group ${mockGroups[2].name}`);
       await userEvent.click(systemKebabButton);
 
-      // Actions should be disabled for system groups
-      const editAction = await within(document.body).findByText('Edit user group');
-      const deleteAction = await within(document.body).findByText('Delete user group');
+      // Edit action should be hidden for system groups
+      const editAction = within(document.body).queryByText('Edit user group');
+      await expect(editAction).not.toBeInTheDocument();
 
-      // Verify actions exist but are disabled (implementation verified by other passing tests)
-      await expect(editAction).toBeInTheDocument();
-      await expect(deleteAction).toBeInTheDocument();
-
-      // System groups should show edit and delete options but they should be disabled
-      // The exact disabled state implementation is verified by the functional behavior
+      // Delete action should still be present but disabled
+      const deleteAction = await within(document.body).findByRole('menuitem', { name: /delete user group/i });
+      await expect(deleteAction).toBeDisabled();
     });
   },
 };

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/UserGroups.tsx
@@ -165,7 +165,11 @@ export const UserGroups: React.FC<UserGroupsProps> = ({ groupsRef, defaultPerPag
           groupName={focusedGroup?.name}
           groupId={focusedGroup?.uuid}
           onClose={() => setFocusedGroup(undefined)}
-          onEditGroup={focusedGroup ? () => handleEditGroup(focusedGroup) : undefined}
+          onEditGroup={
+            focusedGroup && !focusedGroup.platform_default && !focusedGroup.admin_default && !focusedGroup.system
+              ? () => handleEditGroup(focusedGroup)
+              : undefined
+          }
           drawerRef={drawerRef}
           ouiaId="groups-details-drawer"
           activeTabKey={activeTabKey}

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/GroupDetailsDrawer.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/GroupDetailsDrawer.stories.tsx
@@ -96,6 +96,67 @@ const DrawerExample = () => {
   );
 };
 
+// Drawer with no Edit button (simulates default access group)
+const DrawerNoEditExample = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <GroupDetailsDrawer
+      isOpen={isOpen}
+      groupName="Default access"
+      onClose={() => setIsOpen(false)}
+      drawerRef={drawerRef}
+      ouiaId="group-details-drawer-no-edit"
+      activeTabKey={activeTabKey}
+      onTabSelect={setActiveTabKey}
+      renderUsersTab={() => <div style={{ padding: '1rem' }}>Users tab content</div>}
+      renderServiceAccountsTab={() => <div style={{ padding: '1rem' }}>Service accounts tab content</div>}
+      renderRolesTab={() => <div style={{ padding: '1rem' }}>Assigned roles tab content</div>}
+    >
+      <Card>
+        <CardBody>
+          <h2>User Groups Table</h2>
+          <p>Click the button below to open the group details drawer without an Edit button.</p>
+          <Button onClick={() => setIsOpen(true)} disabled={isOpen}>
+            View Default Group Details
+          </Button>
+        </CardBody>
+      </Card>
+    </GroupDetailsDrawer>
+  );
+};
+
+export const DefaultGroupNoEdit: Story = {
+  render: () => <DrawerNoEditExample />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default access groups do not show the Edit button in the drawer. The `onEditGroup` prop is omitted, hiding the pencil icon.',
+      },
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Open drawer and verify no Edit button', async () => {
+      const openButton = await canvas.findByRole('button', { name: /view default group details/i });
+      await userEvent.click(openButton);
+
+      await expect(canvas.findByText('Default access')).resolves.toBeInTheDocument();
+
+      // Edit button should NOT be visible
+      await expect(canvas.queryByRole('button', { name: /edit user group/i })).not.toBeInTheDocument();
+
+      // Tabs should still be present
+      await expect(canvas.findByRole('tab', { name: /users/i })).resolves.toBeInTheDocument();
+      await expect(canvas.findByRole('tab', { name: /service accounts/i })).resolves.toBeInTheDocument();
+      await expect(canvas.findByRole('tab', { name: /assigned roles/i })).resolves.toBeInTheDocument();
+    });
+  },
+};
+
 export const Default: Story = {
   render: () => <DrawerExample />,
   play: async ({ canvasElement, step }) => {

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.stories.tsx
@@ -272,7 +272,7 @@ export const FocusedGroup: Story = {
   },
 };
 
-// Actions disabled for system groups
+// Actions hidden/disabled for system groups
 export const SystemGroupActions: Story = {
   args: {
     groups: [mockGroups[4]], // System group
@@ -281,7 +281,7 @@ export const SystemGroupActions: Story = {
     docs: {
       description: {
         story:
-          'System groups have disabled actions to prevent accidental modification. Tests the permission logic that protects critical system groups from user modification.',
+          'System groups have the Edit action hidden and the Delete action disabled. Tests the permission logic that protects critical system groups from user modification.',
       },
     },
   },
@@ -289,14 +289,65 @@ export const SystemGroupActions: Story = {
     await step('Verify', async () => {
       const canvas = within(canvasElement);
 
-      // Test kebab menu functionality for system group (should show both edit and delete)
+      // Test kebab menu functionality for system group (edit should be hidden, delete should be disabled)
       const kebabButton = await canvas.findByLabelText('Actions for group System Group');
       await userEvent.click(kebabButton);
 
-      const editAction = await within(document.body).findByText(/edit/i);
-      const deleteAction = await within(document.body).findByText(/delete/i);
-      await expect(editAction).toBeInTheDocument();
-      await expect(deleteAction).toBeInTheDocument();
+      const editAction = within(document.body).queryByText(/edit user group/i);
+      await expect(editAction).not.toBeInTheDocument();
+
+      const deleteAction = await within(document.body).findByRole('menuitem', { name: /delete user group/i });
+      await expect(deleteAction).toBeDisabled();
+    });
+  },
+};
+
+// Default access groups have Edit hidden and Delete disabled
+export const DefaultGroupActions: Story = {
+  args: {
+    groups: [
+      { ...GROUP_SYSTEM_DEFAULT, principalCount: ALL_USERS_LABEL },
+      { ...GROUP_ADMIN_DEFAULT, principalCount: ALL_ORG_ADMINS_LABEL },
+    ],
+    totalCount: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default access groups (platform_default and admin_default) have the Edit action hidden from the kebab menu and the Delete action disabled. Users must manage default access via Workspace role-bindings instead.',
+      },
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify Default access group has no Edit action', async () => {
+      const canvas = within(canvasElement);
+
+      const kebabButton = await canvas.findByLabelText(`Actions for group ${GROUP_SYSTEM_DEFAULT.name}`);
+      await userEvent.click(kebabButton);
+
+      const editAction = within(document.body).queryByText(/edit user group/i);
+      await expect(editAction).not.toBeInTheDocument();
+
+      const deleteAction = await within(document.body).findByRole('menuitem', { name: /delete user group/i });
+      await expect(deleteAction).toBeDisabled();
+
+      await userEvent.keyboard('{Escape}');
+    });
+
+    await step('Verify Default admin access group has no Edit action', async () => {
+      const canvas = within(canvasElement);
+
+      const kebabButton = await canvas.findByLabelText(`Actions for group ${GROUP_ADMIN_DEFAULT.name}`);
+      await userEvent.click(kebabButton);
+
+      const editAction = within(document.body).queryByText(/edit user group/i);
+      await expect(editAction).not.toBeInTheDocument();
+
+      const deleteAction = await within(document.body).findByRole('menuitem', { name: /delete user group/i });
+      await expect(deleteAction).toBeDisabled();
+
+      await userEvent.keyboard('{Escape}');
     });
   },
 };

--- a/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.tsx
+++ b/src/v2/features/users-and-user-groups/users-and-user-groups/user-groups/components/UserGroupsTable.tsx
@@ -67,8 +67,8 @@ export const UserGroupsTable: React.FC<UserGroupsTableProps> = ({
   // Permission flag for modifying groups
   const canModifyGroups = enableActions && orgAdmin;
 
-  // Check if group can be edited
-  const isGroupEditable = useCallback((group: Group) => !group.platform_default && !group.system, []);
+  // Check if group can be edited (default access groups and system groups cannot be edited)
+  const isGroupEditable = useCallback((group: Group) => !group.platform_default && !group.admin_default && !group.system, []);
 
   // Check if group can be deleted (platform_default and system groups cannot be deleted)
   const isGroupDeletable = useCallback((group: Group) => !group.platform_default && !group.system && orgAdmin, [orgAdmin]);
@@ -135,12 +135,15 @@ export const UserGroupsTable: React.FC<UserGroupsTableProps> = ({
                   ariaLabel={`Actions for group ${group.name}`}
                   ouiaId={`${ouiaId}-${group.uuid}-actions`}
                   items={[
-                    {
-                      key: 'edit',
-                      label: intl.formatMessage(messages['usersAndUserGroupsEditUserGroup']),
-                      onClick: () => onEditGroup?.(group),
-                      isDisabled: !isGroupEditable(group),
-                    },
+                    ...(isGroupEditable(group)
+                      ? [
+                          {
+                            key: 'edit',
+                            label: intl.formatMessage(messages['usersAndUserGroupsEditUserGroup']),
+                            onClick: () => onEditGroup?.(group),
+                          },
+                        ]
+                      : []),
                     {
                       key: 'delete',
                       label: intl.formatMessage(messages['usersAndUserGroupsDeleteUserGroup']),


### PR DESCRIPTION
## Summary
- Hide the "Edit user group" action from the row kebab menu for Default access, Default admin access, and system groups in V2
- Hide the pencil Edit button in the group details drawer for those same groups
- In V2, these groups don't carry roles — users must manage default access via `/workspaces/default` role-bindings

## JIRA
https://redhat.atlassian.net/browse/RHCLOUD-47132

## Test plan
- [ ] Open User Groups page as OrgAdmin
- [ ] Verify "Default access" row kebab has no Edit option, only Delete (disabled)
- [ ] Verify "Default admin access" row kebab has no Edit option, only Delete (disabled)
- [ ] Click on "Default access" row to open drawer — verify no Edit button
- [ ] Click on "Default admin access" row to open drawer — verify no Edit button
- [ ] Verify regular groups still have Edit and Delete in kebab and Edit in drawer
- [ ] Storybook: `DefaultGroupActions`, `DefaultGroupNoEdit`, `SystemGroupActions` stories pass
- [ ] Playwright: `user-group-management` and `user-group-detail` specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in and system groups ("Default access", "Default admin access") are no longer editable; the Edit option is hidden in group details and action menus instead of shown disabled.

* **Tests**
  * Added and updated end-to-end and Storybook checks to verify the Edit control is not rendered for protected groups while Delete remains visible (and disabled where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->