### PR TITLE
fix(workspaces): hide Create sibling action for Root and Default workspaces

### DIFF
--- a/e2e/journeys/v2/workspaces/workspace-list.spec.ts
+++ b/e2e/journeys/v2/workspaces/workspace-list.spec.ts
@@ -155,10 +155,12 @@ test.describe('Workspace List', () => {
       const editItem = page.getByRole('menuitem', { name: /edit workspace/i });
       const deleteItem = page.getByRole('menuitem', { name: /delete workspace/i });
       const moveItem = page.getByRole('menuitem', { name: /move workspace/i });
+      const createSiblingItem = page.getByRole('menuitem', { name: /create sibling workspace/i });
 
       await expect(editItem).toBeDisabled({ timeout: E2E_TIMEOUTS.MENU_ANIMATION });
       await expect(deleteItem).toBeDisabled({ timeout: E2E_TIMEOUTS.MENU_ANIMATION });
       await expect(moveItem).toBeDisabled({ timeout: E2E_TIMEOUTS.MENU_ANIMATION });
+      await expect(createSiblingItem).not.toBeVisible();
     });
 
     // Root Workspace selection: backend does not yet support creating workspaces

--- a/src/v2/features/workspaces/WorkspaceList.stories.tsx
+++ b/src/v2/features/workspaces/WorkspaceList.stories.tsx
@@ -384,11 +384,12 @@ export const M2_WithWritePermission: Story = {
 **Expected Behavior:**
 - ✅ "Create workspace" button: **enabled** (with parent selection)
 - ✅ Kebab "Edit workspace": **enabled**
-- ✅ Kebab "Create workspace": **enabled**
+- ✅ Kebab "Create workspace": **enabled** (standard workspaces only)
 - ✅ Kebab "Create subworkspace": **enabled**
 - ✅ Kebab "Move workspace": **enabled**
 - ✅ Kebab "Delete workspace": **enabled** (for leaf workspaces)
 - ✅ Workspace links: **link to Inventory** (standard/ungrouped-hosts types)
+- ❌ Kebab "Create sibling workspace": **hidden** for Root and Default workspaces
         `,
       },
     },
@@ -415,11 +416,11 @@ export const M2_WithWritePermission: Story = {
     const createButton = await canvas.findByRole('button', { name: /create workspace/i });
     await waitFor(() => expect(createButton).not.toBeDisabled(), { timeout: 5000 });
 
-    // Open kebab menu and verify M2 actions are enabled
+    // Open kebab menu on a standard workspace (Production Environment) and verify M2 actions
     const kebabButtons = canvas.getAllByLabelText('Kebab toggle');
-    await user.click(kebabButtons[0]);
+    await user.click(kebabButtons[1]);
 
-    // Verify M2 CRUD actions exist in the kebab menu
+    // Verify M2 CRUD actions exist in the kebab menu for standard workspaces
     await within(document.body).findByText('Edit workspace');
     await within(document.body).findByText('Create sibling workspace');
     await within(document.body).findByText('Create sub-workspace');

--- a/src/v2/features/workspaces/components/WorkspaceActions.stories.tsx
+++ b/src/v2/features/workspaces/components/WorkspaceActions.stories.tsx
@@ -236,12 +236,13 @@ export const MenuNavigation: Story = {
 /**
  * Root workspace with Kessel grants stripped by type constraints.
  * Edit, Grant Access, Create sub-workspace, Move, and Delete are all disabled.
+ * Create sibling is hidden (not rendered) because root has no parent.
  */
 export const ItemsDisabledByWorkspaceType: Story = {
   args: {
     workspace: mockWorkspace,
     permissions: NO_PERMS,
-    callbacks: NOOP_CALLBACKS,
+    callbacks: { ...NOOP_CALLBACKS, onCreateSibling: undefined },
     isDisabled: false,
   },
   parameters: {
@@ -269,6 +270,46 @@ export const ItemsDisabledByWorkspaceType: Story = {
 
       const deleteItem = await body.findByText('Delete workspace');
       await expect(deleteItem.closest('button')).toHaveAttribute('disabled');
+    });
+    await step('Verify Create sibling workspace is not rendered', async () => {
+      await expect(within(document.body).queryByText('Create sibling workspace')).toBeNull();
+    });
+  },
+};
+
+/**
+ * Default workspace type restrictions.
+ * Create sibling is hidden because default's parent is root where creation is restricted.
+ */
+export const DefaultWorkspaceTypeRestrictions: Story = {
+  args: {
+    workspace: { ...mockWorkspace, id: 'default-1', name: 'Default Workspace', type: 'default', parent_id: 'root-1' },
+    permissions: { view: true, edit: true, delete: false, create: true, move: false },
+    callbacks: { ...NOOP_CALLBACKS, onCreateSibling: undefined },
+    isDisabled: false,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        ...workspacesHandlers([
+          mockWorkspace,
+          { ...mockWorkspace, id: 'default-1', name: 'Default Workspace', type: 'default', parent_id: 'root-1' },
+          mockSubWorkspace,
+        ]),
+      ],
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('Verify Create sibling workspace is not rendered for default workspace', async () => {
+      const actionsButton = await canvas.findByRole('button', { name: /actions/i });
+      await userEvent.click(actionsButton);
+
+      const body = within(document.body);
+      await expect(body.queryByText('Create sibling workspace')).toBeNull();
+
+      const editItem = await body.findByText('Edit workspace');
+      await expect(editItem.closest('button')).not.toHaveAttribute('disabled');
     });
   },
 };

--- a/src/v2/features/workspaces/components/WorkspaceListTable.stories.tsx
+++ b/src/v2/features/workspaces/components/WorkspaceListTable.stories.tsx
@@ -313,6 +313,9 @@ export const RootWorkspaceRestrictions: Story = {
       await expect(deleteButton.closest('button')).toHaveAttribute('disabled');
       await expect(moveButton.closest('button')).toHaveAttribute('disabled');
     });
+    await step('Verify Create sibling workspace is not rendered for root', async () => {
+      await expect(within(document.body).queryByText('Create sibling workspace')).toBeNull();
+    });
   },
 };
 

--- a/src/v2/features/workspaces/components/WorkspaceListTable.tsx
+++ b/src/v2/features/workspaces/components/WorkspaceListTable.tsx
@@ -28,6 +28,7 @@ import { AppLink } from '../../../../shared/components/navigation/AppLink';
 import pathnames from '../../../utilities/pathnames';
 import { type WorkspaceActionCallbacks, useWorkspaceActionItems } from './useWorkspaceActionItems';
 import type { WorkspaceFilters, WorkspaceWithChildren, WorkspacesWorkspace } from '../types';
+import { canCreateSiblingInType } from '../workspaceTypes';
 import type { WorkspacePermissions, WorkspaceRelation, WorkspaceWithPermissions } from '../../../data/queries/workspaces';
 
 interface WorkspaceListTableProps {
@@ -171,7 +172,7 @@ export const WorkspaceListTable: React.FC<WorkspaceListTableProps> = ({ workspac
           : { view: false, edit: false, delete: false, create: false, move: false };
         const callbacks: WorkspaceActionCallbacks = {
           onEdit: () => navigate(pathnames['edit-workspaces-list'].link(wsId)),
-          onCreateSibling: () => navigate(pathnames['create-sibling-workspace'].link(wsId)),
+          ...(canCreateSiblingInType(workspace.type) ? { onCreateSibling: () => navigate(pathnames['create-sibling-workspace'].link(wsId)) } : {}),
           onCreateSub: () => navigate(pathnames['create-sub-workspace'].link(wsId)),
           onMove: () => navigate(pathnames['move-workspace'].link(wsId)),
           onDelete: () => navigate(pathnames['delete-workspace'].link(wsId)),

--- a/src/v2/features/workspaces/workspaceTypes.ts
+++ b/src/v2/features/workspaces/workspaceTypes.ts
@@ -58,6 +58,7 @@ const CREATABLE_IN_TYPES: ReadonlySet<string> = new Set([
   WorkspacesWorkspaceTypes.Default,
   WorkspacesWorkspaceTypes.Standard,
 ]);
+const SIBLING_CREATABLE_TYPES: ReadonlySet<string> = new Set([WorkspacesWorkspaceTypes.Standard]);
 const MOVABLE_TYPES: ReadonlySet<string> = new Set([WorkspacesWorkspaceTypes.Standard]);
 const DELETABLE_TYPES: ReadonlySet<string> = new Set([WorkspacesWorkspaceTypes.Standard]);
 
@@ -69,6 +70,11 @@ export function canEditType(type: string | undefined): boolean {
 /** Whether the workspace type allows creating children (root, default, standard). */
 export function canCreateInType(type: string | undefined): boolean {
   return CREATABLE_IN_TYPES.has(type ?? '');
+}
+
+/** Whether the workspace type allows creating a sibling (standard only — root has no parent, default's parent is root where creation is restricted). */
+export function canCreateSiblingInType(type: string | undefined): boolean {
+  return SIBLING_CREATABLE_TYPES.has(type ?? '');
 }
 
 /** Whether the workspace type allows moving (standard only). */


### PR DESCRIPTION
## Summary
- Hide the "Create sibling workspace" kebab menu item for Root and Default workspaces in the hierarchy view
- Root has no parent (sibling is meaningless); Default's parent is Root where creation is restricted
- Add `canCreateSiblingInType()` type guard following existing patterns (`canEditType`, `canMoveType`, etc.)

## Changes
- **workspaceTypes.ts**: New `SIBLING_CREATABLE_TYPES` set and `canCreateSiblingInType()` (standard only)
- **WorkspaceListTable.tsx**: Conditionally omit `onCreateSibling` callback based on workspace type
- **WorkspaceActions.stories.tsx**: Assert sibling absent for root; add `DefaultWorkspaceTypeRestrictions` story
- **WorkspaceListTable.stories.tsx**: Assert sibling absent in `RootWorkspaceRestrictions` story
- **workspace-list.spec.ts**: Assert "Create sibling workspace" not visible in root workspace kebab

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (210 passed)
- [x] `npm run test:storybook` — WorkspaceActions and WorkspaceListTable stories pass (3 pre-existing failures in unrelated stories)
- [ ] Manual: Root workspace kebab has no "Create sibling workspace"
- [ ] Manual: Default workspace kebab has no "Create sibling workspace"
- [ ] Manual: Standard workspaces still show "Create sibling workspace"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * "Create sibling workspace" action is now properly hidden for root and restricted workspace types, preventing users from attempting unsupported operations.

* **Tests**
  * Added comprehensive test coverage to verify workspace type-based action restrictions and ensure correct visibility of workspace operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->