### PR TITLE
fix: add feature flags for workspaces in nav

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -129,6 +129,8 @@ objects:
           permissions:
             - method: featureFlag
               args: [platform.rbac.workspaces, true]
+            - method: featureFlag
+              args: [platform.rbac.workspaces-list, true]
         - id: rbac-access-management
           title: Access Management
           href: /iam/access-management/users-and-user-groups
@@ -250,6 +252,15 @@ objects:
                   href: /iam/access-management/workspaces
                   icon: PlaceholderIcon
                   product: Identity & Access Management
+                  permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces
+                        - true
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces-list
+                        - true
                 - id: audit-log
                   title: Audit Log
                   href: /iam/access-management/audit-log


### PR DESCRIPTION
### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

- require the `platform.rbac.workspaces-list` flag for Workspaces page to appear in the navigation

[RHCLOUD-47873](https://redhat.atlassian.net/browse/RHCLOUD-47873)

---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-47873]: https://redhat.atlassian.net/browse/RHCLOUD-47873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added feature flag controls for workspaces listing in RBAC and access management features, enabling selective availability based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->