### PR TITLE
fix(nav): add missing service accounts segment

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -256,6 +256,9 @@ objects:
                   permissions:
                     - method: isOrgAdmin
                   product: Identity & Access Management
+                - segmentRef:
+                    frontendName: service-accounts
+                    segmentId: iam-access-management-service-accounts
             - id: organization-management
               title: Organization Management
               expandable: true


### PR DESCRIPTION
### What and why
adds missing service accounts segment 

[RHCLOUD-49428](https://redhat.atlassian.net/browse/RHCLOUD-49428)

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


[RHCLOUD-49428]: https://redhat.atlassian.net/browse/RHCLOUD-49428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Service Accounts entry to the IAM access management navigation.
  * The entry appears alongside existing access management routes when the updated navigation is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->