### PR TITLE
fix: add path-specific CODEOWNERS for structural gatekeeping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,37 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
+# Default — team reviews all feature code
+*                               @RedHatInsights/experience-ui-committers
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence.
-*       @RedHatInsights/experience-ui-committers
-*       @RedHatInsights/experience-ui-admins
+# Structural / architectural gatekeeping — broad blast radius
+/.github/                       @riccardo-forina @jjaquish
+/.storybook/                    @riccardo-forina @jjaquish
+/.husky/                        @riccardo-forina @jjaquish
+/.tekton/                       @riccardo-forina @jjaquish
+/.travis/                       @riccardo-forina @jjaquish
+/.travis.yml                    @riccardo-forina @jjaquish
+/.coderabbit.yaml               @riccardo-forina @jjaquish
+/.commitlintrc.js               @riccardo-forina @jjaquish
+/.gitignore                     @riccardo-forina @jjaquish
+/.prettierrc.json               @riccardo-forina @jjaquish
+/.node-version                  @riccardo-forina @jjaquish
+/.nvmrc                         @riccardo-forina @jjaquish
+/config/                        @riccardo-forina @jjaquish
+/babel.config.js                @riccardo-forina @jjaquish
+/package.json                   @riccardo-forina @jjaquish
+/package-lock.json              @riccardo-forina @jjaquish
+/tsconfig.json                  @riccardo-forina @jjaquish
+
+# E2E
+/e2e/                           @riccardo-forina @jjaquish
+
+# ESLint rules — architectural boundary enforcement
+/eslint-rules/                  @riccardo-forina @jjaquish
+
+# App shell and routes
+/src/Iam.tsx                    @riccardo-forina @jjaquish
+/src/v1/Routing.tsx             @riccardo-forina @jjaquish
+/src/v2/Routing.tsx             @riccardo-forina @jjaquish
+
+# Data layer — API contracts, queries, mocks
+/src/v1/data/                   @riccardo-forina @jjaquish
+/src/v2/data/                   @riccardo-forina @jjaquish
+/src/shared/data/               @riccardo-forina @jjaquish


### PR DESCRIPTION
## Summary

- Team alias (`experience-ui-committers`) remains the default reviewer for all feature code
- Riccardo and Jack are additionally required on structural/architectural paths where a bad merge has broad blast radius: dotfiles, CI, e2e, eslint rules, routes, app shell, and the data layer

The team stays accountable — nobody can ignore this repo. The named owners add a gatekeeping layer on the paths where automation can't catch everything.

## Test plan

- [x] Verify CODEOWNERS syntax is valid (GitHub flags errors on the PR)
- [ ] Confirm path rules match current architectural boundaries

Resolves [RHCLOUD-49610](https://redhat.atlassian.net/browse/RHCLOUD-49610)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49610]: https://redhat.atlassian.net/browse/RHCLOUD-49610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ