### PR TITLE
fix: correct edit group error typo (RHCLOUD-49738)

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -419,7 +419,7 @@ export default defineMessages({
   editGroupErrorDescription: {
     id: 'editGroupErrorDescription',
     description: 'Edit group error notification description',
-    defaultMessage: 'The group was not updated successfuly.',
+    defaultMessage: 'The group was not updated successfully.',
   },
   deleteWorkspaceErrorTitle: {
     id: 'deleteWorkspaceErrorTitle',

--- a/src/locales/data.json
+++ b/src/locales/data.json
@@ -181,7 +181,7 @@
     "editAccessForThisWorkspace": "Edit access for this workspace",
     "editCustomRole": "Edit custom role",
     "editGroupCanceledDescription": "Edit group was canceled by the user.",
-    "editGroupErrorDescription": "The group was not updated successfuly.",
+    "editGroupErrorDescription": "The group was not updated successfully.",
     "editGroupErrorTitle": "Failed updating group",
     "editGroupInfo": "Edit group's information",
     "editGroupSuccessDescription": "The group was updated successfully.",

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -180,7 +180,7 @@
   "editAccessForThisWorkspace": "Edit access for this workspace",
   "editCustomRole": "Edit custom role",
   "editGroupCanceledDescription": "Edit group was canceled by the user.",
-  "editGroupErrorDescription": "The group was not updated successfuly.",
+  "editGroupErrorDescription": "The group was not updated successfully.",
   "editGroupErrorTitle": "Failed updating group",
   "editGroupInfo": "Edit group's information",
   "editGroupSuccessDescription": "The group was updated successfully.",

--- a/src/v1/features/groups/EditGroupModal.stories.tsx
+++ b/src/v1/features/groups/EditGroupModal.stories.tsx
@@ -416,7 +416,7 @@ export const ErrorNotification: Story = {
       // Notification may take time to render after form submission failure
       const body = within(document.body);
       await body.findByText('Failed updating group', {}, { timeout: 5000 });
-      await body.findByText('The group was not updated successfuly.', {}, { timeout: 2000 });
+      await body.findByText('The group was not updated successfully.', {}, { timeout: 2000 });
 
       // ✅ Error handling completed - the EditGroupModal handles its own error logic
     });


### PR DESCRIPTION
### What and why
<!-- What problem does this solve? Link the issue/story. -->
<!-- If this is a visual change, explain the before/after behaviour, not just "updated the button". -->

[RHCLOUD-49738](https://redhat.atlassian.net/browse/RHCLOUD-49738)

---

### Screenshots



https://github.com/user-attachments/assets/e5740d6e-f313-4e81-83d3-0e08a80f58f1


https://github.com/user-attachments/assets/821b87ed-67b1-4208-b332-0727784c071c




---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a spelling error in the group update failure message.
  - Updated the displayed error notification to read: “The group was not updated successfully.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHCLOUD-49738]: https://redhat.atlassian.net/browse/RHCLOUD-49738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ