### PR TITLE
fix: strip bundled PatternFly styles to prevent sticky header CSS leak

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -5,6 +5,7 @@ module.exports = {
   debug: true,
   useProxy: true,
   proxyVerbose: true,
+  stripAllPfStyles: true,
   frontendCRDPath: path.resolve(__dirname, './deploy/frontend.yaml'),
   /**
    * Change to false after your app is registered in configuration files


### PR DESCRIPTION
### What and why

A PatternFly v6.5.x CSS bug causes column header text to become invisible on tables with sticky headers. The root cause is that apps bundle their own `@patternfly/react-styles` CSS from nested `node_modules` (transitive dependencies like `@redhat-cloud-services/access-requests-frontend`), which leaks during client-side navigation and overrides the global PF stylesheet served by Chrome.

Adding `stripAllPfStyles: true` to `fec.config.js` tells the sass-loader to strip all `@patternfly/react-styles` CSS from `node_modules`, preventing the leak. Only PF CSS inside `node_modules` is affected — custom app styles in `src/` are untouched.

[RHCLOUD-47948](https://issues.redhat.com/browse/RHCLOUD-47948)

---

### Screenshots

No direct UI change in this repo — no components use `isStickyHeader` or `pf-m-sticky-header`. The fix prevents CSS from leaking into the global scope during client-side navigation, which would otherwise cause invisible table headers across the platform.

---

### Anything non-obvious reviewers should know?

- The nested `@patternfly/react-styles` lives inside `node_modules/@redhat-cloud-services/access-requests-frontend/node_modules/` — this is the source of the leaked CSS.
- `stripAllPfStyles` only strips PF CSS from `node_modules`, not from `src/`. App-level custom styles are unaffected.
- No component code was changed — this is a build config fix only.

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-47948]: https://redhat.atlassian.net/browse/RHCLOUD-47948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling configuration to consistently remove all Pathfinder styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->