### PR TITLE
feat(permissions): check rbac_roles_write per role instead of org

### DIFF
--- a/.storybook/contexts/StorybookMockContext.tsx
+++ b/.storybook/contexts/StorybookMockContext.tsx
@@ -106,6 +106,8 @@ export interface MockState {
   tenantPermissions: TenantPermissionsMap;
   /** Optional custom user identity for auth.getUser() */
   userIdentity?: MockUserIdentity;
+  /** Role IDs the mocked user can write; undefined falls back to tenant-level rbac_roles_write */
+  writableRoleIds?: string[];
 }
 
 /**
@@ -152,6 +154,8 @@ export interface StoryParameters {
    * ```
    */
   tenantPermissions?: Partial<TenantPermissionsMap>;
+  /** Role IDs the mocked user can write; undefined falls back to tenant-level rbac_roles_write */
+  writableRoleIds?: string[];
   /** User identity for auth.getUser() */
   userIdentity?: MockUserIdentity;
   /** Feature flags */
@@ -185,6 +189,7 @@ export const StorybookMockProvider: React.FC<ProviderProps> = ({
   permissions = EMPTY_PERMISSIONS,
   workspacePermissions = EMPTY_WORKSPACE_PERMISSIONS,
   tenantPermissions = EMPTY_TENANT_PERMISSIONS,
+  writableRoleIds,
   userIdentity,
 }) => {
   const value = useMemo<MockState>(
@@ -194,9 +199,10 @@ export const StorybookMockProvider: React.FC<ProviderProps> = ({
       permissions,
       workspacePermissions: { ...EMPTY_WORKSPACE_PERMISSIONS, ...workspacePermissions },
       tenantPermissions: { ...EMPTY_TENANT_PERMISSIONS, ...tenantPermissions },
+      writableRoleIds,
       userIdentity,
     }),
-    [environment, isOrgAdmin, permissions, workspacePermissions, tenantPermissions, userIdentity],
+    [environment, isOrgAdmin, permissions, workspacePermissions, tenantPermissions, writableRoleIds, userIdentity],
   );
   return <StorybookMockContext.Provider value={value}>{children}</StorybookMockContext.Provider>;
 };

--- a/.storybook/hooks/kesselAccessCheck.tsx
+++ b/.storybook/hooks/kesselAccessCheck.tsx
@@ -73,7 +73,13 @@ export const useSelfAccessCheck = (params: UseSelfAccessCheckOptions) => {
 
   const resolvePermission = (relation: string, resource: Resource): boolean => {
     if (resource.type === 'tenant') return checkTenantPermission(relation, mockRef.current.tenantPermissions);
-    if (resource.type === 'role') return checkTenantPermission(relation, mockRef.current.tenantPermissions);
+    if (resource.type === 'role') {
+      const { writableRoleIds } = mockRef.current;
+      if (writableRoleIds !== undefined) {
+        return relation === 'rbac_roles_write' && writableRoleIds.includes(resource.id);
+      }
+      return checkTenantPermission(relation, mockRef.current.tenantPermissions);
+    }
     return checkWorkspacePermission(relation, resource.id, mockRef.current.workspacePermissions);
   };
 

--- a/.storybook/hooks/kesselAccessCheck.tsx
+++ b/.storybook/hooks/kesselAccessCheck.tsx
@@ -73,6 +73,7 @@ export const useSelfAccessCheck = (params: UseSelfAccessCheckOptions) => {
 
   const resolvePermission = (relation: string, resource: Resource): boolean => {
     if (resource.type === 'tenant') return checkTenantPermission(relation, mockRef.current.tenantPermissions);
+    if (resource.type === 'role') return checkTenantPermission(relation, mockRef.current.tenantPermissions);
     return checkWorkspacePermission(relation, resource.id, mockRef.current.workspacePermissions);
   };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -127,6 +127,8 @@ const preview: Preview = {
       const explicitTenantPermissions = args.tenantPermissions ?? parameters.tenantPermissions;
       const tenantPermissions = explicitTenantPermissions ?? deriveTenantPermissions(permissions);
 
+      const writableRoleIds: string[] | undefined = args.writableRoleIds ?? parameters.writableRoleIds;
+
       // User identity for auth.getUser() - use userIdentity parameter
       const userIdentity = parameters.userIdentity;
 
@@ -168,6 +170,7 @@ const preview: Preview = {
             permissions={permissions}
             workspacePermissions={workspacePermissions}
             tenantPermissions={tenantPermissions}
+            writableRoleIds={writableRoleIds}
             userIdentity={userIdentity}
           >
             <FeatureFlagsProvider value={featureFlags}>
@@ -185,6 +188,7 @@ const preview: Preview = {
           permissions={permissions}
           workspacePermissions={workspacePermissions}
           tenantPermissions={tenantPermissions}
+          writableRoleIds={writableRoleIds}
           userIdentity={userIdentity}
         >
           <FeatureFlagsProvider value={featureFlags}>

--- a/src/user-journeys/_shared/components/KesselAppEntryWithRouter.tsx
+++ b/src/user-journeys/_shared/components/KesselAppEntryWithRouter.tsx
@@ -61,6 +61,8 @@ interface KesselAppEntryWithRouterProps {
   'platform.rbac.group-service-accounts'?: boolean;
   'platform.rbac.group-service-accounts.stable'?: boolean;
   'platform.rbac.common-auth-model'?: boolean;
+  /** Role IDs the mocked user can write; undefined falls back to tenant-level rbac_roles_write */
+  writableRoleIds?: string[];
 }
 
 /**
@@ -148,6 +150,8 @@ export const createDynamicEnvironment = (args: KesselAppEntryWithRouterProps) =>
     workspacePermissions,
     // Tenant permissions for V2 domain hooks (useRolesAccess, useGroupsAccess, etc.)
     tenantPermissions,
+    // Per-role write allowlist (undefined = fall back to tenant rbac_roles_write flag)
+    writableRoleIds: args.writableRoleIds,
     // User identity for auth.getUser() - used by StorybookMockContext
     userIdentity: {
       org_id: '12510751',

--- a/src/user-journeys/access-management/DeletingARole.stories.tsx
+++ b/src/user-journeys/access-management/DeletingARole.stories.tsx
@@ -96,6 +96,7 @@ const meta = {
     orgAdmin: true,
     'platform.rbac.common-auth-model': true,
     'platform.rbac.workspaces': true, // M5 flag - enables V2 roles view with kebab menus
+    writableRoleIds: ['role-rhel-devops', 'role-rhel-inventory'],
   },
   parameters: {
     ...createDynamicEnvironment({
@@ -103,6 +104,7 @@ const meta = {
       orgAdmin: true,
       'platform.rbac.common-auth-model': true,
       'platform.rbac.workspaces': true,
+      writableRoleIds: ['role-rhel-devops', 'role-rhel-inventory'],
     }),
     msw: {
       handlers: [

--- a/src/user-journeys/access-management/EditingARole.stories.tsx
+++ b/src/user-journeys/access-management/EditingARole.stories.tsx
@@ -65,6 +65,7 @@ const meta = {
     orgAdmin: true,
     'platform.rbac.common-auth-model': true,
     'platform.rbac.workspaces': true, // M5 flag - enables V2 roles view with kebab menus
+    writableRoleIds: ['role-rhel-devops', 'role-inventory-viewer'],
   },
   parameters: {
     ...createDynamicEnvironment({
@@ -72,6 +73,7 @@ const meta = {
       orgAdmin: true,
       'platform.rbac.common-auth-model': true,
       'platform.rbac.workspaces': true,
+      writableRoleIds: ['role-rhel-devops', 'role-inventory-viewer'],
     }),
     msw: {
       handlers: [

--- a/src/v2/data/queries/roles.ts
+++ b/src/v2/data/queries/roles.ts
@@ -111,7 +111,7 @@ export function useAllRolesV2Query(options?: { enabled?: boolean; name?: string;
       do {
         const response = await rolesApi.rolesList({
           limit: 100,
-          fields: 'id,name,description,permissions_count,last_modified,org_id',
+          fields: 'id,name,description,permissions_count,last_modified',
           ...(cursor && { cursor }),
           ...(options?.name && { name: options.name }),
           ...(hasExtra && { options: { params: extraParams } }),

--- a/src/v2/features/roles/hooks/useRolePermissions.ts
+++ b/src/v2/features/roles/hooks/useRolePermissions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useRolesAccess } from '../../../hooks/useRbacAccess';
+import { useRoleWriteAccess } from '../../../hooks/useRbacAccess';
 
 export interface RolePermissions {
   edit: boolean;
@@ -8,37 +8,29 @@ export interface RolePermissions {
 
 interface Role {
   id?: string;
-  org_id?: string | null;
 }
 
 /**
  * Per-role permission check.
  *
- * Combines two checks:
- * 1. **Tenant-scoped Kessel check** (`rbac_roles_write` on the org) — does
- *    the user have write permission for roles at all?
- * 2. **`org_id` guard** — is this a user-created role? System/canned roles
- *    have `org_id` as `null` or `undefined` and are never editable/deletable
- *    regardless of tenant permission.
- *
- * `canEdit(roleId) = tenantCanWrite && role.org_id != null`
+ * Checks `rbac_roles_write` against each role resource directly via Kessel.
+ * Canned roles return false from the backend — no frontend org_id guard needed.
  */
 export function useRolePermissions(roles: Role[]) {
-  const { canUpdate, canDelete: canDeleteTenant, isLoading } = useRolesAccess();
-
-  const userCreatedIds = useMemo(() => new Set(roles.filter((r) => r.id && r.org_id != null).map((r) => r.id!)), [roles]);
+  const roleIds = useMemo(() => roles.map((r) => r.id).filter((id): id is string => id != null), [roles]);
+  const { writableIds, isLoading } = useRoleWriteAccess(roleIds);
 
   const permissionsFor = useCallback(
     (roleId: string): RolePermissions => ({
-      edit: canUpdate && userCreatedIds.has(roleId),
-      delete: canDeleteTenant && userCreatedIds.has(roleId),
+      edit: writableIds.has(roleId),
+      delete: writableIds.has(roleId),
     }),
-    [canUpdate, canDeleteTenant, userCreatedIds],
+    [writableIds],
   );
 
-  const canEdit = useCallback((roleId: string): boolean => canUpdate && userCreatedIds.has(roleId), [canUpdate, userCreatedIds]);
-  const canDelete = useCallback((roleId: string): boolean => canDeleteTenant && userCreatedIds.has(roleId), [canDeleteTenant, userCreatedIds]);
-  const canWriteAny = canUpdate && userCreatedIds.size > 0;
+  const canEdit = useCallback((roleId: string): boolean => writableIds.has(roleId), [writableIds]);
+  const canDelete = useCallback((roleId: string): boolean => writableIds.has(roleId), [writableIds]);
+  const canWriteAny = writableIds.size > 0;
 
   return { permissionsFor, canEdit, canDelete, canWriteAny, isLoading };
 }

--- a/src/v2/features/roles/useRolesWithWorkspaces.ts
+++ b/src/v2/features/roles/useRolesWithWorkspaces.ts
@@ -64,7 +64,7 @@ export const useRoles = (options: UseRolesOptions = {}): UseRolesReturn => {
     limit: tableState.apiParams.limit,
     cursor: tableState.apiParams.cursor,
     name: nameFilter ? `*${nameFilter}*` : undefined,
-    fields: 'id,name,description,permissions_count,last_modified,org_id',
+    fields: 'id,name,description,permissions_count,last_modified',
     orderBy: tableState.apiParams.orderBy,
   };
 

--- a/src/v2/hooks/useRbacAccess.ts
+++ b/src/v2/hooks/useRbacAccess.ts
@@ -150,14 +150,16 @@ function useBulkRoleCheck(roleIds: string[]): { writableIds: Set<string>; isLoad
 
   const { data, loading } = useSelfAccessCheck({ resources });
 
+  const roleIdSet = useMemo(() => new Set(roleIds), [roleIds]);
+
   const writableIds = useMemo(() => {
     const out = new Set<string>();
     if (!hasIds || !Array.isArray(data)) return out;
     for (const check of data) {
-      if (check.allowed) out.add(check.resource.id);
+      if (check.allowed && roleIdSet.has(check.resource.id)) out.add(check.resource.id);
     }
     return out;
-  }, [data, hasIds]);
+  }, [data, hasIds, roleIdSet]);
 
   return { writableIds, isLoading: hasIds && loading };
 }

--- a/src/v2/hooks/useRbacAccess.ts
+++ b/src/v2/hooks/useRbacAccess.ts
@@ -127,6 +127,46 @@ function useBulkWorkspaceCheck<R extends RbacWorkspaceRelation>(workspaceId: str
 }
 
 // ============================================================================
+// Role-scoped bulk check helper
+// ============================================================================
+
+/**
+ * Per-role write check. Sends one /checkselfbulk item per role ID against
+ * the role resource directly. Canned roles return false from the backend
+ * without any frontend org_id guard needed.
+ */
+function useBulkRoleCheck(roleIds: string[]): { writableIds: Set<string>; isLoading: boolean } {
+  const hasIds = roleIds.length > 0;
+
+  const resources = useMemo<NotEmptyArray<SelfAccessCheckResourceWithRelation>>(() => {
+    if (!hasIds) return [] as unknown as NotEmptyArray<SelfAccessCheckResourceWithRelation>;
+    return roleIds.map((id) => ({
+      id,
+      type: 'role' as const,
+      reporter: RBAC_REPORTER,
+      relation: 'rbac_roles_write',
+    })) as unknown as NotEmptyArray<SelfAccessCheckResourceWithRelation>;
+  }, [roleIds, hasIds]);
+
+  const { data, loading } = useSelfAccessCheck({ resources });
+
+  const writableIds = useMemo(() => {
+    const out = new Set<string>();
+    if (!hasIds || !Array.isArray(data)) return out;
+    for (const check of data) {
+      if (check.allowed) out.add(check.resource.id);
+    }
+    return out;
+  }, [data, hasIds]);
+
+  return { writableIds, isLoading: hasIds && loading };
+}
+
+export function useRoleWriteAccess(roleIds: string[]): { writableIds: Set<string>; isLoading: boolean } {
+  return useBulkRoleCheck(roleIds);
+}
+
+// ============================================================================
 // Domain Hooks — public API (UI action language)
 // ============================================================================
 


### PR DESCRIPTION
### What and why
Replaced the org level `rbac_roles_write` check + frontend `org_id` guard with a direct role Kessel permission check.
                                                                                                                                                                                         
[RHCLOUD-47496](https://issues.redhat.com/browse/RHCLOUD-47496)
---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->
N/A
---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

`org_id` has been removed from the roles list query fields since nothing reads it anymore.                                                                                                                               

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-47496]: https://redhat.atlassian.net/browse/RHCLOUD-47496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Role permission evaluation now derives edit/delete rights from explicit per-role write checks rather than org_id heuristics.
  * Role list queries request fewer fields to reduce payload.

* **New Features**
  * Added a role-scoped write-access check that exposes writable role IDs and loading state.
  * Storybook and journey test harnesses now support an optional writableRoleIds mock to simulate writable roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->