### PR TITLE
fix(coderabbit): align with experience-ui-governance template and add rbac-specific rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,6 +54,13 @@ reviews:
         Export rule: shared components must use named exports only. No default exports.
         Flag any `export default` in `**/components/` as a blocking issue.
 
+        Separation of concerns: components must be presentational. They must NOT directly import
+        or call feature flags (`useFlag`, `useFeatureFlag`), identity/auth hooks (`useIdentity`,
+        `useChrome`), or permission hooks (`usePermissions`). These concerns belong in the
+        consuming feature (`**/features/`), which passes the resolved values as props or
+        conditionally renders the component. If a component in `**/components/` imports any of
+        these hooks, flag it as a blocking issue.
+
     - path: "**/components/table-view/**"
       instructions: |
         Changes here are shared infrastructure with wide blast radius.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,41 +1,38 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# CodeRabbit review configuration.
+# CodeRabbit review configuration for insights-rbac-ui.
 #
-# AGENTS.md (auto-detected) covers rules for agents WRITING code.
-# This file covers rules for CodeRabbit REVIEWING code.
-# They are complementary: AGENTS.md = coding standards, this file = PR hygiene checks.
+# General team rules are sourced from experience-ui-governance/templates/coderabbit.yml.
+# This file adds rbac-specific rules on top.
 
 reviews:
   path_instructions:
-    # Catch-all: general PR hygiene checks applied to every changed file
+    # ──────────────────────────────────────────────────────────────────────
+    # TEAM RULES (from experience-ui-governance template)
+    # Keep in sync with: https://github.com/RedHatInsights/experience-ui-governance/blob/main/templates/coderabbit.yml
+    # ──────────────────────────────────────────────────────────────────────
+
     - path: "**"
       instructions: |
         ## PR hygiene checks
 
         ### Routes
-        If the PR adds or modifies a route (check `src/utilities/pathnames.ts`, routing config,
-        or any component that introduces a new URL-tied modal/page):
-        - There must be a Storybook user-journey story covering the happy path (create/edit/delete).
-        - If it is a page or modal tied to a real URL, there must also be a Playwright E2E spec
-          in `e2e/journeys/` or a concrete plan to add one.
+        If the PR adds or modifies a route (check routing config or any component
+        that introduces a new URL-tied modal/page):
+        - There must be a Storybook user-journey story covering the happy path.
+        - If it is a page or modal tied to a real URL, there must also be a Playwright
+          E2E spec or a concrete plan to add one.
         - Flag the absence of either as a blocking issue.
 
         ### Components
-        If the PR adds a new component in `**/features/` or `**/components`:
+        If the PR adds a new component in `**/features/` or `**/components/`:
         - There must be a `.stories.tsx` file alongside it.
         - The story must have at least one `play` function testing an interaction.
         - Flag missing stories as a blocking issue. Flag stories with no `play` function as a warning.
 
         ### TableView usage
         If the PR introduces a `TableView` import without a corresponding `useTableState` import
-        in the same file, flag it as a blocking issue. The ESLint rule `rbac-local/require-use-table-state`
-        enforces this, but CodeRabbit should flag it explicitly in the review comment too.
-
-        ### API calls
-        If the PR adds direct calls to `@redhat-cloud-services/rbac-client` methods WITHOUT
-        the `(api.method as any)` cast pattern, flag it. The client types are broken and direct
-        usage causes silent runtime failures. See `src/docs/APIClientPatterns.mdx`.
+        in the same file, flag it as a blocking issue.
 
         ### Feature island READMEs
         If the PR modifies files inside `**/features/<island>/` and introduces a new sub-feature,
@@ -64,6 +61,22 @@ reviews:
         interpreting raw infrastructure or consuming a resolved domain concept. If a component
         imports a banned hook, flag it as a blocking issue.
 
+    - path: ".github/CODEOWNERS"
+      instructions: |
+        Each owner entry must be on its own line for independent approval enforcement.
+        A single line with multiple teams means only one approval is required total — flag this.
+
+    # ──────────────────────────────────────────────────────────────────────
+    # RBAC-SPECIFIC RULES (only apply to this repo)
+    # ──────────────────────────────────────────────────────────────────────
+
+    - path: "**"
+      instructions: |
+        ### API calls (rbac-specific)
+        If the PR adds direct calls to `@redhat-cloud-services/rbac-client` methods WITHOUT
+        the `(api.method as any)` cast pattern, flag it. The client types are broken and direct
+        usage causes silent runtime failures. See `src/docs/APIClientPatterns.mdx`.
+
     - path: "**/components/table-view/**"
       instructions: |
         Changes here are shared infrastructure with wide blast radius.
@@ -73,14 +86,6 @@ reviews:
 
     - path: "src/docs/**"
       instructions: |
-        Docs must not duplicate TypeScript type definitions from source — they reference source file paths instead.
-        Flag code blocks that contain `interface Foo { ... }` or `type Foo = ...` declarations — these are
-        definitions that will drift from source.
-        Do NOT flag: inline shape descriptions with comments (e.g. `{ offset: number; limit: number }`),
-        usage snippets showing how to call a function, or option tables describing behaviour. Those are
-        illustrative, not definitions.
-
-    - path: ".github/CODEOWNERS"
-      instructions: |
-        Each owner entry must be on its own line for independent approval enforcement.
-        A single line with multiple teams means only one approval is required total — flag this.
+        Docs must not duplicate TypeScript type definitions from source — they reference
+        source file paths instead. Flag code blocks that contain `interface Foo { ... }` or
+        `type Foo = ...` declarations — these are definitions that will drift from source.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -51,7 +51,8 @@ reviews:
 
     - path: "**/components/**/*.tsx"
       instructions: |
-        Export rule: shared components must use named exports only. No default exports.
+        Export rule (skip `*.stories.tsx` — Storybook CSF requires a default meta export):
+        shared components must use named exports only. No default exports.
         Flag any `export default` in `**/components/` as a blocking issue.
 
         Separation of concerns: components must not import raw infrastructure hooks — i.e.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,7 +22,7 @@ reviews:
         - Flag the absence of either as a blocking issue.
 
         ### Components
-        If the PR adds a new component in `src/features/` or `src/components/`:
+        If the PR adds a new component in `**/features/` or `**/components`:
         - There must be a `.stories.tsx` file alongside it.
         - The story must have at least one `play` function testing an interaction.
         - Flag missing stories as a blocking issue. Flag stories with no `play` function as a warning.
@@ -38,23 +38,23 @@ reviews:
         usage causes silent runtime failures. See `src/docs/APIClientPatterns.mdx`.
 
         ### Feature island READMEs
-        If the PR modifies files inside `src/features/<island>/` and introduces a new sub-feature,
+        If the PR modifies files inside `**/features/<island>/` and introduces a new sub-feature,
         changes the data layer, alters the permission model, or adds a notable constraint —
         the island's `README.md` should be updated. Flag missing README updates as a warning.
 
-    - path: "src/features/**/*.tsx"
+    - path: "**/features/**/*.tsx"
       instructions: |
         Export rule: components must use named exports only. Features (route/page containers, i.e. files
-        directly under `src/features/<island>/`) may additionally export a default, but must always have
+        directly under `**/features/<island>/`) may additionally export a default, but must always have
         a named export too. Flag `export default function` or `export default` as the only export on a
         component file as a blocking issue.
 
-    - path: "src/components/**/*.tsx"
+    - path: "**/components/**/*.tsx"
       instructions: |
         Export rule: shared components must use named exports only. No default exports.
-        Flag any `export default` in `src/components/` as a blocking issue.
+        Flag any `export default` in `**/components/` as a blocking issue.
 
-    - path: "src/components/table-view/**"
+    - path: "**/components/table-view/**"
       instructions: |
         Changes here are shared infrastructure with wide blast radius.
         Before approving: identify all consumers of the changed file, verify no consumer's

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,12 +54,14 @@ reviews:
         Export rule: shared components must use named exports only. No default exports.
         Flag any `export default` in `**/components/` as a blocking issue.
 
-        Separation of concerns: components must be presentational. They must NOT directly import
-        or call feature flags (`useFlag`, `useFeatureFlag`), identity/auth hooks (`useIdentity`,
-        `useChrome`), or permission hooks (`usePermissions`). These concerns belong in the
-        consuming feature (`**/features/`), which passes the resolved values as props or
-        conditionally renders the component. If a component in `**/components/` imports any of
-        these hooks, flag it as a blocking issue.
+        Separation of concerns: components must not import raw infrastructure hooks — i.e.
+        low-level primitives that expose platform internals the component shouldn't know about.
+        Banned: `useFlag` (raw Unleash primitive — the component shouldn't know flag names),
+        `useIdentity` (raw identity context), `useChrome` (platform kitchen-sink API),
+        `usePermissions` (raw RBAC check). Semantic/domain hooks that encapsulate a decision
+        (e.g. `useWorkspacesFlag`) are fine — the distinction is whether the component is
+        interpreting raw infrastructure or consuming a resolved domain concept. If a component
+        imports a banned hook, flag it as a blocking issue.
 
     - path: "**/components/table-view/**"
       instructions: |


### PR DESCRIPTION
## Why

CodeRabbit's review rules had blind spots that let PR [#2396](https://github.com/RedHatInsights/insights-rbac-ui/pull/2396) slip through without flagging missing separation of concerns or story coverage.

Two problems:
1. Path instructions were anchored to `src/components/` and `src/features/`, missing nested paths like `src/v1/components/`.
2. No rule preventing components from importing raw infrastructure hooks (`useFlag`, `useIdentity`, `useChrome`, `usePermissions`).

These rules are now sourced from the team's shared governance template at [experience-ui-governance](https://github.com/RedHatInsights/experience-ui-governance/blob/main/templates/coderabbit.yml), with rbac-specific rules layered on top.

## What changed

- Replaced `src/`-anchored path prefixes with `**/` globs
- Added separation-of-concerns rule: raw infrastructure hooks banned in components (semantic domain hooks are fine)
- Added `*.stories.tsx` exclusion from default-export ban (Storybook CSF requires it)
- Restructured config into team rules (from governance template) and rbac-specific rules (API client cast pattern, table-view blast radius, docs no-duplication)

[RHCLOUD-50105](https://redhat.atlassian.net/browse/RHCLOUD-50105)

## Test plan

- [x] Lint, tests, pre-push hooks pass
- [ ] Verify CodeRabbit triggers the stories-required check on nested component paths
- [ ] Verify CodeRabbit flags a component that imports `useFlag` directly

[RHCLOUD-50105]: https://redhat.atlassian.net/browse/RHCLOUD-50105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ