### PR TITLE
feat: set withAncestry to true for all workspace list requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.36",
         "@redhat-cloud-services/host-inventory-client": "^4.1.7",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",
-        "@redhat-cloud-services/rbac-client": "^9.0.0",
+        "@redhat-cloud-services/rbac-client": "^9.0.7",
         "@redhat-cloud-services/types": "^3.4.1",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-query-devtools": "^5.91.2",
@@ -135,7 +135,7 @@
       },
       "engines": {
         "node": ">=22.12.0",
-        "npm": ">=7.0.0"
+        "npm": ">=8.3.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8021,9 +8021,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-9.0.0.tgz",
-      "integrity": "sha512-thTL2Yw408IJVwxepjJowvX1ku7VAuFozxB5pRHf32v7xo+z3Yld6FJvrvge+8DlqptJQq8jSAJ8NDNBW6ckwQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-9.0.7.tgz",
+      "integrity": "sha512-0uELAxGSjOQOFl12OB7s+yQhrM4FlLP+dQ3c+suAVzkgETydbU47XFyp8bcM/9dLzbMZjEf2ueRzcGffdk/PPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "^7.0.36",
     "@redhat-cloud-services/host-inventory-client": "^4.1.7",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",
-    "@redhat-cloud-services/rbac-client": "^9.0.0",
+    "@redhat-cloud-services/rbac-client": "^9.0.7",
     "@redhat-cloud-services/types": "^3.4.1",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",

--- a/src/v2/data/queries/workspaces.ts
+++ b/src/v2/data/queries/workspaces.ts
@@ -56,6 +56,7 @@ export function useWorkspacesQuery(params: WorkspacesListParams = {}, options?: 
           type: params.type ?? 'all',
           name: params.name,
           orderBy: params.orderBy,
+          withAncestry: true,
         });
         return response.data;
       },


### PR DESCRIPTION
### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

- add the parameter `withAncestry` and set it to true for all workspace list requests
- prevents other users from seeing root/default workspaces (without `withAncestry`) they should not have access to see

[RHCLOUD-49062](https://redhat.atlassian.net/browse/RHCLOUD-49062)

---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-49062]: https://redhat.atlassian.net/browse/RHCLOUD-49062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace listings now include ancestry information for improved hierarchy visibility.

* **Bug Fixes**
  * Updated the RBAC client dependency to the latest compatible patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->