### PR TITLE
fix(coderabbit): widen path globs to catch nested component dirs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,14 +45,14 @@ reviews:
     - path: "**/features/**/*.tsx"
       instructions: |
         Export rule: components must use named exports only. Features (route/page containers, i.e. files
-        directly under `src/features/<island>/`) may additionally export a default, but must always have
+        directly under `**/features/<island>/`) may additionally export a default, but must always have
         a named export too. Flag `export default function` or `export default` as the only export on a
         component file as a blocking issue.
 
     - path: "**/components/**/*.tsx"
       instructions: |
         Export rule: shared components must use named exports only. No default exports.
-        Flag any `export default` in `src/components/` as a blocking issue.
+        Flag any `export default` in `**/components/` as a blocking issue.
 
     - path: "**/components/table-view/**"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,7 +22,7 @@ reviews:
         - Flag the absence of either as a blocking issue.
 
         ### Components
-        If the PR adds a new component in `src/features/` or `src/components/`:
+        If the PR adds a new component in `**/features/` or `**/components`:
         - There must be a `.stories.tsx` file alongside it.
         - The story must have at least one `play` function testing an interaction.
         - Flag missing stories as a blocking issue. Flag stories with no `play` function as a warning.
@@ -38,23 +38,23 @@ reviews:
         usage causes silent runtime failures. See `src/docs/APIClientPatterns.mdx`.
 
         ### Feature island READMEs
-        If the PR modifies files inside `src/features/<island>/` and introduces a new sub-feature,
+        If the PR modifies files inside `**/features/<island>/` and introduces a new sub-feature,
         changes the data layer, alters the permission model, or adds a notable constraint —
         the island's `README.md` should be updated. Flag missing README updates as a warning.
 
-    - path: "src/features/**/*.tsx"
+    - path: "**/features/**/*.tsx"
       instructions: |
         Export rule: components must use named exports only. Features (route/page containers, i.e. files
         directly under `src/features/<island>/`) may additionally export a default, but must always have
         a named export too. Flag `export default function` or `export default` as the only export on a
         component file as a blocking issue.
 
-    - path: "src/components/**/*.tsx"
+    - path: "**/components/**/*.tsx"
       instructions: |
         Export rule: shared components must use named exports only. No default exports.
         Flag any `export default` in `src/components/` as a blocking issue.
 
-    - path: "src/components/table-view/**"
+    - path: "**/components/table-view/**"
       instructions: |
         Changes here are shared infrastructure with wide blast radius.
         Before approving: identify all consumers of the changed file, verify no consumer's


### PR DESCRIPTION
## Summary

- CodeRabbit path instructions were anchored to `src/components/` and `src/features/`, missing components under `src/v1/components/` and similar nested paths.
- PR #2396 exposed the gap: a new component landed in `src/v1/components/` without stories, and CodeRabbit didn't flag it — the "missing stories = blocking issue" rule simply didn't fire because the path didn't match.
- Changed all hardcoded `src/` prefixes to `**/` globs so the rules apply regardless of directory nesting depth.

## Why this matters

The governance rules exist to enforce storybook coverage and export conventions. When the path globs are too narrow, new code silently bypasses the review checks — the wall has a gap. This was caught by a human reviewer, but the whole point of CodeRabbit rules is to not rely on that.

## Test plan

- [ ] Verify CodeRabbit triggers the stories-required check on a PR that adds a component under `src/v1/components/`
- [ ] Verify existing `src/components/` and `src/features/` paths still match


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded component and feature review checks across the repository.
  * Updated table-view checks to cover all relevant component paths.
  * Generalized README and component export validation for feature and component directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->