### PR TITLE
fix(nav): gate V1 search entries and service tiles for V2 users attempt...

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -176,6 +176,7 @@ objects:
         - segmentId: module-rbac-ui
           bundleId: iam
           navItems:
+            # New navigation structure with platform.rbac.workspaces feature flag
             - id: overview
               title: Overview
               href: /iam/overview
@@ -253,6 +254,7 @@ objects:
                   permissions:
                     - method: isOrgAdmin
                   product: Identity & Access Management
+            # Legacy navigation structure (when new feature flag is off)
             - id: my-user-access
               title: My User Access
               href: /iam/my-user-access

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -31,11 +31,9 @@ objects:
           description: Manage your organization's administrator users (Identity & Access Management).
           alt_title: [org administrator, IAM, user access]
           permissions:
-            - &featureFlagV1
-              method: featureFlag
+            - method: featureFlag
               args: [platform.rbac.workspaces, false]
-            - &loosePrincipalRead
-              method: loosePermissions
+            - method: loosePermissions
               args: [[rbac:principal:read]]
         - id: rbac-org-admin-v2
           title: Org Admins
@@ -43,19 +41,19 @@ objects:
           description: Manage your organization's administrator users (Identity & Access Management).
           alt_title: [org administrator, IAM, user access]
           permissions:
-            - &featureFlagV2
-              method: featureFlag
+            - method: featureFlag
               args: [platform.rbac.workspaces, true]
-            - *loosePrincipalRead
+            - method: loosePermissions
+              args: [[rbac:principal:read]]
         - id: rbac-roles
           title: Roles
           href: /iam/user-access/roles
           description: View and manage custom roles for your organization (Identity & Access Management).
           alt_title: [role, roles, RBAC, IAM, user access]
           permissions:
-            - *featureFlagV1
-            - &looseRoleRead
-              method: loosePermissions
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - method: loosePermissions
               args: [[rbac:role:read]]
         - id: rbac-roles-v2
           title: Roles
@@ -63,33 +61,39 @@ objects:
           description: View and manage custom roles for your organization (Identity & Access Management).
           alt_title: [role, roles, RBAC, IAM, user access]
           permissions:
-            - *featureFlagV2
-            - *looseRoleRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - method: loosePermissions
+              args: [[rbac:role:read]]
         - id: rbac-users
           title: Users
           href: /iam/user-access/users
           description: Manage users and their role-based access (Identity & Access Management).
           alt_title: [user, users, IAM, user access, RBAC]
           permissions:
-            - *featureFlagV1
-            - *loosePrincipalRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - method: loosePermissions
+              args: [[rbac:principal:read]]
         - id: rbac-users-v2
           title: Users
           href: /iam/access-management/users-and-user-groups
           description: Manage users and their role-based access (Identity & Access Management).
           alt_title: [user, users, IAM, user access, RBAC]
           permissions:
-            - *featureFlagV2
-            - *loosePrincipalRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - method: loosePermissions
+              args: [[rbac:principal:read]]
         - id: rbac-groups
           title: Groups
           href: /iam/user-access/groups
           description: Manage groups and their role assignments (Identity & Access Management).
           alt_title: [group, groups, IAM, user access, RBAC]
           permissions:
-            - *featureFlagV1
-            - &looseGroupRead
-              method: loosePermissions
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - method: loosePermissions
               args: [[rbac:group:read]]
         - id: rbac-groups-v2
           title: Groups
@@ -97,36 +101,42 @@ objects:
           description: Manage groups and their role assignments (Identity & Access Management).
           alt_title: [group, groups, IAM, user access, RBAC]
           permissions:
-            - *featureFlagV2
-            - *looseGroupRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - method: loosePermissions
+              args: [[rbac:group:read]]
         - id: rbac-my-access
           title: My User Access
           href: /iam/my-user-access
           description: View your current permissions and access (Identity & Access Management).
           alt_title: [my access, my permissions, IAM, RBAC, user access]
           permissions:
-            - *featureFlagV1
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
         - id: rbac-my-access-v2
           title: My Access
           href: /iam/my-access
           description: View your current permissions and access (Identity & Access Management).
           alt_title: [my access, my permissions, IAM, RBAC, user access]
           permissions:
-            - *featureFlagV2
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
         - id: rbac-workspaces-v2
           title: Workspaces
           href: /iam/access-management/workspaces
           description: Organize systems with workspaces for granular user access (Identity & Access Management).
           alt_title: [workspace, workspaces, IAM, user access, RBAC]
           permissions:
-            - *featureFlagV2
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
         - id: rbac-access-management
           title: Access Management
           href: /iam/access-management/users-and-user-groups
           description: Manage users, groups, roles, and workspaces (Identity & Access Management).
           alt_title: [access management, IAM, user access, RBAC, roles, workspaces]
           permissions:
-            - *featureFlagV2
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
             - method: loosePermissions
               args:
                 - - rbac:principal:read
@@ -140,8 +150,10 @@ objects:
           description: Manage your organization's role-based access control (RBAC) to services.
           icon: PlaceholderIcon
           permissions:
-            - *featureFlagV1
-            - *loosePrincipalRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - method: loosePermissions
+              args: [[rbac:principal:read]]
         - section: iam
           group: iam
           id: users-v2
@@ -150,8 +162,10 @@ objects:
           description: Manage your organization's role-based access control (RBAC) to services.
           icon: PlaceholderIcon
           permissions:
-            - *featureFlagV2
-            - *loosePrincipalRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - method: loosePermissions
+              args: [[rbac:principal:read]]
         - section: iam
           group: iam
           id: groups
@@ -160,8 +174,10 @@ objects:
           description: ""
           icon: PlaceholderIcon
           permissions:
-            - *featureFlagV1
-            - *looseGroupRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - method: loosePermissions
+              args: [[rbac:group:read]]
         - section: iam
           group: iam
           id: groups-v2
@@ -170,8 +186,10 @@ objects:
           description: ""
           icon: PlaceholderIcon
           permissions:
-            - *featureFlagV2
-            - *looseGroupRead
+            - method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - method: loosePermissions
+              args: [[rbac:group:read]]
       bundleSegments:
         - segmentId: module-rbac-ui
           bundleId: iam

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -28,13 +28,109 @@ objects:
         - id: rbac-org-admin
           title: Org Admins
           href: /iam/user-access/users
-          description: Manage your organization's administrator users.
-          alt_title:
-            - org administrator
+          description: Manage your organization's administrator users (Identity & Access Management).
+          alt_title: [org administrator, IAM, user access]
           permissions:
+            - &featureFlagV1
+              method: featureFlag
+              args: [platform.rbac.workspaces, false]
+            - &loosePrincipalRead
+              method: loosePermissions
+              args: [[rbac:principal:read]]
+        - id: rbac-org-admin-v2
+          title: Org Admins
+          href: /iam/access-management/users-and-user-groups
+          description: Manage your organization's administrator users (Identity & Access Management).
+          alt_title: [org administrator, IAM, user access]
+          permissions:
+            - &featureFlagV2
+              method: featureFlag
+              args: [platform.rbac.workspaces, true]
+            - *loosePrincipalRead
+        - id: rbac-roles
+          title: Roles
+          href: /iam/user-access/roles
+          description: View and manage custom roles for your organization (Identity & Access Management).
+          alt_title: [role, roles, RBAC, IAM, user access]
+          permissions:
+            - *featureFlagV1
+            - &looseRoleRead
+              method: loosePermissions
+              args: [[rbac:role:read]]
+        - id: rbac-roles-v2
+          title: Roles
+          href: /iam/access-management/roles
+          description: View and manage custom roles for your organization (Identity & Access Management).
+          alt_title: [role, roles, RBAC, IAM, user access]
+          permissions:
+            - *featureFlagV2
+            - *looseRoleRead
+        - id: rbac-users
+          title: Users
+          href: /iam/user-access/users
+          description: Manage users and their role-based access (Identity & Access Management).
+          alt_title: [user, users, IAM, user access, RBAC]
+          permissions:
+            - *featureFlagV1
+            - *loosePrincipalRead
+        - id: rbac-users-v2
+          title: Users
+          href: /iam/access-management/users-and-user-groups
+          description: Manage users and their role-based access (Identity & Access Management).
+          alt_title: [user, users, IAM, user access, RBAC]
+          permissions:
+            - *featureFlagV2
+            - *loosePrincipalRead
+        - id: rbac-groups
+          title: Groups
+          href: /iam/user-access/groups
+          description: Manage groups and their role assignments (Identity & Access Management).
+          alt_title: [group, groups, IAM, user access, RBAC]
+          permissions:
+            - *featureFlagV1
+            - &looseGroupRead
+              method: loosePermissions
+              args: [[rbac:group:read]]
+        - id: rbac-groups-v2
+          title: Groups
+          href: /iam/access-management/users-and-user-groups
+          description: Manage groups and their role assignments (Identity & Access Management).
+          alt_title: [group, groups, IAM, user access, RBAC]
+          permissions:
+            - *featureFlagV2
+            - *looseGroupRead
+        - id: rbac-my-access
+          title: My User Access
+          href: /iam/my-user-access
+          description: View your current permissions and access (Identity & Access Management).
+          alt_title: [my access, my permissions, IAM, RBAC, user access]
+          permissions:
+            - *featureFlagV1
+        - id: rbac-my-access-v2
+          title: My Access
+          href: /iam/my-access
+          description: View your current permissions and access (Identity & Access Management).
+          alt_title: [my access, my permissions, IAM, RBAC, user access]
+          permissions:
+            - *featureFlagV2
+        - id: rbac-workspaces-v2
+          title: Workspaces
+          href: /iam/access-management/workspaces
+          description: Organize systems with workspaces for granular user access (Identity & Access Management).
+          alt_title: [workspace, workspaces, IAM, user access, RBAC]
+          permissions:
+            - *featureFlagV2
+        - id: rbac-access-management
+          title: Access Management
+          href: /iam/access-management/users-and-user-groups
+          description: Manage users, groups, roles, and workspaces (Identity & Access Management).
+          alt_title: [access management, IAM, user access, RBAC, roles, workspaces]
+          permissions:
+            - *featureFlagV2
             - method: loosePermissions
               args:
                 - - rbac:principal:read
+                - - rbac:group:read
       serviceTiles:
         - section: iam
           group: iam
@@ -44,9 +140,18 @@ objects:
           description: Manage your organization's role-based access control (RBAC) to services.
           icon: PlaceholderIcon
           permissions:
-            - method: loosePermissions
-              args:
-                - - rbac:principal:read
+            - *featureFlagV1
+            - *loosePrincipalRead
+        - section: iam
+          group: iam
+          id: users-v2
+          href: /iam/access-management/users-and-user-groups
+          title: Users
+          description: Manage your organization's role-based access control (RBAC) to services.
+          icon: PlaceholderIcon
+          permissions:
+            - *featureFlagV2
+            - *loosePrincipalRead
         - section: iam
           group: iam
           id: groups
@@ -55,14 +160,22 @@ objects:
           description: ""
           icon: PlaceholderIcon
           permissions:
-            - method: loosePermissions
-              args:
-                - - rbac:group:read
+            - *featureFlagV1
+            - *looseGroupRead
+        - section: iam
+          group: iam
+          id: groups-v2
+          href: /iam/access-management/users-and-user-groups
+          title: Groups
+          description: ""
+          icon: PlaceholderIcon
+          permissions:
+            - *featureFlagV2
+            - *looseGroupRead
       bundleSegments:
         - segmentId: module-rbac-ui
           bundleId: iam
           navItems:
-            # New navigation structure with platform.rbac.workspaces feature flag
             - id: overview
               title: Overview
               href: /iam/overview
@@ -140,7 +253,6 @@ objects:
                   permissions:
                     - method: isOrgAdmin
                   product: Identity & Access Management
-            # Legacy navigation structure (when new feature flag is off)
             - id: my-user-access
               title: My User Access
               href: /iam/my-user-access

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "lint:js:fix": "eslint config src e2e .storybook --fix",
     "lint:e2e": "tsc --noEmit -p e2e/tsconfig.json",
     "lint:permissions": "npx tsx scripts/validate-permissions.ts",
+    "lint:search-entries": "npx tsx scripts/validate-search-entries.ts",
     "lint:prettier": "prettier --check \"src/**/*.{ts,tsx,js}\" \"e2e/**/*.ts\" \"config/**/*.ts\" \".storybook/**/*.{ts,tsx}\"",
     "lint:circular": "madge --circular --extensions ts,js ./src",
     "server:ctr": "node src/server/generateServerKey.js",

--- a/scripts/validate-permissions.ts
+++ b/scripts/validate-permissions.ts
@@ -27,12 +27,13 @@ interface YamlPermission {
 }
 
 interface YamlNavItem {
-  id: string;
+  id?: string;
   title?: string;
   href?: string;
   permissions?: YamlPermission[];
   routes?: YamlNavItem[];
   expandable?: boolean;
+  segmentRef?: { frontendName: string; segmentId: string };
 }
 
 interface FrontendYaml {
@@ -142,6 +143,7 @@ function collectYamlNavItems(
   result: Map<string, { rbacPermissions: string[]; requireOrgAdmin: boolean; checkAll: boolean }>,
 ): void {
   for (const item of items) {
+    if (item.segmentRef) continue;
     if (item.href && item.permissions) {
       const normalizedPath = normalizePath(item.href);
       const { rbacPermissions, requireOrgAdmin, hasFeatureFlagOnly, checkAll } = extractYamlPermissions(item.permissions);

--- a/scripts/validate-search-entries.ts
+++ b/scripts/validate-search-entries.ts
@@ -80,7 +80,17 @@ function main(): void {
     }
   }
 
-  const ids = new Set(entries.map((e) => e.id).filter(Boolean));
+  const allIds = entries.map((e) => e.id).filter(Boolean) as string[];
+  const seen = new Set<string>();
+  for (const id of allIds) {
+    if (seen.has(id)) {
+      console.error(`❌ Duplicate search entry id: ${id}`);
+      failed = true;
+    }
+    seen.add(id);
+  }
+
+  const ids = new Set(allIds);
   const byId = new Map(entries.filter((e) => e.id).map((e) => [e.id!, e]));
 
   for (const expectedId of EXPECTED_IAM_IDS) {

--- a/scripts/validate-search-entries.ts
+++ b/scripts/validate-search-entries.ts
@@ -27,6 +27,8 @@ const V1_V2_PAIRS: [string, string][] = [
   ['rbac-my-access', 'rbac-my-access-v2'],
 ];
 
+const V2_ONLY_IDS = ['rbac-workspaces-v2', 'rbac-access-management'];
+
 const WORKSPACES_FLAG = 'platform.rbac.workspaces';
 const IAM_ALT_TITLE_TERMS = ['IAM', 'RBAC', 'user access', 'roles', 'workspaces'];
 
@@ -84,6 +86,14 @@ function main(): void {
   for (const expectedId of EXPECTED_IAM_IDS) {
     if (!ids.has(expectedId)) {
       console.error(`❌ Missing expected search entry id: ${expectedId}`);
+      failed = true;
+    }
+  }
+
+  for (const v2OnlyId of V2_ONLY_IDS) {
+    const flag = byId.get(v2OnlyId) ? getFeatureFlagValue(byId.get(v2OnlyId)!, WORKSPACES_FLAG) : undefined;
+    if (flag !== true) {
+      console.error(`❌ V2 entry id="${v2OnlyId}" must have ${WORKSPACES_FLAG}=true (found: ${flag ?? 'missing'})`);
       failed = true;
     }
   }

--- a/scripts/validate-search-entries.ts
+++ b/scripts/validate-search-entries.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+const REQUIRED_FIELDS = ['id', 'title', 'description', 'href'] as const;
+
+const EXPECTED_IAM_IDS = [
+  'rbac-org-admin',
+  'rbac-org-admin-v2',
+  'rbac-roles',
+  'rbac-roles-v2',
+  'rbac-users',
+  'rbac-users-v2',
+  'rbac-groups',
+  'rbac-groups-v2',
+  'rbac-my-access',
+  'rbac-my-access-v2',
+  'rbac-workspaces-v2',
+  'rbac-access-management',
+];
+
+const V1_V2_PAIRS: [string, string][] = [
+  ['rbac-org-admin', 'rbac-org-admin-v2'],
+  ['rbac-roles', 'rbac-roles-v2'],
+  ['rbac-users', 'rbac-users-v2'],
+  ['rbac-groups', 'rbac-groups-v2'],
+  ['rbac-my-access', 'rbac-my-access-v2'],
+];
+
+const WORKSPACES_FLAG = 'platform.rbac.workspaces';
+const IAM_ALT_TITLE_TERMS = ['IAM', 'RBAC', 'user access', 'roles', 'workspaces'];
+
+interface PermissionItem {
+  method?: string;
+  args?: unknown[];
+}
+
+interface SearchEntry {
+  id?: string;
+  title?: string;
+  description?: string;
+  href?: string;
+  alt_title?: string[];
+  permissions?: PermissionItem[];
+}
+
+function getFeatureFlagValue(entry: SearchEntry, flagName: string): boolean | undefined {
+  for (const p of entry.permissions ?? []) {
+    if (p?.method === 'featureFlag' && Array.isArray(p.args) && p.args[0] === flagName) {
+      return p.args[1] as boolean;
+    }
+  }
+  return undefined;
+}
+
+function main(): void {
+  const path = resolve(__dirname, '../deploy/frontend.yaml');
+  const content = readFileSync(path, 'utf8');
+  const doc = parse(content);
+  const entries: SearchEntry[] = doc?.objects?.[0]?.spec?.searchEntries ?? [];
+  let failed = false;
+
+  if (entries.length === 0) {
+    console.error('❌ No searchEntries found in deploy/frontend.yaml');
+    process.exit(1);
+  }
+
+  for (const entry of entries) {
+    for (const field of REQUIRED_FIELDS) {
+      if (entry[field] === undefined || entry[field] === '') {
+        console.error(`❌ Entry id="${entry.id ?? '(missing)'}" missing required field: ${field}`);
+        failed = true;
+      }
+    }
+    if (entry.href && !entry.href.startsWith('/iam/')) {
+      console.error(`❌ Entry id="${entry.id}" href must start with /iam/: ${entry.href}`);
+      failed = true;
+    }
+  }
+
+  const ids = new Set(entries.map((e) => e.id).filter(Boolean));
+  const byId = new Map(entries.filter((e) => e.id).map((e) => [e.id!, e]));
+
+  for (const expectedId of EXPECTED_IAM_IDS) {
+    if (!ids.has(expectedId)) {
+      console.error(`❌ Missing expected search entry id: ${expectedId}`);
+      failed = true;
+    }
+  }
+
+  for (const [v1Id, v2Id] of V1_V2_PAIRS) {
+    const v1Flag = byId.get(v1Id) ? getFeatureFlagValue(byId.get(v1Id)!, WORKSPACES_FLAG) : undefined;
+    const v2Flag = byId.get(v2Id) ? getFeatureFlagValue(byId.get(v2Id)!, WORKSPACES_FLAG) : undefined;
+
+    if (v1Flag !== false) {
+      console.error(`❌ V1 entry id="${v1Id}" must have ${WORKSPACES_FLAG}=false (found: ${v1Flag ?? 'missing'})`);
+      failed = true;
+    }
+    if (v2Flag !== true) {
+      console.error(`❌ V2 entry id="${v2Id}" must have ${WORKSPACES_FLAG}=true (found: ${v2Flag ?? 'missing'})`);
+      failed = true;
+    }
+  }
+
+  const allAltTitles = entries.flatMap((e) => e.alt_title ?? []).map((t) => t.toLowerCase());
+  const hasIamCoverage = IAM_ALT_TITLE_TERMS.some((term) => allAltTitles.some((t) => t.includes(term.toLowerCase())));
+  if (!hasIamCoverage) {
+    console.error(`❌ searchEntries must include IAM-related alt_title terms (IAM, RBAC, user access, roles, workspaces)`);
+    failed = true;
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  console.log(`✅ searchEntries validation passed (${entries.length} entries)`);
+}
+
+main();


### PR DESCRIPTION
…pt...

### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature-flag-controlled "Access Management" variant to the RBAC interface and new IAM-specific routing.
  * Expanded search entries and keywords to include IAM/RBAC/access-management terminology; RBAC access-management entry now allows broader read access (principal + group).

* **Chores**
  * Added validation tooling and a lint script to validate search entry configuration and IAM-related entry rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->