### PR TITLE
Expose conversionbanner

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -25,6 +25,7 @@ module.exports = {
       // Shared modules (self-contained with providers)
       './modules/CreateWorkspaceWizard': path.resolve(__dirname, './src/federated-modules/CreateWorkspaceWizard.tsx'),
       './modules/WorkspaceSelector': path.resolve(__dirname, './src/federated-modules/WorkspaceSelector.tsx'),
+      './modules/ConversionOptInBanner': path.resolve(__dirname, './src/federated-modules/ConversionOptInBanner.tsx'),
     },
     exclude: ['react-router-dom'],
     shared: [{ 'react-router-dom': { singleton: true, version: '^6.18.0', requiredVersion: '*' } }],

--- a/src/federated-modules/ConversionOptInBanner.stories.tsx
+++ b/src/federated-modules/ConversionOptInBanner.stories.tsx
@@ -1,0 +1,113 @@
+/**
+ * ConversionOptInBanner - Federated Module Stories
+ *
+ * Smoke tests that validate the federated module renders without Storybook's
+ * context providers (noWrapping: true).
+ *
+ * For comprehensive component tests, see:
+ * Features/Overview (co-located) and User Journeys/Production/V1/Conversion Banner
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import ConversionOptInBanner, { type ConversionOptInBannerProps } from './ConversionOptInBanner';
+
+const meta: Meta<ConversionOptInBannerProps> = {
+  title: 'Federated Modules/ConversionOptInBanner',
+  component: ConversionOptInBanner,
+  tags: ['autodocs'],
+  parameters: {
+    noWrapping: true,
+    docs: {
+      description: {
+        component: `
+## Federated Module Smoke Test
+
+This story validates that \`ConversionOptInBanner\` renders as a federated module with \`noWrapping: true\`.
+
+### External Consumer Usage
+
+\`\`\`tsx
+<AsyncComponent
+  scope="rbac"
+  module="./modules/ConversionOptInBanner"
+  isOrgAdmin={isOrgAdmin}
+  onGetStarted={handleGetStarted}
+  fallback={<Skeleton />}
+/>
+\`\`\`
+
+### Providers Included
+
+- **IntlProvider** - internationalization
+
+### Props (ConversionOptInBannerProps)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`isOrgAdmin\` | \`boolean\` | – | Whether the current user is an org admin |
+| \`onGetStarted\` | \`() => void\` | – | Callback when "Get started now" is clicked |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    isOrgAdmin: {
+      description: 'Whether the current user is an org admin',
+      control: { type: 'boolean' },
+    },
+    onGetStarted: {
+      description: 'Callback fired when "Get started now" is clicked',
+      action: 'get-started-clicked',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ConversionOptInBannerProps>;
+
+/** Smoke test - banner renders for org admin with all providers */
+export const OrgAdmin: Story = {
+  args: {
+    isOrgAdmin: true,
+    onGetStarted: fn(),
+  },
+  play: async ({ canvasElement, args, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify banner renders with correct content', async () => {
+      await expect(canvas.findByText('Elevate your infrastructure with workspace-based access management')).resolves.toBeInTheDocument();
+      await expect(canvas.findByText('Get started now')).resolves.toBeInTheDocument();
+      await expect(canvas.findByText('Learn more about the benefits', { exact: false })).resolves.toBeInTheDocument();
+    });
+
+    await step('Verify Get started fires callback', async () => {
+      const getStartedButton = await canvas.findByText('Get started now');
+      await userEvent.click(getStartedButton);
+      await expect(args.onGetStarted).toHaveBeenCalledTimes(1);
+    });
+
+    await step('Verify Learn more link opens in new tab', async () => {
+      const learnMoreLink = await canvas.findByText('Learn more about the benefits', { exact: false });
+      const anchor = learnMoreLink.closest('a');
+      await expect(anchor).toHaveAttribute('target', '_blank');
+      await expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  },
+};
+
+/** Non-admin - banner should not render */
+export const NonAdmin: Story = {
+  args: {
+    isOrgAdmin: false,
+    onGetStarted: fn(),
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Verify banner is not rendered for non-admin', async () => {
+      expect(canvas.queryByText('Elevate your infrastructure with workspace-based access management')).not.toBeInTheDocument();
+      expect(canvas.queryByText('Get started now')).not.toBeInTheDocument();
+    });
+  },
+};

--- a/src/federated-modules/ConversionOptInBanner.tsx
+++ b/src/federated-modules/ConversionOptInBanner.tsx
@@ -21,10 +21,7 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import messages from '../locales/data.json';
-import {
-  ConversionOptInBanner as ConversionOptInBannerInner,
-  ConversionOptInBannerProps,
-} from '../v1/components/ConversionOptInBanner';
+import { ConversionOptInBanner as ConversionOptInBannerInner, ConversionOptInBannerProps } from '../v1/components/ConversionOptInBanner';
 
 export const locale = 'en';
 

--- a/src/federated-modules/ConversionOptInBanner.tsx
+++ b/src/federated-modules/ConversionOptInBanner.tsx
@@ -1,0 +1,40 @@
+/**
+ * ConversionOptInBanner - Federated Module
+ *
+ * Self-contained conversion opt-in banner for module federation.
+ * External consumers can use this via AsyncComponent without needing their own providers.
+ *
+ * ```tsx
+ * <AsyncComponent
+ *   scope="rbac"
+ *   module="./modules/ConversionOptInBanner"
+ *   isOrgAdmin={isOrgAdmin}
+ *   onGetStarted={handleGetStarted}
+ *   fallback={<Skeleton />}
+ * />
+ * ```
+ *
+ * Providers included:
+ * - IntlProvider (i18n)
+ */
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import messages from '../locales/data.json';
+import {
+  ConversionOptInBanner as ConversionOptInBannerInner,
+  ConversionOptInBannerProps,
+} from '../v1/components/ConversionOptInBanner';
+
+export const locale = 'en';
+
+const ConversionOptInBanner: React.FC<ConversionOptInBannerProps> = (props) => {
+  return (
+    <IntlProvider locale={locale} messages={messages[locale]}>
+      <ConversionOptInBannerInner {...props} />
+    </IntlProvider>
+  );
+};
+
+export default ConversionOptInBanner;
+export type { ConversionOptInBannerProps };


### PR DESCRIPTION
### What and why
Need to expose the Conversion Opt-In Banner through Federated Modules so that I can use it in the widget dashboard

---

### Anything non-obvious reviewers should know?
<!-- Intentional trade-offs, known limitations, things that look wrong but are right. -->
<!-- If you had to think about something twice, write it here. -->

---

### Attention needed
- [ ] _(Optional) QE: notable impact on test coverage or OUIA IDs changed_
- [ ] _(Optional) UX: end-user UX modified, designs may need sign-off_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a federated conversion opt-in banner that can be loaded by compatible applications.
  - The banner supports English localization and accepts configurable banner properties.
- **Bug Fixes**
  - The banner is shown to administrators and hidden for non-administrators.
  - Added support for the banner’s get-started action and external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->