### PR TITLE
chore(RHCLOUD-50355): migrate Chromatic workflow to shared reusable pipeline

### DIFF
--- a/.github/workflows/chromatic-upload.yml
+++ b/.github/workflows/chromatic-upload.yml
@@ -5,90 +5,17 @@ on:
     workflows: ["Storybook"]
     types: [completed]
 
+concurrency:
+  group: chromatic-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
-  pull-requests: write
+  contents: read
   actions: read
+  pull-requests: write
 
 jobs:
-  upload:
-    runs-on: ubuntu-24.04
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'push')
-    steps:
-      # Checkout base repo with full history — Chromatic needs git log to find
-      # the baseline commit. We always check out the default branch (not the PR
-      # branch) so that no untrusted code from forks is ever executed.
-      - name: Checkout Base Repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: storybook-static
-          path: storybook-static
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to Chromatic
-        id: chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: storybook-static
-          # Auto-accept changes on master (push) to establish the visual baseline.
-          # PR builds are left for review.
-          autoAcceptChanges: ${{ github.event.workflow_run.event == 'push' }}
-
-      # Post Chromatic URLs as a PR comment (only for pull_request events)
-      - name: Find PR number
-        id: find-pr
-        if: github.event.workflow_run.event == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // workflow_run.pull_requests works for same-repo PRs
-            const prs = context.payload.workflow_run.pull_requests;
-            if (prs && prs.length > 0) {
-              return prs[0].number;
-            }
-            // Fallback: search for a PR matching the head SHA (covers fork PRs)
-            const head_sha = context.payload.workflow_run.head_sha;
-            const { data: pulls } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              sort: 'updated',
-              direction: 'desc',
-              per_page: 10,
-            });
-            const matched = pulls.find(pr => pr.head.sha === head_sha);
-            return matched ? matched.number : '';
-
-      - name: Find existing comment
-        id: find-comment
-        if: steps.find-pr.outputs.result && steps.find-pr.outputs.result != ''
-        uses: peter-evans/find-comment@v3
-        with:
-          issue-number: ${{ steps.find-pr.outputs.result }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- chromatic-build -->'
-
-      - name: Comment on PR
-        if: steps.find-pr.outputs.result && steps.find-pr.outputs.result != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ steps.find-pr.outputs.result }}
-          edit-mode: replace
-          body: |
-            <!-- chromatic-build -->
-            ### Chromatic Build
-
-            | | Link |
-            |---|---|
-            | Storybook | ${{ steps.chromatic.outputs.storybookUrl }} |
-            | Build | ${{ steps.chromatic.outputs.buildUrl }} |
+  chromatic:
+    uses: RedHatInsights/experience-ui-governance/.github/workflows/reusable-chromatic.yml@5a772c75817a80fc30fae4e5c2bbd54b4ba114eb # main
+    secrets:
+      chromatic-project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the standalone Chromatic upload workflow with the shared reusable workflow from `experience-ui-governance`
- Centralizes Chromatic upload logic for easier maintenance and consistent behavior across repos

## Test plan
- [ ] Verify Chromatic upload works on a PR build
- [ ] Verify Chromatic baseline is auto-accepted on push to master
- [ ] Verify PR comment with Storybook/Build links appears correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved visual testing workflow reliability by preventing conflicting runs and canceling outdated checks.
  * Updated automation permissions to support pull request reporting and repository validation.
  * Streamlined screenshot publication and review feedback through the standardized workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->