### PR TITLE
Remove background from content text in glass mode

### DIFF
--- a/src/shared/components/data-display/CustomDataListItem.tsx
+++ b/src/shared/components/data-display/CustomDataListItem.tsx
@@ -24,6 +24,10 @@ interface CustomDataListItemProps {
   isExpanded?: boolean;
 }
 
+const contentStyle: React.CSSProperties = {
+  '--pf-v6-c-data-list__expandable-content--BackgroundColor': 'transparent',
+} as React.CSSProperties;
+
 const CustomDataListItem: React.FC<CustomDataListItemProps> = ({ icon, heading, linkTitle, linkTarget, expandableContent, isExpanded }) => {
   const [expanded, setExpanded] = React.useState(isExpanded || false);
 
@@ -61,7 +65,7 @@ const CustomDataListItem: React.FC<CustomDataListItemProps> = ({ icon, heading, 
             </DataListAction>
           )}
         </DataListItemRow>
-        <DataListContent aria-label={`${heading} - Detailed Explanation`} id="expand1" isHidden={!expanded}>
+        <DataListContent aria-label={`${heading} - Detailed Explanation`} id="expand1" isHidden={!expanded} style={contentStyle}>
           {expandableContent}
         </DataListContent>
       </DataListItem>


### PR DESCRIPTION
### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

[RHCLOUD-49088](https://redhat.atlassian.net/browse/RHCLOUD-49088)
- Remove unnecessary background that appears behind text when new glass theme is enabled
---

### Screenshots
<!-- Required for any visible UI change. Before and after. -->
<!-- A link to the relevant Storybook story works as well, and is often better — it lets reviewers interact with the component. -->
<!-- Skip this section only for pure logic / non-visual changes. -->
Before:
<img width="1316" height="565" alt="image" src="https://github.com/user-attachments/assets/53ce6d28-f838-4c89-8ed5-0552424f0f86" />
<img width="1316" height="565" alt="image" src="https://github.com/user-attachments/assets/823928b2-75d0-425a-a493-a0be75aedec3" />

After:
<img width="1316" height="565" alt="image" src="https://github.com/user-attachments/assets/0d7d5657-c48b-4f4c-954b-a53a20ff9b45" />
<img width="1316" height="565" alt="image" src="https://github.com/user-attachments/assets/66bffe5b-0a2e-489c-9e98-034ed3a0a307" />

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-49088]: https://redhat.atlassian.net/browse/RHCLOUD-49088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated expandable list sections to use a transparent background, improving the visual consistency of expandable content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->