### PR TITLE
fix: unable to add user to a group (RHCLOUD-47872)

### DIFF
--- a/src/v1/Routing.tsx
+++ b/src/v1/Routing.tsx
@@ -90,7 +90,7 @@ export const V1Routing = () => {
           {/* User Detail */}
           <Route path={pathnames['user-detail'].path} element={<UserDetail />}>
             <Route {...guard(['rbac:principal:write'])}>
-              <Route path={pathnames['add-user-to-group'].path} element={<AddUserToGroup />} />
+              <Route path={pathnames['add-user-to-group'].path} element={outletElement(AddUserToGroup)} />
             </Route>
             <Route {...guard(['rbac:group:write'])}>
               <Route path={pathnames['user-add-group-roles'].path} element={<AddGroupRoles />} />

--- a/src/v1/features/users/User.stories.tsx
+++ b/src/v1/features/users/User.stories.tsx
@@ -698,3 +698,4 @@ export const GroupLinkInExpandedRow: Story = {
     });
   },
 };
+

--- a/src/v1/features/users/User.stories.tsx
+++ b/src/v1/features/users/User.stories.tsx
@@ -698,4 +698,3 @@ export const GroupLinkInExpandedRow: Story = {
     });
   },
 };
-

--- a/src/v1/features/users/add-user-to-group/AddUserToGroupJourney.stories.tsx
+++ b/src/v1/features/users/add-user-to-group/AddUserToGroupJourney.stories.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { User } from '../User';
+import { AddUserToGroup } from './AddUserToGroup';
+import ElementWrapper from '../../../../shared/components/ElementWrapper';
+import { usersHandlers } from '../../../../shared/data/mocks/users.handlers';
+import { groupsHandlers } from '../../../../shared/data/mocks/groups.handlers';
+import { groupMembersHandlers } from '../../../../shared/data/mocks/groupMembers.handlers';
+import { v1RolesHandlers } from '../../../data/mocks/roles.handlers';
+import type { GroupOut, Principal } from '../../../../shared/data/mocks/db';
+
+const addMembersToGroupSpy = fn();
+
+const mockUser = {
+  username: 'john.doe',
+  email: 'john.doe@redhat.com',
+  first_name: 'John',
+  last_name: 'Doe',
+  is_active: true,
+  is_org_admin: false,
+};
+
+const mockAdminGroup = {
+  uuid: 'admin-group-uuid',
+  name: 'Default admin access',
+  description: 'Default admin group',
+  admin_default: true,
+  platform_default: false,
+  system: true,
+};
+
+const mockAvailableGroups = [
+  {
+    uuid: 'available-group-1',
+    name: 'Engineering',
+    description: 'Engineering team',
+    platform_default: false,
+    admin_default: false,
+    roleCount: 2,
+    principalCount: 4,
+  },
+  {
+    uuid: 'available-group-2',
+    name: 'QA Team',
+    description: 'Quality assurance',
+    platform_default: false,
+    admin_default: false,
+    roleCount: 1,
+    principalCount: 3,
+  },
+];
+
+const withRouter = (Story: React.ComponentType) => (
+  <MemoryRouter initialEntries={['/iam/user-access/users/detail/john.doe/add-to-group']}>
+    <Routes>
+      <Route
+        path="/iam/user-access/users/detail/:username/*"
+        element={
+          <div style={{ minHeight: '100vh' }}>
+            <Story />
+          </div>
+        }
+      >
+        <Route
+          path="add-to-group"
+          element={
+            <ElementWrapper>
+              <AddUserToGroup />
+            </ElementWrapper>
+          }
+        />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+);
+
+const meta: Meta<typeof User> = {
+  component: User,
+  title: 'v1/features/users/AddUserToGroupJourney',
+  tags: ['journey'],
+  decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof User>;
+
+export const Default: Story = {
+  tags: ['perm:org-admin'],
+  parameters: {
+    orgAdmin: true,
+    permissions: ['rbac:*:*'],
+    msw: {
+      handlers: [
+        ...usersHandlers([mockUser as unknown as Principal]),
+        ...v1RolesHandlers([]),
+        ...groupsHandlers([mockAdminGroup, ...mockAvailableGroups] as unknown as GroupOut[]),
+        ...groupMembersHandlers({}, {}, { onAddMembers: addMembersToGroupSpy }),
+      ],
+    },
+  },
+  beforeEach: () => {
+    addMembersToGroupSpy.mockClear();
+  },
+  play: async ({ step }) => {
+    const body = within(document.body);
+
+    await step('Verify modal appears via outlet context', async () => {
+      await body.findByRole('dialog', {}, { timeout: 5000 });
+      await body.findByText('Engineering', {}, { timeout: 5000 });
+    });
+
+    await step('Select a group and submit', async () => {
+      const dialog = await body.findByRole('dialog');
+      const checkboxes = within(dialog).getAllByRole('checkbox');
+      await userEvent.click(checkboxes[1]);
+
+      const saveButton = within(dialog).getByRole('button', { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+      await userEvent.click(saveButton);
+    });
+
+    await step('Verify API called with correct username from outlet context', async () => {
+      await waitFor(
+        () => {
+          expect(addMembersToGroupSpy).toHaveBeenCalledWith(
+            'available-group-1',
+            expect.objectContaining({
+              principals: [{ username: 'john.doe' }],
+            }),
+          );
+        },
+        { timeout: 5000 },
+      );
+    });
+  },
+};

--- a/src/v1/features/users/add-user-to-group/AddUserToGroupJourney.stories.tsx
+++ b/src/v1/features/users/add-user-to-group/AddUserToGroupJourney.stories.tsx
@@ -9,51 +9,18 @@ import { usersHandlers } from '../../../../shared/data/mocks/users.handlers';
 import { groupsHandlers } from '../../../../shared/data/mocks/groups.handlers';
 import { groupMembersHandlers } from '../../../../shared/data/mocks/groupMembers.handlers';
 import { v1RolesHandlers } from '../../../data/mocks/roles.handlers';
+import { DEFAULT_GROUPS, DEFAULT_USERS } from '../../../../shared/data/mocks/seed';
 import type { GroupOut, Principal } from '../../../../shared/data/mocks/db';
+import { selectTableRow } from '../../../../test-utils/interactionHelpers';
 
 const addMembersToGroupSpy = fn();
 
-const mockUser = {
-  username: 'john.doe',
-  email: 'john.doe@redhat.com',
-  first_name: 'John',
-  last_name: 'Doe',
-  is_active: true,
-  is_org_admin: false,
-};
-
-const mockAdminGroup = {
-  uuid: 'admin-group-uuid',
-  name: 'Default admin access',
-  description: 'Default admin group',
-  admin_default: true,
-  platform_default: false,
-  system: true,
-};
-
-const mockAvailableGroups = [
-  {
-    uuid: 'available-group-1',
-    name: 'Engineering',
-    description: 'Engineering team',
-    platform_default: false,
-    admin_default: false,
-    roleCount: 2,
-    principalCount: 4,
-  },
-  {
-    uuid: 'available-group-2',
-    name: 'QA Team',
-    description: 'Quality assurance',
-    platform_default: false,
-    admin_default: false,
-    roleCount: 1,
-    principalCount: 3,
-  },
-];
+const seedUser = DEFAULT_USERS[0];
+const seedAdminGroup = DEFAULT_GROUPS.find((g) => g.admin_default)!;
+const seedAvailableGroups = DEFAULT_GROUPS.filter((g) => !g.admin_default && !g.platform_default);
 
 const withRouter = (Story: React.ComponentType) => (
-  <MemoryRouter initialEntries={['/iam/user-access/users/detail/john.doe/add-to-group']}>
+  <MemoryRouter initialEntries={[`/iam/user-access/users/detail/${seedUser.username}/add-to-group`]}>
     <Routes>
       <Route
         path="/iam/user-access/users/detail/:username/*"
@@ -96,9 +63,9 @@ export const Default: Story = {
     permissions: ['rbac:*:*'],
     msw: {
       handlers: [
-        ...usersHandlers([mockUser as unknown as Principal]),
+        ...usersHandlers([seedUser as unknown as Principal]),
         ...v1RolesHandlers([]),
-        ...groupsHandlers([mockAdminGroup, ...mockAvailableGroups] as unknown as GroupOut[]),
+        ...groupsHandlers([seedAdminGroup, ...seedAvailableGroups] as unknown as GroupOut[]),
         ...groupMembersHandlers({}, {}, { onAddMembers: addMembersToGroupSpy }),
       ],
     },
@@ -107,32 +74,33 @@ export const Default: Story = {
     addMembersToGroupSpy.mockClear();
   },
   play: async ({ step }) => {
+    const user = userEvent.setup();
     const body = within(document.body);
+    const targetGroup = seedAvailableGroups[0];
 
     await step('Verify modal appears via outlet context', async () => {
       await body.findByRole('dialog', {}, { timeout: 5000 });
-      await body.findByText('Engineering', {}, { timeout: 5000 });
+      await body.findByText(targetGroup.name, {}, { timeout: 5000 });
     });
 
     await step('Select a group and submit', async () => {
-      const dialog = await body.findByRole('dialog');
-      const checkboxes = within(dialog).getAllByRole('checkbox');
-      await userEvent.click(checkboxes[1]);
+      const dialog = within(await body.findByRole('dialog'));
+      await selectTableRow(user, dialog, targetGroup.name);
 
-      const saveButton = within(dialog).getByRole('button', { name: /save/i });
+      const saveButton = dialog.getByRole('button', { name: /save/i });
       await waitFor(() => {
         expect(saveButton).not.toBeDisabled();
       });
-      await userEvent.click(saveButton);
+      await user.click(saveButton);
     });
 
     await step('Verify API called with correct username from outlet context', async () => {
       await waitFor(
         () => {
           expect(addMembersToGroupSpy).toHaveBeenCalledWith(
-            'available-group-1',
+            targetGroup.uuid,
             expect.objectContaining({
-              principals: [{ username: 'john.doe' }],
+              principals: [{ username: seedUser.username }],
             }),
           );
         },


### PR DESCRIPTION
## Summary

- **Root cause**: `AddUserToGroup` was rendered without `outletElement()` in `Routing.tsx`, so the `username` from `User.tsx`'s outlet context never reached it. The mutation fired with `undefined` username, causing the API 400 error: "the username is required for user principals".
- **Fix**: one-line change wrapping `AddUserToGroup` with `outletElement()`, matching every other child route in the file.
- **Regression test**: new journey story (`AddUserToGroupJourney.stories.tsx`) that renders `User` → `ElementWrapper` → `AddUserToGroup` through the real outlet context and asserts the API call includes `username: 'john.doe'`.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 210 tests pass
- [x] `npm run test:storybook` — 1030 stories pass (including the new journey story)
- [ ] Manual: navigate to User detail → Add to group → select group → submit → verify no 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated routing rendering to be consistent with other modal/outlet routes for improved component handling.

* **Tests**
  * Added an interactive Storybook journey for the user-group assignment flow with mocked data and an automated play test to verify selection and submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->