### PR TITLE
chore(CI): cleanup obsolete compute-resource params

### DIFF
--- a/.tekton/insights-rbac-ui-full-test-run.yaml
+++ b/.tekton/insights-rbac-ui-full-test-run.yaml
@@ -40,10 +40,6 @@ spec:
       npm ci
       npm run lint
       NODE_OPTIONS="--max-old-space-size=1536" npm test
-  - name: unit-tests-memory-request
-    value: "8Gi"
-  - name: unit-tests-memory-limit
-    value: "8Gi"
 
   # E2E testing configuration
   - name: e2e-app-port

--- a/.tekton/insights-rbac-ui-pull-request.yaml
+++ b/.tekton/insights-rbac-ui-pull-request.yaml
@@ -39,10 +39,6 @@ spec:
       npm ci
       npm run lint
       NODE_OPTIONS="--max-old-space-size=1536" npm test
-  - name: unit-tests-memory-request
-    value: "8Gi"
-  - name: unit-tests-memory-limit
-    value: "8Gi"
 
   pipelineRef:
     resolver: git


### PR DESCRIPTION

### What and why

remove the obsolete compute-resource params `unit-tests-memory-request` and `unit-tests-memory-limit`.

these custom params are dead-code, as they're not supported by the remote pipeline anymore (see [konflux-pipelines #120][1]).

---

### Attention needed
- [ ] if needed, compute-resources can be allocated via `taskRunSpecs.pipelineTaskName[run-unit-tests].stepSpecs[unit-tests].computeResources.requests/limits`.  
  see the "implications" section of [konflux-pipelines #120][1] for the full example snippet.



[1]: https://github.com/RedHatInsights/konflux-pipelines/pull/120
